### PR TITLE
[internal] add sideEffects: false to pkg for webpack 4

### DIFF
--- a/packages/vx-annotation/package.json
+++ b/packages/vx-annotation/package.json
@@ -2,10 +2,9 @@
   "name": "@vx/annotation",
   "version": "0.0.147",
   "description": "vx annotation",
+  "sideEffects": false,
   "main": "build/index.js",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
@@ -15,13 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -55,9 +48,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/axis",
   "version": "0.0.152",
   "description": "vx axis",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -55,9 +48,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-bounds/package.json
+++ b/packages/vx-bounds/package.json
@@ -1,26 +1,21 @@
 {
   "name": "@vx/bounds",
   "version": "0.0.147",
-  "description": "Utilities to make your life with bounding boxes better",
+  "description":
+    "Utilities to make your life with bounding boxes better",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "visualizations", "charts"],
   "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
@@ -51,9 +46,6 @@
     "react-dom": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-boxplot/package.json
+++ b/packages/vx-boxplot/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/boxplot",
   "version": "0.0.143",
   "description": "vx box plot",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -12,13 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@conglei",
   "license": "MIT",
   "bugs": {
@@ -49,9 +44,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-brush/package.json
+++ b/packages/vx-brush/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/brush",
   "version": "0.0.143",
   "description": "vx brush",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "d3",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "d3", "react", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -52,9 +45,6 @@
     "recompose": "^0.23.1"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-clip-path/package.json
+++ b/packages/vx-clip-path/package.json
@@ -2,15 +2,14 @@
   "name": "@vx/clip-path",
   "version": "0.0.143",
   "description": "vx clip-path",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
@@ -49,9 +48,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-curve/package.json
+++ b/packages/vx-curve/package.json
@@ -2,23 +2,16 @@
   "name": "@vx/curve",
   "version": "0.0.143",
   "description": "vx curve",
+  "sideEffects": false,
   "main": "build/index.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualization",
-    "chart"
-  ],
+  "keywords": ["vx", "react", "d3", "visualization", "chart"],
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
@@ -41,9 +34,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-demo/package.json
+++ b/packages/vx-demo/package.json
@@ -9,11 +9,7 @@
     "start": "next start",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "demo",
-    "examples"
-  ],
+  "keywords": ["vx", "demo", "examples"],
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
@@ -66,9 +62,7 @@
     "topojson-client": "^3.0.0"
   },
   "browserify": {
-    "transform": [
-      "babelify"
-    ]
+    "transform": ["babelify"]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vx-drag/package.json
+++ b/packages/vx-drag/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/drag",
   "version": "0.0.143",
   "description": "vx drag",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -48,9 +41,6 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-event/package.json
+++ b/packages/vx-event/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/event",
   "version": "0.0.143",
   "description": "vx event",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "d3",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "d3", "react", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -48,9 +41,6 @@
     "@vx/point": "0.0.143"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-geo/package.json
+++ b/packages/vx-geo/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/geo",
   "version": "0.0.150",
   "description": "vx geo",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -53,9 +54,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-glyph/package.json
+++ b/packages/vx-glyph/package.json
@@ -1,27 +1,20 @@
 {
   "name": "@vx/glyph",
   "version": "0.0.143",
-  "description": "vx glyph ",
+  "description": "vx glyph",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -53,9 +46,6 @@
     "d3-shape": "^1.2.0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-gradient/package.json
+++ b/packages/vx-gradient/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/gradient",
   "version": "0.0.143",
   "description": "vx gradient",
+  "sideEffects": false,
   "main": "build/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -52,9 +45,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-grid/package.json
+++ b/packages/vx-grid/package.json
@@ -2,10 +2,9 @@
   "name": "@vx/grid",
   "version": "0.0.147",
   "description": "vx grid",
+  "sideEffects": false,
   "main": "build/index.js",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
@@ -15,13 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -54,9 +47,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-group/package.json
+++ b/packages/vx-group/package.json
@@ -2,15 +2,14 @@
   "name": "@vx/group",
   "version": "0.0.143",
   "description": "vx group",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
@@ -52,9 +51,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-heatmap/package.json
+++ b/packages/vx-heatmap/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/heatmap",
   "version": "0.0.143",
   "description": "vx heatmap",
+  "sideEffects": false,
   "main": "build/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -52,9 +45,6 @@
     "classnames": "^2.2.5"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-hierarchy/package.json
+++ b/packages/vx-hierarchy/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/hierarchy",
   "version": "0.0.144",
   "description": "vx tree",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -12,13 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "d3",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "d3", "react", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -50,9 +45,6 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-legend/package.json
+++ b/packages/vx-legend/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/legend",
   "version": "0.0.143",
   "description": "vx legend",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -12,13 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -50,9 +45,6 @@
     "prop-types": "^15.5.10"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-marker/package.json
+++ b/packages/vx-marker/package.json
@@ -2,10 +2,9 @@
   "name": "@vx/marker",
   "version": "0.0.147",
   "description": "vx marker",
+  "sideEffects": false,
   "main": "build/index.js",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
@@ -15,13 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -53,9 +46,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-mock-data/package.json
+++ b/packages/vx-mock-data/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/mock-data",
   "version": "0.0.147",
   "description": "vx mock data",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -48,9 +41,6 @@
     "d3-random": "^1.0.3"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-network/package.json
+++ b/packages/vx-network/package.json
@@ -1,23 +1,17 @@
 {
   "name": "@vx/network",
   "version": "0.0.143",
-  "description": "vx graph",
+  "description": "vx network",
+  "sideEffects": false,
   "main": "build/index.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "data",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "data", "visualizations", "charts"],
   "author": "@andyfang_dz",
   "license": "MIT",
   "devDependencies": {
@@ -45,9 +39,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-pattern/package.json
+++ b/packages/vx-pattern/package.json
@@ -2,10 +2,9 @@
   "name": "@vx/pattern",
   "version": "0.0.143",
   "description": "vx pattern",
+  "sideEffects": false,
   "main": "build/index.js",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
@@ -15,13 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualization",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualization", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -52,9 +45,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-point/package.json
+++ b/packages/vx-point/package.json
@@ -2,22 +2,16 @@
   "name": "@vx/point",
   "version": "0.0.143",
   "description": "vx point",
+  "sideEffects": false,
   "main": "build/index.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "data",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "data", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "devDependencies": {
@@ -37,9 +31,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-responsive/package.json
+++ b/packages/vx-responsive/package.json
@@ -2,10 +2,9 @@
   "name": "@vx/responsive",
   "version": "0.0.152",
   "description": "vx responsive svg",
+  "sideEffects": false,
   "main": "build/index.js",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
@@ -15,13 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -52,9 +45,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-scale/package.json
+++ b/packages/vx-scale/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/scale",
   "version": "0.0.152",
   "description": "vx scale",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -48,9 +41,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-shape/package.json
+++ b/packages/vx-shape/package.json
@@ -2,23 +2,16 @@
   "name": "@vx/shape",
   "version": "0.0.147",
   "description": "vx shape",
+  "sideEffects": false,
   "main": "build/index.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
@@ -51,9 +44,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-stats/package.json
+++ b/packages/vx-stats/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/stats",
   "version": "0.0.152",
   "description": "vx stats box violin",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -12,13 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@conglei",
   "license": "MIT",
   "bugs": {
@@ -51,9 +46,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -2,10 +2,9 @@
   "name": "@vx/text",
   "version": "0.0.152",
   "description": "vx text",
+  "sideEffects": false,
   "main": "build/index.js",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
@@ -15,13 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualization",
-    "chart"
-  ],
+  "keywords": ["vx", "react", "d3", "visualization", "chart"],
   "author": "@techniq",
   "license": "MIT",
   "bugs": {
@@ -53,9 +46,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/tooltip",
   "version": "0.0.148",
   "description": "vx tooltip",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -12,13 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -50,9 +45,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-voronoi/package.json
+++ b/packages/vx-voronoi/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/voronoi",
   "version": "0.0.143",
   "description": "vx voronoi",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
@@ -53,9 +46,6 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-vx/package.json
+++ b/packages/vx-vx/package.json
@@ -2,6 +2,7 @@
   "name": "@vx/vx",
   "version": "0.0.152",
   "description": "One stop install for all vx packages",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
@@ -12,13 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -76,9 +71,6 @@
     "@vx/zoom": "0.0.143"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-zoom/package.json
+++ b/packages/vx-zoom/package.json
@@ -2,26 +2,19 @@
   "name": "@vx/zoom",
   "version": "0.0.143",
   "description": "vx zoom",
+  "sideEffects": false,
   "main": "build/index.js",
   "scripts": {
     "build": "make build SRC=./src",
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -45,9 +38,6 @@
     "regenerator-runtime": "^0.10.5"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }


### PR DESCRIPTION
#### :house: Internal

- [internal] add sideEffects: false to pkg for webpack 4

-----------

In preparation for webpack 4, this change will tell webpack to it's safe to prune unused exports.

This benefits developers using webpack for perf gains in the form of smaller bundle sizes.

Until webpack 4 is out, it's preferred to import from the deep path for vx users (only include what you use in your build vs including the entire lib index).

```js
import AxisBottom from '@vx/axis/build/axis/AxisBottom';
```

more info:
- d3 discussion: https://github.com/d3/d3/issues/3131
- https://github.com/webpack/webpack/tree/next/examples/side-effects
- related discussion: https://github.com/hshoff/vx/issues/143