### PR TITLE
[demo] fix streamgraph transparent fill pattern

### DIFF
--- a/packages/vx-demo/components/tiles/streamgraph.js
+++ b/packages/vx-demo/components/tiles/streamgraph.js
@@ -87,10 +87,10 @@ export default class Streamgraph extends React.Component {
         'mustard',
         'cherry',
         'navy',
-        'transparent',
-        'transparent',
-        'transparent',
-        'transparent',
+        'circles',
+        'circles',
+        'circles',
+        'circles',
       ],
     });
 
@@ -122,7 +122,7 @@ export default class Streamgraph extends React.Component {
           complement
         />
         <PatternCircles
-          id="transparent"
+          id="circles"
           height={60}
           width={60}
           radius={10}
@@ -156,10 +156,12 @@ export default class Streamgraph extends React.Component {
                       d={path(series)}
                       fill={zScale(series.key)}
                     />
-                    <path
-                      d={path(series)}
-                      fill={`url(#${patternScale(series.key)})`}
-                    />
+                    {patternScale(series.key) !== 'circles' && (
+                      <path
+                        d={path(series)}
+                        fill={`url(#${patternScale(series.key)})`}
+                      />
+                    )}
                   </g>
                 );
               });


### PR DESCRIPTION
#### :house: Internal

- [demo] fix streamgraph transparent fill

before
<img width="453" alt="screen shot 2018-02-11 at 3 20 24 pm" src="https://user-images.githubusercontent.com/339208/36077980-255313dc-0f3f-11e8-8e50-da4bc260e067.png">

after
<img width="454" alt="screen shot 2018-02-11 at 3 20 33 pm" src="https://user-images.githubusercontent.com/339208/36077985-2c6781d0-0f3f-11e8-801b-d1d4c37bf4a5.png">

