### PR TITLE
new(vx-brush): update brush position when initialBrushPosition changes

### DIFF
--- a/packages/vx-brush/src/utils.ts
+++ b/packages/vx-brush/src/utils.ts
@@ -1,4 +1,4 @@
-import { Scale } from './types';
+import { Scale, PartialBrushStartEnd, Point } from './types';
 
 export function scaleInvert(scale: Scale, value: number) {
   // Test if the scale is an ordinalScale or not,
@@ -52,4 +52,25 @@ export function getDomainFromExtent(
   }
 
   return domain;
+}
+
+export function shouldUpdateInitialBrushPosition(
+  initialBrushPosition: PartialBrushStartEnd | undefined,
+  prevInitialBrushPosition: PartialBrushStartEnd | undefined,
+  currStart: Point,
+  currEnd: Point,
+) {
+  const initialBrushPositionDidChange =
+    initialBrushPosition?.start?.x !== prevInitialBrushPosition?.start?.x ||
+    initialBrushPosition?.start?.y !== prevInitialBrushPosition?.start?.y ||
+    initialBrushPosition?.end?.x !== prevInitialBrushPosition?.end?.x ||
+    initialBrushPosition?.end?.y !== prevInitialBrushPosition?.end?.y;
+
+  const brushPositionIsDifferentFromCurrentPosition =
+    initialBrushPosition?.start?.x !== currStart.x ||
+    initialBrushPosition?.start?.y !== currStart.y ||
+    initialBrushPosition?.end?.x !== currEnd.x ||
+    initialBrushPosition?.end?.y !== currEnd.y;
+
+  return initialBrushPositionDidChange && brushPositionIsDifferentFromCurrentPosition;
 }

--- a/packages/vx-brush/test/utils.test.ts
+++ b/packages/vx-brush/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { createScale } from '@vx/scale';
-import { getDomainFromExtent, scaleInvert } from '../src/utils';
+import { getDomainFromExtent, scaleInvert, shouldUpdateInitialBrushPosition } from '../src/utils';
 
 describe('getDomainFromExtent()', () => {
   test('it should return { start, end } if scale.invert', () => {
@@ -71,5 +71,26 @@ describe('scaleInvert()', () => {
     const value = 3;
     const result = scaleInvert(scale, value);
     expect(result).toEqual(2);
+  });
+});
+
+describe('shouldUpdateInitialBrushPosition', () => {
+  const point1 = { x: 0, y: 0 };
+  const point2 = { x: 100, y: 10 };
+  const point3 = { x: 50, y: 7 };
+
+  it('should return false if position did not change', () => {
+    const position = { start: point1, end: point2 };
+    expect(shouldUpdateInitialBrushPosition(position, position, point1, point3)).toBe(false);
+  });
+  it('should return false if not different from brush position', () => {
+    const position1 = { start: point1, end: point2 };
+    const position2 = { start: point3, end: point3 };
+    expect(shouldUpdateInitialBrushPosition(position1, position2, point1, point2)).toBe(false);
+  });
+  it('should return true if position changed and it is different from brush position', () => {
+    const position1 = { start: point1, end: point2 };
+    const position2 = { start: point1, end: point3 };
+    expect(shouldUpdateInitialBrushPosition(position1, position2, point1, point3)).toBe(true);
   });
 });

--- a/packages/vx-demo/package.json
+++ b/packages/vx-demo/package.json
@@ -68,6 +68,7 @@
     "d3-shape": "^1.0.6",
     "d3-time-format": "^2.0.5",
     "markdown-loader": "^5.1.0",
+    "moment": "2.27.0",
     "next": "9.4.4",
     "nprogress": "^0.2.0",
     "prismjs": "^1.19.0",

--- a/packages/vx-demo/src/sandboxes/vx-brush/Example.tsx
+++ b/packages/vx-demo/src/sandboxes/vx-brush/Example.tsx
@@ -97,8 +97,8 @@ function BrushChart({
   );
 
   const [initialBrushPosition, setInitialBrushPosition] = useState({
-    start: { x: fullDateRangeScale(getDate(filteredStock[0])) },
-    end: { x: fullDateRangeScale(getDate(filteredStock[filteredStock.length - 1])) },
+    start: { x: fullDateRangeScale(getDate(filteredStock[0] ?? {})) },
+    end: { x: fullDateRangeScale(getDate(filteredStock[filteredStock.length - 1] ?? {})) },
   });
 
   const onBrushChange = useCallback((bounds: Bounds | null) => {

--- a/packages/vx-demo/src/sandboxes/vx-brush/package.json
+++ b/packages/vx-demo/src/sandboxes/vx-brush/package.json
@@ -18,6 +18,7 @@
     "@vx/scale": "latest",
     "@vx/shape": "latest",
     "d3-array": "^2.4.0",
+    "moment": "2.27.0",
     "react": "^16.8",
     "react-dom": "^16.8",
     "react-scripts-ts": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5236,6 +5236,11 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
 
+d3-array@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.6.0.tgz#b8df0c695eab26e2b2fd4ffe2d84bd703f8d0faf"
+  integrity sha512-1TgzIGb6hrHKSCGccdL209Ibk41HCeyv5znFEvJfBsBGhD3qpoHt/2W2ECpyLxpG1k7aNJz0BYrmLpVs9hIGNQ==
+
 d3-chord@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
@@ -9426,6 +9431,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+moment@2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
 moo@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
#### :rocket: Enhancements

This PR 
- updates `@vx/brush` to update the `Brush`s `state.start/end` when `props.initialBrushPosition` changes. This makes the brush somewhere between a controlled and uncontrolled component. 
- updates the `/brush` demo to show how you could use this to snap the brush position to the nearest month. 
- adds tests

A couple caveats
- this probably shouldn't be used with `onBrushChange` as the # of callbacks is insane. Note in the demo I snap the brush `onBrushEnd` so that the update only happens on mouse up.
- there is an edge case I can't figure out a solution for with this approach: say `initialBrushPosition=[Jan 1, Feb 1]`, then you move the `Brush` slightly to `[Jan 10, Feb 10]`. When you release the brush, `onBrushEnd` is invoked but the snapping logic results in the same `[Jan 1, Feb 1]` position. The `Brush` gets this new `initialBrushPosition`, but because it `===` the previous `initialBrushPosition`, it does **not** update the `Brush` position `state` which stays at `[Jan 10, Feb 10]` 😱 
  - one option is updating `Brush` `state.start/end` whenever `initialBrushPosition` does not match it, but unless the renderer proactively updates `initialBrushPosition` themself, the brush will snap back to `initialBrushPosition` upon `onBrushEnd`

^ would love thoughts on this!

![snappy-brush](https://user-images.githubusercontent.com/4496521/91232359-d264af80-e6e3-11ea-940e-7045dc507ed4.gif)

[Code sandbox link](https://codesandbox.io/s/github/hshoff/vx/tree/chris--controlled-brush/packages/vx-demo/src/sandboxes/vx-brush) to play with it (this will break after the PR is merged)

@kristw @hshoff @emeeks