### PR TITLE
fix(demo/axis): add react-spring dependency

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-axis/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-axis/package.json
@@ -22,6 +22,7 @@
     "react": "^16",
     "react-dom": "^16",
     "react-scripts-ts": "3.1.0",
+    "react-spring": "8.0.27",
     "typescript": "^3"
   },
   "keywords": [


### PR DESCRIPTION
#### :bug: Bug Fix

Currently the `/axis` [sandbox](https://codesandbox.io/s/github/hshoff/vx/tree/master/packages/vx-demo/src/sandboxes/vx-axis) is broken because it doesn't specify the needed `react-spring` dependency, which is a peer dependency of `@vx/react-spring`. This works in the demo site because the demo package includes the dependency.

#### Testing

- [x] verified that adding the `react-spring` dep fixes the sandbox

@hshoff @kristw 