### PR TITLE
new(xychart): add BarSeries

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -16,11 +16,11 @@ type Props = {
   height: number;
 };
 
-const xScaleConfig = { type: 'time' } as const;
+const xScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const yScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
 const data = cityTemperature.slice(150, 225);
-const getDate = (d: CityTemperature) => new Date(d.date);
+const getDate = (d: CityTemperature) => d.date; // new Date(d.date);
 const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNyTemperature = (d: CityTemperature) => Number(d['New York']);
 
@@ -46,7 +46,7 @@ export default function Example({ height }: Props) {
           <XYChart height={Math.min(400, height)}>
             <CustomChartBackground />
             <AnimatedGrid
-              key={`grid-${animationTrajectory}`}
+              key={`grid-${animationTrajectory}`} // force animate on update
               rows={showGridRows}
               columns={showGridColumns}
               animationTrajectory={animationTrajectory}
@@ -58,7 +58,6 @@ export default function Example({ height }: Props) {
                 data={data}
                 xAccessor={renderHorizontally ? getNyTemperature : getDate}
                 yAccessor={renderHorizontally ? getDate : getNyTemperature}
-                barPadding={0.2}
                 horizontal={renderHorizontally}
               />
             )}
@@ -71,7 +70,7 @@ export default function Example({ height }: Props) {
               />
             )}
             <AnimatedAxis
-              key={`time-axis-${animationTrajectory}-${renderHorizontally}`} // force animate on update
+              key={`time-axis-${animationTrajectory}-${renderHorizontally}`}
               orientation={renderHorizontally ? yAxisOrientation : xAxisOrientation}
               numTicks={numTicks}
               animationTrajectory={animationTrajectory}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -29,7 +29,9 @@ export default function Example({ height }: Props) {
     <ExampleControls>
       {({
         animationTrajectory,
+        renderBarSeries,
         renderHorizontally,
+        renderLineSeries,
         showGridColumns,
         showGridRows,
         theme,
@@ -50,20 +52,24 @@ export default function Example({ height }: Props) {
               animationTrajectory={animationTrajectory}
               numTicks={numTicks}
             />
-            <BarSeries
-              dataKey="ny"
-              data={data}
-              xAccessor={renderHorizontally ? getNyTemperature : getDate}
-              yAccessor={renderHorizontally ? getDate : getNyTemperature}
-              barPadding={0.2}
-              horizontal={renderHorizontally}
-            />
-            <LineSeries
-              dataKey="sf"
-              data={data}
-              xAccessor={renderHorizontally ? getSfTemperature : getDate}
-              yAccessor={renderHorizontally ? getDate : getSfTemperature}
-            />
+            {renderBarSeries && (
+              <BarSeries
+                dataKey="ny"
+                data={data}
+                xAccessor={renderHorizontally ? getNyTemperature : getDate}
+                yAccessor={renderHorizontally ? getDate : getNyTemperature}
+                barPadding={0.2}
+                horizontal={renderHorizontally}
+              />
+            )}
+            {renderLineSeries && (
+              <LineSeries
+                dataKey="sf"
+                data={data}
+                xAccessor={renderHorizontally ? getSfTemperature : getDate}
+                yAccessor={renderHorizontally ? getDate : getSfTemperature}
+              />
+            )}
             <AnimatedAxis
               key={`time-axis-${animationTrajectory}-${renderHorizontally}`} // force animate on update
               orientation={renderHorizontally ? yAxisOrientation : xAxisOrientation}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import cityTemperature, { CityTemperature } from '@visx/mock-data/lib/mocks/cityTemperature';
-import { AnimatedAxis, AnimatedGrid, DataProvider, LineSeries, XYChart } from '@visx/xychart';
+import {
+  AnimatedAxis,
+  AnimatedGrid,
+  DataProvider,
+  BarSeries,
+  LineSeries,
+  XYChart,
+} from '@visx/xychart';
 import ExampleControls from './ExampleControls';
 import CustomChartBackground from './CustomChartBackground';
 
@@ -12,37 +19,30 @@ type Props = {
 const xScaleConfig = { type: 'time' } as const;
 const yScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
-const data = cityTemperature.slice(0, 100);
+const data = cityTemperature.slice(150, 225);
 const getDate = (d: CityTemperature) => new Date(d.date);
 const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
+const getNyTemperature = (d: CityTemperature) => Number(d['New York']);
 
 export default function Example({ height }: Props) {
   return (
     <ExampleControls>
       {({
+        animationTrajectory,
+        renderHorizontally,
+        showGridColumns,
+        showGridRows,
         theme,
         xAxisOrientation,
         yAxisOrientation,
-        showGridRows,
-        showGridColumns,
-        animationTrajectory,
       }) => (
-        <DataProvider theme={theme} xScale={xScaleConfig} yScale={yScaleConfig}>
+        <DataProvider
+          theme={theme}
+          xScale={renderHorizontally ? yScaleConfig : xScaleConfig}
+          yScale={renderHorizontally ? xScaleConfig : yScaleConfig}
+        >
           <XYChart height={Math.min(400, height)}>
             <CustomChartBackground />
-            <AnimatedAxis
-              key={`xaxis-${animationTrajectory}`} // force animate on update
-              orientation={xAxisOrientation}
-              numTicks={numTicks}
-              animationTrajectory={animationTrajectory}
-            />
-            <AnimatedAxis
-              key={`yaxis-${animationTrajectory}`}
-              label="Temperature (°F)"
-              orientation={yAxisOrientation}
-              numTicks={numTicks}
-              animationTrajectory={animationTrajectory}
-            />
             <AnimatedGrid
               key={`grid-${animationTrajectory}`}
               rows={showGridRows}
@@ -50,11 +50,32 @@ export default function Example({ height }: Props) {
               animationTrajectory={animationTrajectory}
               numTicks={numTicks}
             />
-            <LineSeries
-              dataKey="line"
+            <BarSeries
+              dataKey="ny"
               data={data}
-              xAccessor={getDate}
-              yAccessor={getSfTemperature}
+              xAccessor={renderHorizontally ? getNyTemperature : getDate}
+              yAccessor={renderHorizontally ? getDate : getNyTemperature}
+              barPadding={0.2}
+              horizontal={renderHorizontally}
+            />
+            <LineSeries
+              dataKey="sf"
+              data={data}
+              xAccessor={renderHorizontally ? getSfTemperature : getDate}
+              yAccessor={renderHorizontally ? getDate : getSfTemperature}
+            />
+            <AnimatedAxis
+              key={`time-axis-${animationTrajectory}-${renderHorizontally}`} // force animate on update
+              orientation={renderHorizontally ? yAxisOrientation : xAxisOrientation}
+              numTicks={numTicks}
+              animationTrajectory={animationTrajectory}
+            />
+            <AnimatedAxis
+              key={`temp-axis-${animationTrajectory}-${renderHorizontally}`}
+              label="Temperature (°F)"
+              orientation={renderHorizontally ? xAxisOrientation : yAxisOrientation}
+              numTicks={numTicks}
+              animationTrajectory={animationTrajectory}
             />
           </XYChart>
         </DataProvider>

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -7,6 +7,8 @@ import customTheme from './customTheme';
 type ProvidedProps = {
   animationTrajectory: AnimationTrajectory;
   renderHorizontally: boolean;
+  renderBarSeries: boolean;
+  renderLineSeries: boolean;
   showGridColumns: boolean;
   showGridRows: boolean;
   theme: XYChartTheme;
@@ -26,12 +28,16 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [xAxisOrientation, setXAxisOrientation] = useState<'top' | 'bottom'>('bottom');
   const [yAxisOrientation, setYAxisOrientation] = useState<'left' | 'right'>('right');
   const [renderHorizontally, setRenderHorizontally] = useState(false);
+  const [renderBarSeries, setRenderBarSeries] = useState(true);
+  const [renderLineSeries, setRenderLineSeries] = useState(true);
 
   return (
     <>
       {children({
         animationTrajectory,
+        renderBarSeries,
         renderHorizontally,
+        renderLineSeries,
         showGridColumns,
         showGridRows,
         theme,
@@ -197,6 +203,26 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={animationTrajectory === 'max'}
             />{' '}
             from max
+          </label>
+        </div>
+        {/** series */}
+        <div>
+          <strong>series</strong>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setRenderLineSeries(!renderLineSeries)}
+              checked={renderLineSeries}
+            />{' '}
+            line
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setRenderBarSeries(!renderBarSeries)}
+              checked={renderBarSeries}
+            />{' '}
+            bar
           </label>
         </div>
       </div>

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -6,6 +6,7 @@ import customTheme from './customTheme';
 
 type ProvidedProps = {
   animationTrajectory: AnimationTrajectory;
+  renderHorizontally: boolean;
   showGridColumns: boolean;
   showGridRows: boolean;
   theme: XYChartTheme;
@@ -24,11 +25,13 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [showGridRows, showGridColumns] = gridProps;
   const [xAxisOrientation, setXAxisOrientation] = useState<'top' | 'bottom'>('bottom');
   const [yAxisOrientation, setYAxisOrientation] = useState<'left' | 'right'>('right');
+  const [renderHorizontally, setRenderHorizontally] = useState(false);
 
   return (
     <>
       {children({
         animationTrajectory,
+        renderHorizontally,
         showGridColumns,
         showGridRows,
         theme,
@@ -62,6 +65,27 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={theme === customTheme}
             />{' '}
             custom
+          </label>
+        </div>
+
+        {/** series orientation */}
+        <div>
+          <strong>series orientation</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderHorizontally(false)}
+              checked={!renderHorizontally}
+            />{' '}
+            vertical
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderHorizontally(true)}
+              checked={renderHorizontally}
+            />{' '}
+            horizontal
           </label>
         </div>
 

--- a/packages/visx-demo/src/sandboxes/visx-xychart/customTheme.ts
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/customTheme.ts
@@ -2,7 +2,7 @@ import { buildChartTheme } from '@visx/xychart';
 
 export default buildChartTheme({
   backgroundColor: '#f09ae9',
-  colors: ['#6a097d', '#c060a1', '#ffc1fa'],
+  colors: ['rgba(255,231,143,0.8)', '#6a097d', '#ffc1fa'],
   gridColor: '#336d88',
   gridColorDark: '#1d1b38',
   labelStyles: { fill: '#1d1b38' },

--- a/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
+++ b/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
@@ -20,7 +20,7 @@ export default function AnimatedTicks<Scale extends AxisScale>({
   ticks,
   animationTrajectory,
 }: TicksRendererProps<Scale> & { animationTrajectory?: AnimationTrajectory }) {
-  const animatedTicks = useTransition(ticks, tick => `${tick.value}-${horizontal}`, {
+  const animatedTicks = useTransition(ticks, tick => `${tick.value}`, {
     unique: true,
     ...useLineTransitionConfig({ scale, animateXOrY: horizontal ? 'x' : 'y', animationTrajectory }),
   });

--- a/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
+++ b/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
@@ -39,7 +39,7 @@ export default function AnimatedTicks<Scale extends AxisScale>({
           index,
         ) => {
           const tickLabelProps = allTickLabelProps[index] ?? allTickLabelProps[0] ?? {};
-          return (
+          return item == null || key == null ? null : (
             <animated.g
               key={key}
               className={cx('visx-axis-tick', tickClassName)}
@@ -70,7 +70,7 @@ export default function AnimatedTicks<Scale extends AxisScale>({
                 )}
                 opacity={opacity}
               >
-                <Text {...tickLabelProps}>{item.formattedValue}</Text>
+                <Text {...tickLabelProps}>{item?.formattedValue}</Text>
               </animated.g>
             </animated.g>
           );

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -51,6 +51,7 @@
     "@visx/text": "1.0.0",
     "classnames": "^2.2.5",
     "d3-array": "2.6.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.6.2",
+    "uuid": "8.3.0"
   }
 }

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -51,7 +51,6 @@
     "@visx/text": "1.0.0",
     "classnames": "^2.2.5",
     "d3-array": "2.6.0",
-    "prop-types": "^15.6.2",
-    "uuid": "8.3.0"
+    "prop-types": "^15.6.2"
   }
 }

--- a/packages/visx-xychart/src/classes/DataRegistry.ts
+++ b/packages/visx-xychart/src/classes/DataRegistry.ts
@@ -24,7 +24,7 @@ export default class DataRegistry<
         this.registryKeys = this.registryKeys.filter(key => key !== currEntry.key);
       }
       this.registry[currEntry.key] = currEntry;
-      this.registryKeys.push(currEntry.key);
+      this.registryKeys = this.registryKeys.concat(currEntry.key);
     });
   }
 

--- a/packages/visx-xychart/src/classes/DataRegistry.ts
+++ b/packages/visx-xychart/src/classes/DataRegistry.ts
@@ -5,7 +5,7 @@ import { DataRegistryEntry } from '../types/data';
 export default class DataRegistry<
   XScale extends AxisScale,
   YScale extends AxisScale,
-  Datum = unknown
+  Datum extends object
 > {
   private registry: { [key: string]: DataRegistryEntry<XScale, YScale, Datum> } = {};
 

--- a/packages/visx-xychart/src/classes/DataRegistry.ts
+++ b/packages/visx-xychart/src/classes/DataRegistry.ts
@@ -21,10 +21,9 @@ export default class DataRegistry<
     entries.forEach(currEntry => {
       if (currEntry.key in this.registry && this.registry[currEntry.key] != null) {
         console.debug('Overriding data registry key', currEntry.key);
-        this.registryKeys = this.registryKeys.filter(key => key !== currEntry.key);
       }
       this.registry[currEntry.key] = currEntry;
-      this.registryKeys = this.registryKeys.concat(currEntry.key);
+      this.registryKeys = Object.keys(this.registry);
     });
   }
 
@@ -33,7 +32,7 @@ export default class DataRegistry<
     const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
     keys.forEach(currKey => {
       delete this.registry[currKey];
-      this.registryKeys = this.registryKeys.filter(key => key !== currKey);
+      this.registryKeys = Object.keys(this.registry);
     });
   }
 

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -3,6 +3,7 @@ import ParentSize from '@visx/responsive/lib/components/ParentSize';
 
 import DataContext from '../context/DataContext';
 import { Margin } from '../types';
+import useLifecycleLogging from '../hooks/useLifecycleLogging';
 
 const DEFAULT_MARGIN = { top: 50, right: 50, bottom: 50, left: 50 };
 
@@ -17,6 +18,7 @@ type Props = {
 export default function XYChart(props: Props) {
   const { children, width, height, margin = DEFAULT_MARGIN } = props;
   const { setDimensions } = useContext(DataContext);
+  useLifecycleLogging('XYChart', width != null && height != null);
 
   // update dimensions in context
   useEffect(() => {

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -3,7 +3,6 @@ import ParentSize from '@visx/responsive/lib/components/ParentSize';
 
 import DataContext from '../context/DataContext';
 import { Margin } from '../types';
-import useLifecycleLogging from '../hooks/useLifecycleLogging';
 
 const DEFAULT_MARGIN = { top: 50, right: 50, bottom: 50, left: 50 };
 
@@ -18,7 +17,6 @@ type Props = {
 export default function XYChart(props: Props) {
   const { children, width, height, margin = DEFAULT_MARGIN } = props;
   const { setDimensions } = useContext(DataContext);
-  useLifecycleLogging('XYChart', width != null && height != null);
 
   // update dimensions in context
   useEffect(() => {

--- a/packages/visx-xychart/src/components/series/BarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/BarSeries.tsx
@@ -1,0 +1,103 @@
+import React, { useContext, useCallback, useMemo } from 'react';
+import { AxisScale } from '@visx/axis';
+import DataContext from '../../context/DataContext';
+import { SeriesProps } from '../../types';
+import withRegisteredData, { WithRegisteredDataProps } from '../../enhancers/withRegisteredData';
+import getScaledValueFactory from '../../utils/getScaledValueFactory';
+import isValidNumber from '../../typeguards/isValidNumber';
+import getScaleBandwidth from '../../utils/getScaleBandwidth';
+
+type BarSeriesProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> = SeriesProps<XScale, YScale, Datum> & {
+  /** Whether bars should be rendered horizontally instead of vertically. */
+  horizontal?: boolean;
+  /**
+   * Specify bar padding when bar thickness does not come from a `band` scale.
+   * Accepted values are [0, 1], 0 = no padding, 1 = no bar, defaults to 0.1.
+   */
+  barPadding?: number;
+};
+
+function BarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
+  barPadding = 0.9,
+  data,
+  dataKey,
+  horizontal,
+  xAccessor,
+  xScale,
+  yAccessor,
+  yScale,
+}: BarSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
+  const { colorScale, theme, innerWidth = 0, innerHeight = 0 } = useContext(DataContext);
+  const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
+  const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
+  const [xMin, xMax] = xScale.range().map(Number);
+  const [yMax, yMin] = yScale.range().map(Number);
+
+  const scaleBandwidth = getScaleBandwidth(horizontal ? yScale : xScale);
+  const barThicknessFraction = scaleBandwidth
+    ? 1 // if scale has bandwidth, padding comes from scale config
+    : // clamp padding to [0, 1], bar width = (1-padding) * availableSpace
+      1 - Math.min(1, Math.max(0, barPadding));
+  const barThickness =
+    barThicknessFraction *
+    (scaleBandwidth ||
+      // non-bandwidth estimate assumes no missing data values
+      (horizontal ? innerHeight : innerWidth) / data.length);
+
+  // try to figure out the 0 baseline for correct rendering of negative values
+  // we aren't sure if these are numeric scales or not a priori
+  const maybeXZero = xScale(0);
+  const maybeYZero = yScale(0);
+  const xZeroPosition = isValidNumber(maybeXZero)
+    ? // if maybeXZero _is_ a number, but the scale is not clamped and it's outside the domain
+      // fallback to the scale's minimum
+      Math.max(maybeXZero, Math.min(xMin, xMax))
+    : Math.min(xMin, xMax);
+  const yZeroPosition = isValidNumber(maybeYZero)
+    ? Math.min(maybeYZero, Math.max(yMin, yMax))
+    : Math.max(yMin, yMax);
+
+  const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';
+
+  const bars = useMemo(
+    () =>
+      data.map(datum => {
+        const x = getScaledX(datum) - (scaleBandwidth || horizontal ? 0 : barThickness / 2);
+        const y = getScaledY(datum) - (scaleBandwidth || !horizontal ? 0 : barThickness / 2);
+        const barLength = horizontal ? x - xZeroPosition : y - yZeroPosition;
+
+        return {
+          x: horizontal ? xZeroPosition + Math.min(0, barLength) : x,
+          y: horizontal ? y : yZeroPosition + Math.min(0, barLength),
+          width: horizontal ? Math.abs(barLength) : barThickness,
+          height: horizontal ? barThickness : Math.abs(barLength),
+          fill: color, // @TODO allow prop overriding
+        };
+      }),
+    [
+      barThickness,
+      scaleBandwidth,
+      color,
+      data,
+      getScaledX,
+      getScaledY,
+      horizontal,
+      xZeroPosition,
+      yZeroPosition,
+    ],
+  );
+
+  return (
+    <g className="vx-bar-series">
+      {bars.map(({ x, y, width, height, fill }, i) => (
+        <rect key={i} x={x} y={y} width={width} height={height} fill={fill} />
+      ))}
+    </g>
+  );
+}
+
+export default withRegisteredData(BarSeries);

--- a/packages/visx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/LineSeries.tsx
@@ -1,16 +1,15 @@
 import React, { useContext, useCallback, useEffect } from 'react';
 import LinePath from '@visx/shape/lib/shapes/LinePath';
-import { ScaleInput } from '@visx/scale';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../../context/DataContext';
 import isValidNumber from '../../typeguards/isValidNumber';
+import { SeriesProps } from '../../types';
 
-type LineSeriesProps<XScale extends AxisScale, YScale extends AxisScale, Datum> = {
-  dataKey: string;
-  data: Datum[];
-  xAccessor: (d: Datum) => ScaleInput<XScale>;
-  yAccessor: (d: Datum) => ScaleInput<YScale>;
-};
+type LineSeriesProps<XScale extends AxisScale, YScale extends AxisScale, Datum> = SeriesProps<
+  XScale,
+  YScale,
+  Datum
+>;
 
 export default function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum>({
   data,

--- a/packages/visx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/LineSeries.tsx
@@ -14,15 +14,14 @@ type LineSeriesProps<
 
 function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   data,
-  xScale,
-  yScale,
-  xAccessor,
-  yAccessor,
   dataKey,
+  xAccessor,
+  xScale,
+  yAccessor,
+  yScale,
   ...lineProps
 }: LineSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
   const { colorScale, theme } = useContext(DataContext);
-
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
   const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
   const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -31,7 +31,11 @@ export default function withRegisteredData<
       >,
   ) {
     const { dataKey, data, xAccessor, yAccessor } = props;
-    const { xScale, yScale, dataRegistry } = useContext(DataContext);
+    const { xScale, yScale, dataRegistry } = useContext(DataContext) as DataContextType<
+      XAxis,
+      YAxis,
+      Datum
+    >;
 
     useEffect(() => {
       if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -19,12 +19,11 @@ export default function withRegisteredData<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
->(
-  BaseSeriesComponent: React.ComponentType<
-    BaseComponentProps & WithRegisteredDataProps<XScale, YScale, Datum>
-  >,
-) {
-  function WrappedSeriesComponent(props: BaseComponentProps) {
+>(BaseSeriesComponent: React.ComponentType<BaseComponentProps>) {
+  function WrappedSeriesComponent(
+    // expects all props except those provided by this HOC
+    props: Omit<BaseComponentProps, keyof WithRegisteredDataProps<XScale, YScale, Datum>>,
+  ) {
     const { dataKey, data, xAccessor, yAccessor } = props;
     const { xScale, yScale, dataRegistry } = useContext(DataContext) as DataContextType<
       XScale,
@@ -35,7 +34,6 @@ export default function withRegisteredData<
     useEffect(() => {
       if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });
       return () => dataRegistry.unregisterData(dataKey);
-      // @TODO: make accessors defined inline for a component *not* trigger effect
     }, [dataRegistry, dataKey, data, xAccessor, yAccessor]);
 
     const registryEntry = dataRegistry?.get(dataKey);

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -6,7 +6,7 @@ import { DataContextType, SeriesProps } from '../types';
 export type WithRegisteredDataProps<
   XScale extends AxisScale,
   YScale extends AxisScale,
-  Datum
+  Datum extends object
 > = Pick<DataContextType<XScale, YScale, Datum>, 'xScale' | 'yScale'>;
 
 /**
@@ -35,7 +35,7 @@ export default function withRegisteredData<
     useEffect(() => {
       if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });
       return () => dataRegistry?.unregisterData(dataKey);
-      // @TODO: make accessors defined inline *not* trigger effect
+      // @TODO: make accessors defined inline for a component *not* trigger effect
     }, [dataRegistry, dataKey, data, xAccessor, yAccessor]);
 
     const registryEntry = dataRegistry?.get(dataKey);

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect } from 'react';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../context/DataContext';
 import { DataContextType, SeriesProps } from '../types';
+import useLifecycleLogging from '../hooks/useLifecycleLogging';
 
 export type WithRegisteredDataProps<
   XScale extends AxisScale,
@@ -25,6 +26,7 @@ export default function withRegisteredData<
   >,
 ) {
   function WrappedSeriesComponent(props: BaseComponentProps) {
+    useLifecycleLogging(BaseSeriesComponent.name);
     const { dataKey, data, xAccessor, yAccessor } = props;
     const { xScale, yScale, dataRegistry } = useContext(DataContext) as DataContextType<
       XScale,
@@ -34,7 +36,7 @@ export default function withRegisteredData<
 
     useEffect(() => {
       if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });
-      return () => dataRegistry?.unregisterData(dataKey);
+      return () => dataRegistry.unregisterData(dataKey);
       // @TODO: make accessors defined inline for a component *not* trigger effect
     }, [dataRegistry, dataKey, data, xAccessor, yAccessor]);
 

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect } from 'react';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../context/DataContext';
 import { DataContextType, SeriesProps } from '../types';
-import useLifecycleLogging from '../hooks/useLifecycleLogging';
 
 export type WithRegisteredDataProps<
   XScale extends AxisScale,
@@ -26,7 +25,6 @@ export default function withRegisteredData<
   >,
 ) {
   function WrappedSeriesComponent(props: BaseComponentProps) {
-    useLifecycleLogging(BaseSeriesComponent.name);
     const { dataKey, data, xAccessor, yAccessor } = props;
     const { xScale, yScale, dataRegistry } = useContext(DataContext) as DataContextType<
       XScale,

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -1,7 +1,13 @@
 import React, { useContext, useEffect } from 'react';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../context/DataContext';
-import { SeriesProps } from '../types';
+import { DataContextType, SeriesProps } from '../types';
+
+export type WithRegisteredDataProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum
+> = Pick<DataContextType<XScale, YScale, Datum>, 'xScale' | 'yScale'>;
 
 /**
  * An HOC that handles registering the Series's data and renders the
@@ -12,11 +18,19 @@ export default function withRegisteredData<
   BaseComponentProps extends SeriesProps<XScale, YScale, Datum>,
   XScale extends AxisScale,
   YScale extends AxisScale,
-  Datum
->(BaseSeriesComponent: React.ComponentType<BaseComponentProps>) {
+  Datum extends object
+>(
+  BaseSeriesComponent: React.ComponentType<
+    BaseComponentProps & WithRegisteredDataProps<XScale, YScale, Datum>
+  >,
+) {
   function WrappedSeriesComponent(props: BaseComponentProps) {
     const { dataKey, data, xAccessor, yAccessor } = props;
-    const { xScale, yScale, dataRegistry } = useContext(DataContext);
+    const { xScale, yScale, dataRegistry } = useContext(DataContext) as DataContextType<
+      XScale,
+      YScale,
+      Datum
+    >;
 
     useEffect(() => {
       if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -1,0 +1,46 @@
+import React, { useContext, useEffect } from 'react';
+import { AxisScale } from '@visx/axis';
+import DataContext from '../context/DataContext';
+import { SeriesProps } from '../types';
+
+/**
+ * An HOC that handles registering the Series's data and renders the
+ * `BaseSeriesComponent` only if x and y scales are available in context. This is
+ * useful for avoiding nasty syntax with undefined scales when using hooks.
+ */
+export default function withRegisteredData<
+  BaseComponentProps extends SeriesProps<XScale, YScale, Datum>,
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum
+>(BaseSeriesComponent: React.ComponentType<BaseComponentProps>) {
+  function WrappedSeriesComponent(props: BaseComponentProps) {
+    const { dataKey, data, xAccessor, yAccessor } = props;
+    const { xScale, yScale, dataRegistry } = useContext(DataContext);
+
+    useEffect(() => {
+      if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });
+      return () => dataRegistry?.unregisterData(dataKey);
+      // @TODO: make accessors defined inline *not* trigger effect
+    }, [dataRegistry, dataKey, data, xAccessor, yAccessor]);
+
+    const registryEntry = dataRegistry?.get(dataKey);
+
+    // if scales or data are not available in context, render nothing
+    if (!xScale || !yScale || !registryEntry) return null;
+
+    // otherwise pass props + over-write data
+    return (
+      <BaseSeriesComponent
+        {...props}
+        xScale={xScale}
+        yScale={yScale}
+        data={registryEntry.data}
+        xAccessor={registryEntry.xAccessor}
+        yAccessor={registryEntry.yAccessor}
+      />
+    );
+  }
+
+  return WrappedSeriesComponent;
+}

--- a/packages/visx-xychart/src/hooks/useDataRegistry.ts
+++ b/packages/visx-xychart/src/hooks/useDataRegistry.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import { AxisScale } from '@visx/axis';
 import { useCallback, useMemo, useState } from 'react';
 import DataRegistry from '../classes/DataRegistry';
@@ -9,26 +8,27 @@ export default function useDataRegistry<
   YScale extends AxisScale,
   Datum extends object
 >() {
-  const [, setId] = useState(uuid());
+  const [, forceUpdate] = useState(Math.random());
   const privateRegistry = useMemo(() => new DataRegistry<XScale, YScale, Datum>(), []);
 
   const registerData = useCallback(
     (...params: Parameters<typeof DataRegistry.prototype.registerData>) => {
       privateRegistry.registerData(...params);
-      setId(uuid());
+      forceUpdate(Math.random());
     },
     [privateRegistry],
   );
   const unregisterData = useCallback(
     (...params: Parameters<typeof DataRegistry.prototype.unregisterData>) => {
       privateRegistry.unregisterData(...params);
-      setId(uuid());
+      forceUpdate(Math.random());
     },
     [privateRegistry],
   );
   const entries = useCallback(() => privateRegistry.entries(), [privateRegistry]);
   const get = useCallback((key: string) => privateRegistry.get(key), [privateRegistry]);
   const keys = useCallback(() => privateRegistry.keys(), [privateRegistry]);
+
   return useMemo(
     () => ({
       registerData,

--- a/packages/visx-xychart/src/hooks/useDataRegistry.ts
+++ b/packages/visx-xychart/src/hooks/useDataRegistry.ts
@@ -2,7 +2,7 @@ import { AxisScale } from '@visx/axis';
 import { useCallback, useMemo, useState } from 'react';
 import DataRegistry from '../classes/DataRegistry';
 
-/** Hook that returns a constant instance of a DataRegistry.  */
+/** Hook that returns an API equivalent to DataRegistry but which updates as needed for use as a hook. */
 export default function useDataRegistry<
   XScale extends AxisScale,
   YScale extends AxisScale,
@@ -11,32 +11,20 @@ export default function useDataRegistry<
   const [, forceUpdate] = useState(Math.random());
   const privateRegistry = useMemo(() => new DataRegistry<XScale, YScale, Datum>(), []);
 
-  const registerData = useCallback(
-    (...params: Parameters<typeof DataRegistry.prototype.registerData>) => {
-      privateRegistry.registerData(...params);
-      forceUpdate(Math.random());
-    },
-    [privateRegistry],
-  );
-  const unregisterData = useCallback(
-    (...params: Parameters<typeof DataRegistry.prototype.unregisterData>) => {
-      privateRegistry.unregisterData(...params);
-      forceUpdate(Math.random());
-    },
-    [privateRegistry],
-  );
-  const entries = useCallback(() => privateRegistry.entries(), [privateRegistry]);
-  const get = useCallback((key: string) => privateRegistry.get(key), [privateRegistry]);
-  const keys = useCallback(() => privateRegistry.keys(), [privateRegistry]);
-
   return useMemo(
     () => ({
-      registerData,
-      unregisterData,
-      entries,
-      get,
-      keys,
+      registerData: (...params: Parameters<typeof DataRegistry.prototype.registerData>) => {
+        privateRegistry.registerData(...params);
+        forceUpdate(Math.random());
+      },
+      unregisterData: (...params: Parameters<typeof DataRegistry.prototype.unregisterData>) => {
+        privateRegistry.unregisterData(...params);
+        forceUpdate(Math.random());
+      },
+      entries: () => privateRegistry.entries(),
+      get: (key: string) => privateRegistry.get(key),
+      keys: () => privateRegistry.keys(),
     }),
-    [registerData, unregisterData, entries, get, keys],
+    [privateRegistry],
   );
 }

--- a/packages/visx-xychart/src/hooks/useDataRegistry.ts
+++ b/packages/visx-xychart/src/hooks/useDataRegistry.ts
@@ -1,5 +1,6 @@
+import { v4 as uuid } from 'uuid';
 import { AxisScale } from '@visx/axis';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import DataRegistry from '../classes/DataRegistry';
 
 /** Hook that returns a constant instance of a DataRegistry.  */
@@ -8,5 +9,34 @@ export default function useDataRegistry<
   YScale extends AxisScale,
   Datum extends object
 >() {
-  return useMemo(() => new DataRegistry<XScale, YScale, Datum>(), []);
+  const [, setId] = useState(uuid());
+  const privateRegistry = useMemo(() => new DataRegistry<XScale, YScale, Datum>(), []);
+
+  const registerData = useCallback(
+    (...params: Parameters<typeof DataRegistry.prototype.registerData>) => {
+      privateRegistry.registerData(...params);
+      setId(uuid());
+    },
+    [privateRegistry],
+  );
+  const unregisterData = useCallback(
+    (...params: Parameters<typeof DataRegistry.prototype.unregisterData>) => {
+      privateRegistry.unregisterData(...params);
+      setId(uuid());
+    },
+    [privateRegistry],
+  );
+  const entries = useCallback(() => privateRegistry.entries(), [privateRegistry]);
+  const get = useCallback((key: string) => privateRegistry.get(key), [privateRegistry]);
+  const keys = useCallback(() => privateRegistry.keys(), [privateRegistry]);
+  return useMemo(
+    () => ({
+      registerData,
+      unregisterData,
+      entries,
+      get,
+      keys,
+    }),
+    [registerData, unregisterData, entries, get, keys],
+  );
 }

--- a/packages/visx-xychart/src/hooks/useDataRegistry.ts
+++ b/packages/visx-xychart/src/hooks/useDataRegistry.ts
@@ -1,5 +1,5 @@
 import { AxisScale } from '@visx/axis';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import DataRegistry from '../classes/DataRegistry';
 
 /** Hook that returns an API equivalent to DataRegistry but which updates as needed for use as a hook. */

--- a/packages/visx-xychart/src/hooks/useDataRegistry.ts
+++ b/packages/visx-xychart/src/hooks/useDataRegistry.ts
@@ -6,7 +6,7 @@ import DataRegistry from '../classes/DataRegistry';
 export default function useDataRegistry<
   XScale extends AxisScale,
   YScale extends AxisScale,
-  Datum = unknown
+  Datum extends object
 >() {
   return useMemo(() => new DataRegistry<XScale, YScale, Datum>(), []);
 }

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -8,7 +8,7 @@ import DataRegistry from '../classes/DataRegistry';
 export default function useScales<
   XScale extends AxisScale,
   YScale extends AxisScale,
-  Datum = unknown
+  Datum extends object
 >({
   xScaleConfig,
   yScaleConfig,

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -1,5 +1,5 @@
 import { AxisScaleOutput, AxisScale } from '@visx/axis';
-import { ScaleConfig, NumberLike, createScale, ScaleInput } from '@visx/scale';
+import { ScaleConfig, createScale, ScaleInput } from '@visx/scale';
 import { extent as d3Extent } from 'd3-array';
 import { useMemo } from 'react';
 import DataRegistry from '../classes/DataRegistry';

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -40,10 +40,7 @@ export default function useScales<
     );
 
     const xType = xScaleConfig.type;
-    const xDomain =
-      xType === 'band' || xType === 'ordinal'
-        ? xValues
-        : (d3Extent(xValues as NumberLike[]) as XScaleInput[]);
+    const xDomain = xType === 'band' || xType === 'ordinal' ? xValues : d3Extent(xValues);
 
     xScale.range(xScaleConfig.range || [xMin, xMax]);
     xScale.domain(xScaleConfig.domain || xDomain);
@@ -70,10 +67,7 @@ export default function useScales<
     );
 
     const yType = yScaleConfig.type;
-    const yDomain =
-      yType === 'band' || yType === 'ordinal'
-        ? yValues
-        : (d3Extent(yValues as NumberLike[]) as YScaleInput[]);
+    const yDomain = yType === 'band' || yType === 'ordinal' ? yValues : d3Extent(yValues);
 
     yScale.range(yScaleConfig.range || [yMin, yMax]);
     yScale.domain(yScaleConfig.domain || yDomain);

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -18,7 +18,7 @@ export default function useScales<
 }: {
   xScaleConfig: ScaleConfig<AxisScaleOutput>;
   yScaleConfig: ScaleConfig<AxisScaleOutput>;
-  dataRegistry: DataRegistry<XScale, YScale, Datum>;
+  dataRegistry: Omit<DataRegistry<XScale, YScale, Datum>, 'registry' | 'registryKeys'>;
   xRange: [number, number];
   yRange: [number, number];
 }) {

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -1,10 +1,13 @@
 // components
 export { default as XYChart } from './components/XYChart';
-export { default as LineSeries } from './components/series/LineSeries';
 export { default as Axis } from './components/axis/Axis';
 export { default as AnimatedAxis } from './components/axis/AnimatedAxis';
 export { default as Grid } from './components/grid/Grid';
 export { default as AnimatedGrid } from './components/grid/AnimatedGrid';
+
+// series components
+export { default as BarSeries } from './components/series/BarSeries';
+export { default as LineSeries } from './components/series/LineSeries';
 
 // context
 export { default as ThemeContext } from './context/ThemeContext';

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ScaleConfig, ScaleConfigToD3Scale } from '@visx/scale';
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useContext, useMemo } from 'react';
 import createOrdinalScale from '@visx/scale/lib/scales/ordinal';
 import { AxisScaleOutput } from '@visx/axis';
 import { XYChartTheme } from '../types';
@@ -9,7 +9,6 @@ import DataContext from '../context/DataContext';
 import useDataRegistry from '../hooks/useDataRegistry';
 import useDimensions from '../hooks/useDimensions';
 import useScales from '../hooks/useScales';
-import useLifecycleLogging from '../hooks/useLifecycleLogging';
 
 /** Props that can be passed to initialize/update the provider config. */
 export type DataProviderProps<
@@ -32,7 +31,6 @@ export default function DataProvider<
   yScale: yScaleConfig,
   children,
 }: DataProviderProps<XScaleConfig, YScaleConfig>) {
-  useLifecycleLogging('DataProvider');
   // `DataProvider` provides a theme so that `ThemeProvider` is not strictly needed.
   // `props.theme` takes precedent over `context.theme`, which has a default even if
   // a ThemeProvider is not present.

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ScaleConfig, ScaleConfigToD3Scale } from '@visx/scale';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import createOrdinalScale from '@visx/scale/lib/scales/ordinal';
 import { AxisScaleOutput } from '@visx/axis';
 import { XYChartTheme } from '../types';
@@ -9,6 +9,7 @@ import DataContext from '../context/DataContext';
 import useDataRegistry from '../hooks/useDataRegistry';
 import useDimensions from '../hooks/useDimensions';
 import useScales from '../hooks/useScales';
+import useLifecycleLogging from '../hooks/useLifecycleLogging';
 
 /** Props that can be passed to initialize/update the provider config. */
 export type DataProviderProps<
@@ -31,6 +32,7 @@ export default function DataProvider<
   yScale: yScaleConfig,
   children,
 }: DataProviderProps<XScaleConfig, YScaleConfig>) {
+  useLifecycleLogging('DataProvider');
   // `DataProvider` provides a theme so that `ThemeProvider` is not strictly needed.
   // `props.theme` takes precedent over `context.theme`, which has a default even if
   // a ThemeProvider is not present.
@@ -45,7 +47,7 @@ export default function DataProvider<
 
   const dataRegistry = useDataRegistry<XScale, YScale, Datum>();
 
-  const scales: { xScale: XScale; yScale: YScale } = useScales({
+  const { xScale, yScale }: { xScale: XScale; yScale: YScale } = useScales({
     dataRegistry,
     xScaleConfig,
     yScaleConfig,
@@ -71,8 +73,8 @@ export default function DataProvider<
         dataRegistry,
         registerData: dataRegistry.registerData,
         unregisterData: dataRegistry.unregisterData,
-        xScale: scales.xScale,
-        yScale: scales.yScale,
+        xScale,
+        yScale,
         colorScale,
         theme,
         width,

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -11,8 +11,8 @@ import useScales from '../hooks/useScales';
 
 /** Props that can be passed to initialize/update the provider config. */
 export type DataProviderProps<
-  XScaleConfig extends ScaleConfig<AxisScaleOutput>,
-  YScaleConfig extends ScaleConfig<AxisScaleOutput>
+  XScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>,
+  YScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>
 > = {
   theme?: XYChartTheme;
   xScale: XScaleConfig;
@@ -23,7 +23,7 @@ export type DataProviderProps<
 export default function DataProvider<
   XScaleConfig extends ScaleConfig<AxisScaleOutput>,
   YScaleConfig extends ScaleConfig<AxisScaleOutput>,
-  Datum = unknown
+  Datum extends object
 >({
   theme: propsTheme,
   xScale: xScaleConfig,
@@ -35,13 +35,12 @@ export default function DataProvider<
   // a ThemeProvider is not present.
   const contextTheme = useContext(ThemeContext);
   const theme = propsTheme || contextTheme;
-
   const [{ width, height, margin }, setDimensions] = useDimensions();
   const innerWidth = width - (margin?.left ?? 0) - (margin?.right ?? 0);
   const innerHeight = height - (margin?.top ?? 0) - (margin?.bottom ?? 0);
 
-  type XScale = ScaleConfigToD3Scale<XScaleConfig, AxisScaleOutput>;
-  type YScale = ScaleConfigToD3Scale<YScaleConfig, AxisScaleOutput>;
+  type XScale = ScaleConfigToD3Scale<XScaleConfig, AxisScaleOutput, any, any>;
+  type YScale = ScaleConfigToD3Scale<YScaleConfig, AxisScaleOutput, any, any>;
 
   const dataRegistry = useDataRegistry<XScale, YScale, Datum>();
 

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ScaleConfig, ScaleConfigToD3Scale } from '@visx/scale';
 import React, { useContext, useMemo } from 'react';
 import createOrdinalScale from '@visx/scale/lib/scales/ordinal';
@@ -49,7 +50,7 @@ export default function DataProvider<
     xScaleConfig,
     yScaleConfig,
     xRange: [margin.left, width - margin.right],
-    yRange: [margin.top, height - margin.bottom],
+    yRange: [height - margin.bottom, margin.top],
   });
 
   const registryKeys = dataRegistry.keys();

--- a/packages/visx-xychart/src/theme/colors.ts
+++ b/packages/visx-xychart/src/theme/colors.ts
@@ -165,9 +165,10 @@ export const textColor = grayColors[7];
 
 export const defaultColors = [
   allColors.cyan[9],
-  allColors.cyan[6],
+  allColors.cyan[3],
   allColors.yellow[5],
   allColors.red[4],
-  allColors.violet[8],
-  allColors.grape[3],
+  allColors.grape[8],
+  allColors.grape[5],
+  allColors.pink[9],
 ];

--- a/packages/visx-xychart/src/theme/themes/dark.ts
+++ b/packages/visx-xychart/src/theme/themes/dark.ts
@@ -4,12 +4,13 @@ import buildChartTheme from '../buildChartTheme';
 export default buildChartTheme({
   backgroundColor: '#222',
   colors: [
-    allColors.cyan[1],
-    allColors.blue[2],
+    allColors.cyan[4],
+    allColors.teal[1],
     allColors.yellow[2],
-    allColors.red[2],
-    allColors.violet[2],
-    allColors.grape[2],
+    allColors.red[4],
+    allColors.grape[3],
+    allColors.grape[6],
+    allColors.pink[3],
   ],
   tickLength: 4,
   tickLabelStyles: {

--- a/packages/visx-xychart/src/types/data.ts
+++ b/packages/visx-xychart/src/types/data.ts
@@ -31,7 +31,11 @@ export interface DataRegistryEntry<XScale extends AxisScale, YScale extends Axis
   legendShape?: LegendShape;
 }
 
-export interface DataContextType<XScale extends AxisScale, YScale extends AxisScale, Datum> {
+export interface DataContextType<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> {
   xScale: XScale;
   yScale: YScale;
   colorScale: ScaleTypeToD3Scale<string, string>['ordinal'];

--- a/packages/visx-xychart/src/types/data.ts
+++ b/packages/visx-xychart/src/types/data.ts
@@ -44,7 +44,7 @@ export interface DataContextType<
   innerWidth: number;
   innerHeight: number;
   margin: Margin;
-  dataRegistry: DataRegistry<XScale, YScale, Datum>;
+  dataRegistry: Omit<DataRegistry<XScale, YScale, Datum>, 'registry' | 'registryKeys'>;
   registerData: (
     data: DataRegistryEntry<XScale, YScale, Datum> | DataRegistryEntry<XScale, YScale, Datum>[],
   ) => void;

--- a/packages/visx-xychart/src/types/index.ts
+++ b/packages/visx-xychart/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './data';
+export * from './series';
 export * from './theme';

--- a/packages/visx-xychart/src/types/series.ts
+++ b/packages/visx-xychart/src/types/series.ts
@@ -1,0 +1,13 @@
+import { AxisScale } from '@visx/axis';
+import { ScaleInput } from '@visx/scale';
+
+export type SeriesProps<XScale extends AxisScale, YScale extends AxisScale, Datum> = {
+  /** Required data key for the Series, should be unique across all series. */
+  dataKey: string;
+  /** Data for the Series. */
+  data: Datum[];
+  /** Given a Datum, returns the x-scale value. */
+  xAccessor: (d: Datum) => ScaleInput<XScale>;
+  /** Given a Datum, returns the y-scale value. */
+  yAccessor: (d: Datum) => ScaleInput<YScale>;
+};

--- a/packages/visx-xychart/src/types/series.ts
+++ b/packages/visx-xychart/src/types/series.ts
@@ -1,7 +1,11 @@
 import { AxisScale } from '@visx/axis';
 import { ScaleInput } from '@visx/scale';
 
-export type SeriesProps<XScale extends AxisScale, YScale extends AxisScale, Datum> = {
+export type SeriesProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> = {
   /** Required data key for the Series, should be unique across all series. */
   dataKey: string;
   /** Data for the Series. */

--- a/packages/visx-xychart/src/utils/getScaleBandwidth.ts
+++ b/packages/visx-xychart/src/utils/getScaleBandwidth.ts
@@ -1,0 +1,7 @@
+import { AxisScale } from '@visx/axis';
+
+export default function getScaleBandwidth<Scale extends AxisScale>(scale: Scale) {
+  // Broaden type before using 'xxx' in s as typeguard.
+  const s = scale as AxisScale;
+  return 'bandwidth' in s ? s?.bandwidth() ?? 0 : 0;
+}

--- a/packages/visx-xychart/src/utils/getScaledValueFactory.ts
+++ b/packages/visx-xychart/src/utils/getScaledValueFactory.ts
@@ -1,6 +1,7 @@
 import { AxisScale } from '@visx/axis';
 import { ScaleInput } from '@visx/scale';
 import isValidNumber from '../typeguards/isValidNumber';
+import getScaleBandwidth from './getScaleBandwidth';
 
 /** Returns a function that takes a Datum as input and returns a scaled value, correcting for the scale's bandwidth if applicable. */
 export default function getScaledValueFactory<Scale extends AxisScale, Datum>(
@@ -8,15 +9,11 @@ export default function getScaledValueFactory<Scale extends AxisScale, Datum>(
   accessor: (d: Datum) => ScaleInput<Scale>,
   align: 'start' | 'center' | 'end' = 'center',
 ) {
-  // Broaden type before using 'xxx' in s as typeguard.
-  const coercedScale = scale as AxisScale;
-
   return (d: Datum) => {
-    const scaledValue = coercedScale?.(accessor(d));
+    const scaledValue = scale(accessor(d));
     if (isValidNumber(scaledValue)) {
       const bandwidthOffset =
-        (align !== 'start' && 'bandwidth' in coercedScale ? coercedScale.bandwidth() ?? 0 : 0) /
-        (align === 'center' ? 2 : 1);
+        (align === 'start' ? 0 : getScaleBandwidth(scale)) / (align === 'center' ? 2 : 1);
       return scaledValue + bandwidthOffset;
     }
     return NaN;

--- a/packages/visx-xychart/src/utils/getScaledValueFactory.ts
+++ b/packages/visx-xychart/src/utils/getScaledValueFactory.ts
@@ -1,0 +1,24 @@
+import { AxisScale } from '@visx/axis';
+import { ScaleInput } from '@visx/scale';
+import isValidNumber from '../typeguards/isValidNumber';
+
+/** Returns a function that takes a Datum as input and returns a scaled value, correcting for the scale's bandwidth if applicable. */
+export default function getScaledValueFactory<Scale extends AxisScale, Datum>(
+  scale: Scale,
+  accessor: (d: Datum) => ScaleInput<Scale>,
+  align: 'start' | 'center' | 'end' = 'center',
+) {
+  // Broaden type before using 'xxx' in s as typeguard.
+  const coercedScale = scale as AxisScale;
+
+  return (d: Datum) => {
+    const scaledValue = coercedScale?.(accessor(d));
+    if (isValidNumber(scaledValue)) {
+      const bandwidthOffset =
+        (align !== 'start' && 'bandwidth' in coercedScale ? coercedScale.bandwidth() ?? 0 : 0) /
+        (align === 'center' ? 2 : 1);
+      return scaledValue + bandwidthOffset;
+    }
+    return NaN;
+  };
+}

--- a/packages/visx-xychart/test/BarSeries.test.tsx
+++ b/packages/visx-xychart/test/BarSeries.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { DataContext, BarSeries } from '../src';
+import getDataContext from './mocks/getDataContext';
+
+describe('<BarSeries />', () => {
+  it('should be defined', () => {
+    expect(BarSeries).toBeDefined();
+  });
+
+  it('should render a LinePath', () => {
+    const series = { key: 'bar', data: [{}, {}], xAccessor: () => 0, yAccessor: () => 10 };
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <BarSeries dataKey={series.key} {...series} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    expect(wrapper.find('rect')).toHaveLength(2);
+  });
+});

--- a/packages/visx-xychart/test/Grid.test.tsx
+++ b/packages/visx-xychart/test/Grid.test.tsx
@@ -4,15 +4,10 @@ import VxAnimatedGridRows from '@visx/react-spring/lib/grid/AnimatedGridRows';
 import VxAnimatedGridColumns from '@visx/react-spring/lib/grid/AnimatedGridColumns';
 import VxGridRows from '@visx/grid/lib/grids/GridRows';
 import VxGridColumns from '@visx/grid/lib/grids/GridColumns';
-import { scaleLinear } from '@visx/scale';
 import { Grid, AnimatedGrid, DataContext } from '../src';
+import getDataContext from './mocks/getDataContext';
 
-const mockContext = {
-  xScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
-  yScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
-  innerWidth: 10,
-  innerHeight: 10,
-};
+const mockContext = getDataContext();
 
 describe('<Grid />', () => {
   it('should be defined', () => {
@@ -20,7 +15,6 @@ describe('<Grid />', () => {
   });
   it('should render VxGridRows if rows=true', () => {
     const wrapper = mount(
-      // @ts-ignore partial context value
       <DataContext.Provider value={mockContext}>
         <svg>
           <Grid rows columns={false} />
@@ -32,7 +26,6 @@ describe('<Grid />', () => {
   });
   it('should render VxGridColumns if columns=true', () => {
     const wrapper = mount(
-      // @ts-ignore partial context value
       <DataContext.Provider value={mockContext}>
         <svg>
           <Grid rows={false} columns />
@@ -50,7 +43,6 @@ describe('<AnimatedGrid />', () => {
   });
   it('should render VxAnimatedGridRows if rows=true', () => {
     const wrapper = mount(
-      // @ts-ignore partial context value
       <DataContext.Provider value={mockContext}>
         <svg>
           <AnimatedGrid rows columns={false} />
@@ -62,7 +54,6 @@ describe('<AnimatedGrid />', () => {
   });
   it('should render VxAnimatedGridColumns if columns=true', () => {
     const wrapper = mount(
-      // @ts-ignore partial context value
       <DataContext.Provider value={mockContext}>
         <svg>
           <AnimatedGrid rows={false} columns />

--- a/packages/visx-xychart/test/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/LineSeries.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 import { LinePath } from '@visx/shape';
-import { LineSeries } from '../src';
+import { DataContext, LineSeries } from '../src';
+import getDataContext from './mocks/getDataContext';
 
 describe('<LineSeries />', () => {
   it('should be defined', () => {
@@ -9,10 +10,15 @@ describe('<LineSeries />', () => {
   });
 
   it('should render a LinePath', () => {
-    const wrapper = shallow(
-      <LineSeries dataKey="line" data={[]} xAccessor={() => 'x'} yAccessor={() => 'y'} />,
+    const series = { key: 'line', data: [], xAccessor: () => 'x', yAccessor: () => '7' };
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <LineSeries dataKey={series.key} {...series} />
+        </svg>
+      </DataContext.Provider>,
     );
     // @ts-ignore produces a union type that is too complex to represent.ts(2590)
-    expect(wrapper.find(LinePath) as ShallowWrapper).toHaveLength(1);
+    expect(wrapper.find(LinePath)).toHaveLength(1);
   });
 });

--- a/packages/visx-xychart/test/mocks/getDataContext.ts
+++ b/packages/visx-xychart/test/mocks/getDataContext.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { scaleLinear, scaleOrdinal } from '@visx/scale';
+import { DataContextType, lightTheme } from '../../lib';
+import DataRegistry from '../../lib/classes/DataRegistry';
+
+const width = 10;
+const height = 10;
+const margin = { top: 0, right: 0, bottom: 0, left: 0 };
+const noOp = () => {};
+
+const getDataContext = (
+  entries?: Parameters<typeof DataRegistry.prototype.registerData>[0],
+): DataContextType<any, any, any> => {
+  const dataRegistry = new DataRegistry();
+  if (entries) dataRegistry.registerData(entries);
+
+  const mockContext = {
+    dataRegistry,
+    registerData: dataRegistry.registerData,
+    unregisterData: dataRegistry.unregisterData,
+    xScale: scaleLinear({ domain: [0, 10], range: [0, width] }),
+    yScale: scaleLinear({ domain: [0, 10], range: [0, height] }),
+    colorScale: scaleOrdinal({ domain: ['sf', 'ny', 'la'], range: ['purple', 'violet', 'grape'] }),
+    width,
+    height,
+    margin,
+    innerWidth: width,
+    innerHeight: height,
+    theme: lightTheme,
+    setDimensions: noOp,
+  };
+
+  return mockContext;
+};
+
+export default getDataContext;

--- a/packages/visx-xychart/test/useDataRegistry.test.tsx
+++ b/packages/visx-xychart/test/useDataRegistry.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import useDataRegistry from '../src/hooks/useDataRegistry';
+
+describe('useDataRegistry', () => {
+  it('should be defined', () => {
+    expect(useDataRegistry).toBeDefined();
+  });
+
+  it('should provide a DataRegistry', () => {
+    expect.assertions(1);
+
+    const RegistryConsumer = () => {
+      const registry = useDataRegistry();
+      expect(registry).toBeDefined();
+
+      return null;
+    };
+
+    mount(<RegistryConsumer />);
+  });
+});

--- a/packages/visx-xychart/test/withRegisteredData.test.tsx
+++ b/packages/visx-xychart/test/withRegisteredData.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import withRegisteredData from '../src/enhancers/withRegisteredData';
 import getDataContext from './mocks/getDataContext';
 import { DataContext } from '../src';

--- a/packages/visx-xychart/test/withRegisteredData.test.tsx
+++ b/packages/visx-xychart/test/withRegisteredData.test.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import withRegisteredData from '../src/enhancers/withRegisteredData';
+import getDataContext from './mocks/getDataContext';
+import { DataContext } from '../src';
+
+const series = {
+  key: 'visx',
+  xAccessor: () => 'x',
+  yAccessor: () => 'y',
+  data: [{}],
+};
+
+describe('withRegisteredData', () => {
+  it('should be defined', () => {
+    expect(withRegisteredData).toBeDefined();
+  });
+
+  it('should return a component', () => {
+    const BaseComponent = () => <div />;
+    const WrappedComponent = withRegisteredData(BaseComponent);
+    expect(() => <WrappedComponent dataKey={series.key} {...series} />).not.toThrow();
+  });
+
+  it('should not render base component if scales or key is not in context', () => {
+    const mockContextWithSeries = getDataContext(series);
+    const BaseComponent = () => <div />;
+    const WrappedComponent = withRegisteredData(BaseComponent);
+
+    const wrapperNoContext = mount(
+      <DataContext.Provider value={{}}>
+        <WrappedComponent dataKey={series.key} {...series} />
+      </DataContext.Provider>,
+    );
+    const wrapperCompleteContext = mount(
+      <DataContext.Provider value={mockContextWithSeries}>
+        <WrappedComponent dataKey={series.key} {...series} />
+      </DataContext.Provider>,
+    );
+
+    expect(wrapperNoContext.find('div')).toHaveLength(0);
+    expect(wrapperCompleteContext.find('div')).toHaveLength(1);
+  });
+
+  it('should pass data and accessors to BaseComponent from context not props', () => {
+    expect.assertions(3);
+    const mockContext = getDataContext(series);
+    const BaseComponent = ({ data, xAccessor, yAccessor }: any) => {
+      expect(data).toBe(series.data);
+      expect(xAccessor).toBe(series.xAccessor);
+      expect(yAccessor).toBe(series.yAccessor);
+      return null;
+    };
+    const WrappedComponent = withRegisteredData(BaseComponent);
+
+    mount(
+      <DataContext.Provider value={mockContext}>
+        <WrappedComponent
+          dataKey={series.key}
+          {...series}
+          data={[]}
+          xAccessor={() => 3}
+          yAccessor={() => 4}
+        />
+      </DataContext.Provider>,
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5241,6 +5241,11 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
 
+d3-array@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.6.0.tgz#b8df0c695eab26e2b2fd4ffe2d84bd703f8d0faf"
+  integrity sha512-1TgzIGb6hrHKSCGccdL209Ibk41HCeyv5znFEvJfBsBGhD3qpoHt/2W2ECpyLxpG1k7aNJz0BYrmLpVs9hIGNQ==
+
 d3-chord@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
@@ -13502,6 +13507,11 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+uuid@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13508,11 +13508,6 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
-
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"


### PR DESCRIPTION
This PR adds `BarSeries` to the `xychart` package and refactors / fixes other issues in the process

<img src="https://user-images.githubusercontent.com/4496521/94055304-9d568600-fd91-11ea-8dd5-b3ce4eed3a0e.gif" width="600" />

#### :rocket: Enhancements

- adds `BarSeries` component
- adds `withRegisteredData` HOC which swaps `data`/`xAccessor`/`yAccessor` props for those in the `DataRegistry` in context. This makes `*Series` implementation more straight forward because they should always use values from context so they are in sync with the context scales.
- re-writes `useDataRegistry`
  - previously this hook just returned a constant instance of `DataRegistry`, which did not result in the necessary `hook` => `scales` => `context` => `component` updates when the registry was updated.
  - the new implementation mirrors the `DataRegistry` API and uses it for its implementation

- improves the light/dark theme colors:

<img src="https://user-images.githubusercontent.com/4496521/94054881-0ee20480-fd91-11ea-9cde-505b6e2cbf59.png" width="400" />

#### :memo: Documentation

for the `/xychart` demo:
- adds checkbox controls to toggle `line` or `bar` series
- adds `render horizontally` toggle

Adds tests for all new components.

@kristw @techniq @hshoff 