### PR TITLE
fix(Axis): tick index = post-filtered index

### DIFF
--- a/packages/visx-axis/src/axis/Axis.tsx
+++ b/packages/visx-axis/src/axis/Axis.tsx
@@ -47,8 +47,8 @@ export default function Axis<Scale extends AxisScale>({
   );
 
   const filteredTickValues = (tickValues ?? getTicks(scale, numTicks))
-    .map((value, index) => ({ value, index }))
-    .filter(({ value }) => !hideZero || (value !== 0 && value !== '0'));
+    .filter(value => !hideZero || (value !== 0 && value !== '0'))
+    .map((value, index) => ({ value, index }));
 
   const ticks = filteredTickValues.map(({ value, index }) => {
     const scaledValue = coerceNumber(tickPosition(value));

--- a/packages/visx-axis/test/Axis.test.tsx
+++ b/packages/visx-axis/test/Axis.test.tsx
@@ -118,7 +118,7 @@ describe('<Axis />', () => {
         .find('.visx-axis-tick')
         .at(0)
         .key(),
-    ).toBe('visx-tick-1-1');
+    ).toBe('visx-tick-1-0');
   });
 
   test('it should SHOW an axis line if hideAxisLine is false', () => {

--- a/packages/visx-demo/src/sandboxes/visx-threshold/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-threshold/Example.tsx
@@ -21,7 +21,7 @@ const timeScale = scaleTime<number>({
 });
 const temperatureScale = scaleLinear<number>({
   domain: [
-    0, // Math.min(...cityTemperature.map(d => Math.min(ny(d), sf(d)))),
+    Math.min(...cityTemperature.map(d => Math.min(ny(d), sf(d)))),
     Math.max(...cityTemperature.map(d => Math.max(ny(d), sf(d)))),
   ],
   nice: true,
@@ -54,7 +54,7 @@ export default function Theshold({ width, height, margin = defaultMargin }: Thre
           <GridColumns scale={timeScale} width={xMax} height={yMax} stroke="#e0e0e0" />
           <line x1={xMax} x2={xMax} y1={0} y2={yMax} stroke="#e0e0e0" />
           <AxisBottom top={yMax} scale={timeScale} numTicks={width > 520 ? 10 : 5} />
-          <AxisLeft scale={temperatureScale} hideZero tickLabelProps={() => ({ fill: 'red' })} />
+          <AxisLeft scale={temperatureScale} />
           <text x="-70" y="15" transform="rotate(-90)" fontSize={10}>
             Temperature (°F)
           </text>

--- a/packages/visx-demo/src/sandboxes/visx-threshold/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-threshold/Example.tsx
@@ -21,7 +21,7 @@ const timeScale = scaleTime<number>({
 });
 const temperatureScale = scaleLinear<number>({
   domain: [
-    Math.min(...cityTemperature.map(d => Math.min(ny(d), sf(d)))),
+    0, // Math.min(...cityTemperature.map(d => Math.min(ny(d), sf(d)))),
     Math.max(...cityTemperature.map(d => Math.max(ny(d), sf(d)))),
   ],
   nice: true,
@@ -54,7 +54,7 @@ export default function Theshold({ width, height, margin = defaultMargin }: Thre
           <GridColumns scale={timeScale} width={xMax} height={yMax} stroke="#e0e0e0" />
           <line x1={xMax} x2={xMax} y1={0} y2={yMax} stroke="#e0e0e0" />
           <AxisBottom top={yMax} scale={timeScale} numTicks={width > 520 ? 10 : 5} />
-          <AxisLeft scale={temperatureScale} />
+          <AxisLeft scale={temperatureScale} hideZero tickLabelProps={() => ({ fill: 'red' })} />
           <text x="-70" y="15" transform="rotate(-90)" fontSize={10}>
             Temperature (°F)
           </text>


### PR DESCRIPTION
#### :bug: Bug Fix

Fixes #815 . 

This was a regression introduced in #779 / `0.0.199` where `renderTicks` was factored out to allow for an animated variant. We had to pass `tickLabelProps` to `renderTicks` as an array, one for each tick value. However tick `index` corresponded to the _pre-filtered_ `index`, which does not match the `tickLabelProps` array index when `hideZero=true`. This was most noticeable when there were no `tickLabelProps` for the final tick value (see example below), but in reality all of the styles were off by an index of +1.

A simplification of the problem:

```ts
const tickValues = [0, 1, 2];
const filteredTickValues = [{ value: 1, index: 1 }, { value: 2, index: 2 }]; // hideZero filtered
const tickLabelProps = [tickLabelPropsFn(1, 1), tickLabelPropsFn(2, 2)];

// renderTicks
...
const tickValue = { value: 2, index: 2 };
const tickProps = tickLabelProps[tickValue.index]; // doesn't exist
...
```

**Before**
<img src="https://user-images.githubusercontent.com/4496521/94614133-8a90f500-025a-11eb-8009-a446d86b2a4b.png" width="300" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/94612435-f3c33900-0257-11eb-9ebd-15637187973b.png" width="300" />

@kristw @hshoff 