### PR TITLE
fix(tooltip): correct positioning when unstyled is applied

### DIFF
--- a/packages/visx-tooltip/src/tooltips/Tooltip.tsx
+++ b/packages/visx-tooltip/src/tooltips/Tooltip.tsx
@@ -13,7 +13,6 @@ export type TooltipProps = {
 };
 
 export const defaultStyles: React.CSSProperties = {
-  position: 'absolute',
   backgroundColor: 'white',
   color: '#666666',
   padding: '.3rem .5rem',
@@ -39,8 +38,13 @@ export default function Tooltip({
     <div
       className={cx('visx-tooltip', className)}
       style={{
-        top: top == null || offsetTop == null ? top : top + offsetTop,
-        left: left == null || offsetLeft == null ? left : left + offsetLeft,
+        // these styles are needed for correct positioning, regardless of styles
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        transform: `translate(${left == null || offsetLeft == null ? left : left + offsetLeft}px, ${
+          top == null || offsetTop == null ? top : top + offsetTop
+        }px)`,
         ...(!unstyled && style),
       }}
       {...restProps}

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -44,12 +44,11 @@ function TooltipWithBounds({
 
   return (
     <Tooltip
-      style={{
-        top: 0,
-        left: 0,
-        transform: `translate(${left}px, ${top}px)`,
-        ...(!unstyled && style),
-      }}
+      top={top}
+      left={left}
+      offsetTop={0}
+      offsetLeft={0}
+      style={style}
       unstyled={unstyled}
       {...otherProps}
     >

--- a/packages/visx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/visx-tooltip/test/TooltipWithBounds.test.tsx
@@ -11,7 +11,7 @@ describe('<TooltipWithBounds />', () => {
     const wrapper = shallow(<TooltipWithBounds>Hello</TooltipWithBounds>, {
       disableLifecycleMethods: true,
     }).dive();
-    const styles = wrapper.find('Tooltip').props().style as any;
+    const styles = wrapper.find('Tooltip').props().style as unknown;
     Object.entries(defaultStyles).forEach(([key, value]) => {
       expect(styles[key]).toBe(value);
     });
@@ -21,7 +21,11 @@ describe('<TooltipWithBounds />', () => {
     const wrapper = shallow(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>, {
       disableLifecycleMethods: true,
     }).dive();
-    const styles = wrapper.find('Tooltip').props().style as any;
+    const styles = wrapper
+      .find('Tooltip')
+      .dive()
+      .find('.visx-tooltip')
+      .props().style as unknown;
     Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBeUndefined();
     });

--- a/packages/visx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/visx-tooltip/test/TooltipWithBounds.test.tsx
@@ -11,7 +11,7 @@ describe('<TooltipWithBounds />', () => {
     const wrapper = shallow(<TooltipWithBounds>Hello</TooltipWithBounds>, {
       disableLifecycleMethods: true,
     }).dive();
-    const styles = wrapper.find('Tooltip').props().style as unknown;
+    const styles = wrapper.find('Tooltip').props().style as any;
     Object.entries(defaultStyles).forEach(([key, value]) => {
       expect(styles[key]).toBe(value);
     });
@@ -25,7 +25,7 @@ describe('<TooltipWithBounds />', () => {
       .find('Tooltip')
       .dive()
       .find('.visx-tooltip')
-      .props().style as unknown;
+      .props().style as any;
     Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBeUndefined();
     });


### PR DESCRIPTION
#### :bug: Bug Fix

This PR
- fixes #767 where setting `unstyled` on `TooltipWithBounds` breaks positioning because it is passed to `Tooltip`, which then doesn't respect the `style` prop which includes the needed offset
- fixes an issue where if `unstyled` is set on _either_ `Tooltip` or `TooltipWithBounds`, lib consumers must also minimally set `.visx-tooltip { position: absolute; }` themselves in order for the tooltips to be correctly positioned since they rely on `absolute` positioning.
  - this was fixed by removing `position: absolute` from `defaultStyles`, and always setting it (along with the positional offset)

**Testing**
Verified in `/tooltip` demo that tooltip is correctly positioned when `unstyled` is set for all combinations 
- boundary detection + ~portal~
- ~boundary detection~ + ~portal~
- boundary detection + portal
- ~boundary detection~ + portal

@hshoff @kristw @singhanurag05
