### PR TITLE
test(text): improve @visx/text coverage

### DIFF
--- a/packages/visx-text/test/Text.test.tsx
+++ b/packages/visx-text/test/Text.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount, ShallowWrapper } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Text, getStringWidth } from '../src';
 import { addMock, removeMock } from './svgMock';
 
@@ -142,27 +142,16 @@ describe('<Text />', () => {
         This is really long text
       </Text>,
     );
-    expect(
-      wrapper
+    const getVerticalOffset = (w: typeof wrapper) =>
+      w
         .find('tspan')
         .first()
-        .prop('dy'),
-    ).toBe('-1em');
+        .prop('dy');
 
+    expect(getVerticalOffset(wrapper)).toBe('-1em');
     wrapper.setProps({ verticalAnchor: 'middle' });
-    expect(
-      wrapper
-        .find('tspan')
-        .first()
-        .prop('dy'),
-    ).toBe('-0.145em');
-
+    expect(getVerticalOffset(wrapper)).toBe('-0.145em');
     wrapper.setProps({ verticalAnchor: 'start' });
-    expect(
-      wrapper
-        .find('tspan')
-        .first()
-        .prop('dy'),
-    ).toBe('0.71em');
+    expect(getVerticalOffset(wrapper)).toBe('0.71em');
   });
 });

--- a/packages/visx-text/test/Text.test.tsx
+++ b/packages/visx-text/test/Text.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow, mount, ShallowWrapper } from 'enzyme';
 import { Text, getStringWidth } from '../src';
 import { addMock, removeMock } from './svgMock';
 
@@ -134,5 +134,35 @@ describe('<Text />', () => {
 
     const text = wrapper.find('text').first();
     expect(text.prop('transform')).toBe('rotate(45, 0, 0)');
+  });
+
+  it('Offsets vertically if verticalAnchor is given', () => {
+    const wrapper = shallow<Text>(
+      <Text width={200} style={{ fontFamily: 'Courier' }}>
+        This is really long text
+      </Text>,
+    );
+    expect(
+      wrapper
+        .find('tspan')
+        .first()
+        .prop('dy'),
+    ).toBe('-1em');
+
+    wrapper.setProps({ verticalAnchor: 'middle' });
+    expect(
+      wrapper
+        .find('tspan')
+        .first()
+        .prop('dy'),
+    ).toBe('-0.145em');
+
+    wrapper.setProps({ verticalAnchor: 'start' });
+    expect(
+      wrapper
+        .find('tspan')
+        .first()
+        .prop('dy'),
+    ).toBe('0.71em');
   });
 });

--- a/packages/visx-text/test/Text.test.tsx
+++ b/packages/visx-text/test/Text.test.tsx
@@ -101,4 +101,38 @@ describe('<Text />', () => {
 
     expect(wrapperNan.text()).not.toContain('anything');
   });
+
+  it('Recalculates text when children are updated', () => {
+    const wrapper = shallow<Text>(
+      <Text width={200} style={{ fontFamily: 'Courier' }}>
+        This is short text
+      </Text>,
+    );
+    expect(wrapper.instance().state.wordsByLines).toHaveLength(1);
+
+    wrapper.setProps({ children: 'This is really long text' });
+    expect(wrapper.instance().state.wordsByLines).toHaveLength(2);
+  });
+
+  it('Applies transform if scaleToFit is set', () => {
+    const wrapper = shallow<Text>(
+      <Text width={300} scaleToFit style={{ fontFamily: 'Courier' }}>
+        This is really long text
+      </Text>,
+    );
+
+    const text = wrapper.find('text').first();
+    expect(text.prop('transform')).toBe('matrix(1.25, 0, 0, 1.25, 0, 0)');
+  });
+
+  it('Applies transform if angle is given', () => {
+    const wrapper = shallow<Text>(
+      <Text width={300} angle={45} style={{ fontFamily: 'Courier' }}>
+        This is really long text
+      </Text>,
+    );
+
+    const text = wrapper.find('text').first();
+    expect(text.prop('transform')).toBe('rotate(45, 0, 0)');
+  });
 });


### PR DESCRIPTION
#### :house: Internal

Add various missing tests for `@visx/text` to get its coverage to 100% line coverage.

I'm not too seasoned in writing tests, so any constructive criticism/code review is very welcome. This PR is mostly intended to be a first small try at what will hopefully be several coverage-focused PRs.