### PR TITLE
new(responsive): add `ignoreDimensions` prop to handle rerenders

### DIFF
--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -7,10 +7,10 @@ export type ParentSizeProps = {
   className?: string;
   /** Child render updates upon resize are delayed until `debounceTime` milliseconds _after_ the last resize event is observed. */
   debounceTime?: number;
-  /** Optional dimensions provided won't trigger a state change when changed. */
-  disableFor?: keyof ParentSizeState | (keyof ParentSizeState)[];
   /** Optional flag to toggle leading debounce calls. When set to true this will ensure that the component always renders immediately. (defaults to true) */
   enableDebounceLeadingCall?: boolean;
+  /** Optional dimensions provided won't trigger a state change when changed. */
+  ignoreDimensions?: keyof ParentSizeState | (keyof ParentSizeState)[];
   /** Optional `style` object to apply to the parent `div` wrapper used for size measurement. */
   parentSizeStyles?: React.CSSProperties;
   /** Child render function `({ width, height, top, left, ref, resize }) => ReactNode`. */
@@ -35,7 +35,7 @@ export default function ParentSize({
   className,
   children,
   debounceTime = 300,
-  disableFor,
+  ignoreDimensions = [],
   parentSizeStyles = { width: '100%', height: '100%' },
   enableDebounceLeadingCall = true,
   ...restProps
@@ -46,13 +46,13 @@ export default function ParentSize({
   const [state, setState] = useState<ParentSizeState>({ width: 0, height: 0, top: 0, left: 0 });
 
   const resize = useMemo(() => {
-    const normalized = disableFor ? (Array.isArray(disableFor) ? disableFor : [disableFor]) : [];
+    const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
         setState(existing => {
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
-          const keysWithChanges = stateKeys.filter(key => existing[key] !== incoming[key])
+          const keysWithChanges = stateKeys.filter(key => existing[key] !== incoming[key]);
           const shouldBail = keysWithChanges.every(key => normalized.includes(key));
 
           return shouldBail ? existing : incoming;
@@ -61,7 +61,7 @@ export default function ParentSize({
       debounceTime,
       { leading: enableDebounceLeadingCall },
     );
-  }, [debounceTime, disableFor, enableDebounceLeadingCall]);
+  }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
   useEffect(() => {
     const observer = new ResizeObserver((entries = [] /** , observer */) => {

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -7,7 +7,7 @@ export type ParentSizeProps = {
   className?: string;
   /** Child render updates upon resize are delayed until `debounceTime` milliseconds _after_ the last resize event is observed. */
   debounceTime?: number;
-  /** Optional keys provided won't trigger a state change when changed */
+  /** Optional dimensions provided won't trigger a state change when changed. */
   disableFor?: keyof ParentSizeState | (keyof ParentSizeState)[];
   /** Optional flag to toggle leading debounce calls. When set to true this will ensure that the component always renders immediately. (defaults to true) */
   enableDebounceLeadingCall?: boolean;
@@ -52,9 +52,7 @@ export default function ParentSize({
       (incoming: ParentSizeState) => {
         setState(existing => {
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
-          const keysWithChanges = stateKeys.reduce<(keyof ParentSizeState)[]>((diff, key) => {
-            return existing[key] === incoming[key] ? diff : [...diff, key];
-          }, []);
+          const keysWithChanges = stateKeys.filter(key => existing[key] !== incoming[key])
           const shouldBail = keysWithChanges.every(key => normalized.includes(key));
 
           return shouldBail ? existing : incoming;


### PR DESCRIPTION
#### :rocket: Enhancements

This PR

- add a new prop to ParentSize (`disableFor`) to skip when a component doesn't want to be notified by a size change of a certain prop
- also converted the class component to a functional component (hopefully was ok). I did that in a separate commit so you could see what was needed for the feature

Note: I did attempt a test and was unsuccessful, so more than happy to add one provided some direction. I use react-testing-library, so unsure how to simulate resize of an element with enzyme.

~Also, `disableFor` might not be the best name for the prop, so I am open to changing it.~

Close #247 