### PR TITLE
test(xychart): add Event + Tooltip tests

### DIFF
--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -56,5 +56,8 @@
     "d3-array": "2.6.0",
     "mitt": "^2.1.0",
     "prop-types": "^15.6.2"
+  },
+  "devDependencies": {
+    "resize-observer-polyfill": "1.5.1"
   }
 }

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -19,7 +19,11 @@ export type TooltipProps = {
    * Content will be rendered in an HTML parent.
    */
   renderTooltip: (params: RenderTooltipParams) => React.ReactNode;
-  resizeObserverPolyfill: UseTooltipPortalOptions['polyfill'];
+  /**
+   * Tooltip depends on ResizeObserver, which may be pollyfilled globally
+   * or injected into this component.
+   */
+  resizeObserverPolyfill?: UseTooltipPortalOptions['polyfill'];
 } & Omit<BaseTooltipProps, 'left' | 'top' | 'children'> &
   Pick<UseTooltipPortalOptions, 'debounce' | 'detectBounds' | 'scroll'>;
 

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext } from 'react';
 import { useTooltipInPortal, defaultStyles } from '@visx/tooltip';
 import { TooltipProps as BaseTooltipProps } from '@visx/tooltip/lib/tooltips/Tooltip';
 import { PickD3Scale } from '@visx/scale';
+import { UseTooltipPortalOptions } from '@visx/tooltip/lib/hooks/useTooltipInPortal';
 
 import TooltipContext from '../context/TooltipContext';
 import DataContext from '../context/DataContext';
@@ -18,7 +19,9 @@ export type TooltipProps = {
    * Content will be rendered in an HTML parent.
    */
   renderTooltip: (params: RenderTooltipParams) => React.ReactNode;
-} & Omit<BaseTooltipProps, 'left' | 'top' | 'children'>;
+  resizeObserverPolyfill: UseTooltipPortalOptions['polyfill'];
+} & Omit<BaseTooltipProps, 'left' | 'top' | 'children'> &
+  Pick<UseTooltipPortalOptions, 'debounce' | 'detectBounds' | 'scroll'>;
 
 const INVISIBLE_STYLES: React.CSSProperties = {
   position: 'absolute',
@@ -30,10 +33,22 @@ const INVISIBLE_STYLES: React.CSSProperties = {
   pointerEvents: 'none',
 };
 
-export default function Tooltip({ renderTooltip, ...tooltipProps }: TooltipProps) {
+export default function Tooltip({
+  renderTooltip,
+  debounce,
+  detectBounds,
+  resizeObserverPolyfill,
+  scroll,
+  ...tooltipProps
+}: TooltipProps) {
   const { colorScale, theme } = useContext(DataContext) || {};
   const tooltipContext = useContext(TooltipContext);
-  const { containerRef, TooltipInPortal } = useTooltipInPortal();
+  const { containerRef, TooltipInPortal } = useTooltipInPortal({
+    debounce,
+    detectBounds,
+    polyfill: resizeObserverPolyfill,
+    scroll,
+  });
 
   // To correctly position itself in a Portal, the tooltip must know its container bounds
   // this is done by rendering an invisible node which can be used to find its parents element

--- a/packages/visx-xychart/src/components/series/BarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/BarSeries.tsx
@@ -89,10 +89,9 @@ function BarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ext
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const handleMouseMove = useCallback(
     (params: HandlerParams | undefined) => {
-      const { event, svgPoint } = params || {};
-      if (event && svgPoint && width && height && showTooltip) {
+      const { svgPoint } = params || {};
+      if (svgPoint && width && height && showTooltip) {
         const datum = (horizontal ? findNearestDatumY : findNearestDatumX)({
-          event,
           point: svgPoint,
           key: dataKey,
           data,

--- a/packages/visx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/LineSeries.tsx
@@ -32,10 +32,9 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
 
   const handleMouseMove = useCallback(
     (params: HandlerParams | undefined) => {
-      const { event, svgPoint } = params || {};
-      if (event && svgPoint && width && height && showTooltip) {
+      const { svgPoint } = params || {};
+      if (svgPoint && width && height && showTooltip) {
         const datum = findNearestDatumXY({
-          event,
           point: svgPoint,
           key: dataKey,
           data,

--- a/packages/visx-xychart/src/types/event.ts
+++ b/packages/visx-xychart/src/types/event.ts
@@ -10,7 +10,6 @@ export type NearestDatumArgs<
   YScale extends AxisScale,
   Datum extends object
 > = {
-  event: React.MouseEvent | React.TouchEvent;
   point: { x: number; y: number } | null;
   xAccessor: (d: Datum) => ScaleInput<XScale>;
   yAccessor: (d: Datum) => ScaleInput<YScale>;

--- a/packages/visx-xychart/src/utils/findNearestDatumSingleDimension.ts
+++ b/packages/visx-xychart/src/utils/findNearestDatumSingleDimension.ts
@@ -38,7 +38,7 @@ export default function findNearestDatumSingleDimension<
         : nearestDatum0;
     nearestDatumIndex = nearestDatum === nearestDatum0 ? index - 1 : index;
   } else if ('step' in coercedScale && typeof coercedScale.step !== 'undefined') {
-    // Ordinal scales don't have an invert function but they do have discrete domains
+    // band scales don't have an invert function but they do have discrete domains
     // so we manually invert
     const domain = scale.domain();
     const range = scale.range().map(Number);

--- a/packages/visx-xychart/test/classes/DataRegistry.test.ts
+++ b/packages/visx-xychart/test/classes/DataRegistry.test.ts
@@ -1,4 +1,4 @@
-import DataRegistry from '../src/classes/DataRegistry';
+import DataRegistry from '../../src/classes/DataRegistry';
 
 const data = { key: 'visx', data: [], xAccessor: () => 'x', yAccessor: () => 'y' };
 

--- a/packages/visx-xychart/test/components/Axis.test.tsx
+++ b/packages/visx-xychart/test/components/Axis.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { shallow, mount } from 'enzyme';
 import VxAnimatedAxis from '@visx/react-spring/lib/axis/AnimatedAxis';
 import VxAxis from '@visx/axis/lib/axis/Axis';
-import BaseAxis from '../src/components/axis/BaseAxis';
-import { Axis, AnimatedAxis, DataContext, lightTheme } from '../src';
+import BaseAxis from '../../src/components/axis/BaseAxis';
+import { Axis, AnimatedAxis, DataContext, lightTheme } from '../../src';
 
 describe('<Axis />', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/components/BarSeries.test.tsx
+++ b/packages/visx-xychart/test/components/BarSeries.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { DataContext, BarSeries } from '../src';
-import getDataContext from './mocks/getDataContext';
+import { DataContext, BarSeries } from '../../src';
+import getDataContext from '../mocks/getDataContext';
 
 describe('<BarSeries />', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/components/Grid.test.tsx
+++ b/packages/visx-xychart/test/components/Grid.test.tsx
@@ -4,8 +4,8 @@ import VxAnimatedGridRows from '@visx/react-spring/lib/grid/AnimatedGridRows';
 import VxAnimatedGridColumns from '@visx/react-spring/lib/grid/AnimatedGridColumns';
 import VxGridRows from '@visx/grid/lib/grids/GridRows';
 import VxGridColumns from '@visx/grid/lib/grids/GridColumns';
-import { Grid, AnimatedGrid, DataContext } from '../src';
-import getDataContext from './mocks/getDataContext';
+import { Grid, AnimatedGrid, DataContext } from '../../src';
+import getDataContext from '../mocks/getDataContext';
 
 const mockContext = getDataContext();
 

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { LinePath } from '@visx/shape';
-import { DataContext, LineSeries } from '../src';
-import getDataContext from './mocks/getDataContext';
+import { DataContext, LineSeries } from '../../src';
+import getDataContext from '../mocks/getDataContext';
 
 describe('<LineSeries />', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/components/Tooltip.test.tsx
+++ b/packages/visx-xychart/test/components/Tooltip.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+import { mount } from 'enzyme';
+import { Tooltip as BaseTooltip } from '@visx/tooltip';
+import { Tooltip, TooltipContext, TooltipContextType } from '../../src';
+import { TooltipProps } from '../../src/components/Tooltip';
+
+describe('<Tooltip />', () => {
+  type SetupProps =
+    | {
+        props?: Partial<TooltipProps>;
+        context?: Partial<TooltipContextType>;
+      }
+    | undefined;
+  function setup({ props, context }: SetupProps = {}) {
+    const wrapper = mount(
+      <TooltipContext.Provider
+        value={{
+          tooltipOpen: false,
+          showTooltip: jest.fn(),
+          updateTooltip: jest.fn(),
+          hideTooltip: jest.fn(),
+          ...context,
+        }}
+      >
+        <Tooltip resizeObserverPolyfill={ResizeObserver} renderTooltip={() => null} {...props} />
+      </TooltipContext.Provider>,
+    );
+    return wrapper;
+  }
+  it('should be defined', () => {
+    expect(Tooltip).toBeDefined();
+  });
+
+  it('should not render a BaseTooltip when TooltipContext.tooltipOpen=false', () => {
+    const wrapper = setup();
+    expect(wrapper.find(BaseTooltip)).toHaveLength(0);
+  });
+
+  it('should not render a BaseTooltip when TooltipContext.tooltipOpen=true and renderTooltip returns false', () => {
+    const wrapper = setup({ context: { tooltipOpen: true } });
+    expect(wrapper.find(BaseTooltip)).toHaveLength(0);
+  });
+
+  it('should render a BaseTooltip when TooltipContext.tooltipOpen=true and renderTooltip returns non-null', () => {
+    const wrapper = setup({
+      props: { renderTooltip: () => <div /> },
+      context: { tooltipOpen: true },
+    });
+    expect(wrapper.find(BaseTooltip)).toHaveLength(1);
+  });
+
+  it('should not invoke props.renderTooltip when TooltipContext.tooltipOpen=false', () => {
+    const renderTooltip = jest.fn(() => <div />);
+    setup({
+      props: { renderTooltip },
+    });
+    expect(renderTooltip).toHaveBeenCalledTimes(0);
+  });
+
+  it('should invoke props.renderTooltip when TooltipContext.tooltipOpen=true', () => {
+    const renderTooltip = jest.fn(() => <div />);
+    setup({
+      props: { renderTooltip },
+      context: { tooltipOpen: true },
+    });
+    expect(renderTooltip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/visx-xychart/test/components/XYChart.test.tsx
+++ b/packages/visx-xychart/test/components/XYChart.test.tsx
@@ -1,7 +1,13 @@
 import React, { useContext } from 'react';
 import { mount, shallow } from 'enzyme';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
-import { XYChart, DataContext, DataProvider, EventEmitterProvider, TooltipProvider } from '../src';
+import {
+  XYChart,
+  DataContext,
+  DataProvider,
+  EventEmitterProvider,
+  TooltipProvider,
+} from '../../src';
 
 describe('<XYChart />', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/enhancers/withRegisteredData.test.tsx
+++ b/packages/visx-xychart/test/enhancers/withRegisteredData.test.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { mount } from 'enzyme';
-import withRegisteredData from '../src/enhancers/withRegisteredData';
-import getDataContext from './mocks/getDataContext';
-import { DataContext } from '../src';
+import withRegisteredData from '../../src/enhancers/withRegisteredData';
+import getDataContext from '../mocks/getDataContext';
+import { DataContext } from '../../src';
 
 const series = {
   key: 'visx',

--- a/packages/visx-xychart/test/hooks/useDataRegistry.test.tsx
+++ b/packages/visx-xychart/test/hooks/useDataRegistry.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import useDataRegistry from '../src/hooks/useDataRegistry';
+import useDataRegistry from '../../src/hooks/useDataRegistry';
 
 describe('useDataRegistry', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/hooks/useEventEmitter.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventEmitter.test.tsx
@@ -1,0 +1,51 @@
+import React, { useContext, useEffect, useLayoutEffect } from 'react';
+import { mount } from 'enzyme';
+import useEventEmitter from '../../src/hooks/useEventEmitter';
+import { EventEmitterContext, EventEmitterProvider } from '../../src';
+
+describe('useEventEmitter', () => {
+  it('should be defined', () => {
+    expect(useEventEmitter).toBeDefined();
+  });
+
+  it('should provide an emitter', () => {
+    expect.assertions(1);
+
+    const Component = () => {
+      const registry = useEventEmitter();
+      expect(registry).toEqual(expect.any(Function));
+      return null;
+    };
+
+    mount(
+      <EventEmitterProvider>
+        <Component />
+      </EventEmitterProvider>,
+    );
+  });
+
+  it('should register event listeners and emit events', () => {
+    expect.assertions(1);
+
+    const Component = () => {
+      const listener = jest.fn();
+      const emit = useEventEmitter('mousemove', listener);
+
+      useEffect(() => {
+        if (emit) {
+          // @ts-ignore not a React.MouseEvent
+          emit('mousemove', new MouseEvent('mousemove'));
+          expect(listener).toHaveBeenCalledTimes(1);
+        }
+      });
+
+      return null;
+    };
+
+    mount(
+      <EventEmitterProvider>
+        <Component />
+      </EventEmitterProvider>,
+    );
+  });
+});

--- a/packages/visx-xychart/test/hooks/useEventEmitter.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventEmitter.test.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect, useLayoutEffect } from 'react';
+import React, { useEffect } from 'react';
 import { mount } from 'enzyme';
 import useEventEmitter from '../../src/hooks/useEventEmitter';
-import { EventEmitterContext, EventEmitterProvider } from '../../src';
+import { EventEmitterProvider } from '../../src';
 
 describe('useEventEmitter', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/providers/DataProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/DataProvider.test.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { mount } from 'enzyme';
-import { DataProvider, DataContext } from '../src';
-import { DataProviderProps } from '../lib/providers/DataProvider';
+import { DataProvider, DataContext } from '../../src';
+import { DataProviderProps } from '../../lib/providers/DataProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getWrapper = (consumer: React.ReactNode, props?: DataProviderProps<any, any>) => {

--- a/packages/visx-xychart/test/providers/EventEmitterProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/EventEmitterProvider.test.tsx
@@ -1,0 +1,26 @@
+import React, { useContext } from 'react';
+import { mount } from 'enzyme';
+import { EventEmitterProvider, EventEmitterContext } from '../../src';
+
+describe('<EventEmitterProvider />', () => {
+  it('should be defined', () => {
+    expect(EventEmitterProvider).toBeDefined();
+  });
+
+  it('should provide an emitter for subscribing and emitting events', () => {
+    expect.assertions(1);
+
+    const EventEmitterConsumer = () => {
+      const emitter = useContext(EventEmitterContext);
+      expect(emitter).toMatchObject({ on: expect.any(Function), emit: expect.any(Function) });
+
+      return null;
+    };
+
+    mount(
+      <EventEmitterProvider>
+        <EventEmitterConsumer />
+      </EventEmitterProvider>,
+    );
+  });
+});

--- a/packages/visx-xychart/test/providers/ThemeProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/ThemeProvider.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { mount } from 'enzyme';
-import { ThemeProvider, ThemeContext } from '../src';
+import { ThemeProvider, ThemeContext } from '../../src';
 
 describe('<ThemeProvider />', () => {
   it('should be defined', () => {

--- a/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
@@ -1,0 +1,26 @@
+import React, { useContext } from 'react';
+import { mount } from 'enzyme';
+import { TooltipProvider, TooltipContext } from '../../src';
+
+describe('<TooltipProvider />', () => {
+  it('should be defined', () => {
+    expect(TooltipProvider).toBeDefined();
+  });
+
+  it('should provide an emitter for subscribing and emitting events', () => {
+    expect.assertions(1);
+
+    const TooltipConsumer = () => {
+      const tooltipContext = useContext(TooltipContext);
+      expect(tooltipContext).toBeDefined();
+
+      return null;
+    };
+
+    mount(
+      <TooltipProvider>
+        <TooltipConsumer />
+      </TooltipProvider>,
+    );
+  });
+});

--- a/packages/visx-xychart/test/utils/findNearestDatum.test.ts
+++ b/packages/visx-xychart/test/utils/findNearestDatum.test.ts
@@ -1,0 +1,112 @@
+import { AxisScale } from '@visx/axis';
+import { scaleBand, scaleLinear } from '@visx/scale';
+import findNearestDatumX from '../../src/utils/findNearestDatumX';
+import findNearestDatumY from '../../src/utils/findNearestDatumY';
+import findNearestDatumXY from '../../src/utils/findNearestDatumXY';
+import findNearestDatumSingleDimension from '../../src/utils/findNearestDatumSingleDimension';
+import { NearestDatumArgs } from '../../lib';
+
+type Datum = { xVal: number; yVal: string };
+
+const params: NearestDatumArgs<AxisScale, AxisScale, Datum> = {
+  key: 'visx',
+  width: 10,
+  height: 10,
+  point: { x: 3, y: 8 },
+  data: [
+    { xVal: 0, yVal: '0' },
+    { xVal: 8, yVal: '8' },
+  ],
+  xAccessor: d => d.xVal,
+  yAccessor: d => d.yVal,
+  xScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
+  yScale: scaleBand({ domain: ['0', '8'], range: [0, 10] }),
+};
+
+describe('findNearestDatumX', () => {
+  it('should be defined', () => {
+    expect(findNearestDatumX).toBeDefined();
+  });
+
+  it('should find the nearest datum', () => {
+    expect(
+      findNearestDatumX({
+        ...params,
+      })!.datum,
+    ).toEqual({ xVal: 0, yVal: '0' });
+  });
+});
+
+describe('findNearestDatumY', () => {
+  it('should be defined', () => {
+    expect(findNearestDatumY).toBeDefined();
+  });
+  it('should find the nearest datum', () => {
+    expect(
+      findNearestDatumY({
+        ...params,
+      })!.datum,
+    ).toEqual({ xVal: 8, yVal: '8' });
+  });
+});
+
+describe('findNearestDatumXY', () => {
+  it('should be defined', () => {
+    expect(findNearestDatumXY).toBeDefined();
+  });
+
+  it('should find the nearest datum', () => {
+    expect(
+      findNearestDatumXY({
+        ...params,
+        point: { x: 3, y: 3 },
+      })!.datum,
+    ).toEqual({ xVal: 0, yVal: '0' });
+  });
+});
+
+describe('findNearestDatumSingleDimension', () => {
+  it('should be defined', () => {
+    expect(findNearestDatumSingleDimension).toBeDefined();
+  });
+
+  it('should find the nearest datum for scaleLinear', () => {
+    expect(
+      findNearestDatumSingleDimension({
+        scale: params.xScale,
+        accessor: params.xAccessor,
+        data: params.data,
+        scaledValue: 3,
+      })!.datum,
+    ).toEqual({ xVal: 0, yVal: '0' });
+
+    expect(
+      findNearestDatumSingleDimension({
+        scale: params.xScale,
+        accessor: params.xAccessor,
+        data: params.data,
+        scaledValue: 7,
+      })!.datum,
+    ).toEqual({ xVal: 8, yVal: '8' });
+  });
+
+  it('should find the nearest datum for scaleBand', () => {
+    expect(
+      findNearestDatumSingleDimension({
+        scale: params.yScale,
+        accessor: params.yAccessor,
+        data: params.data,
+        scaledValue: 3,
+      })!.datum,
+    ).toEqual({ xVal: 0, yVal: '0' });
+
+    expect(
+      findNearestDatumSingleDimension({
+        scale: params.yScale,
+        accessor: params.yAccessor,
+        data: params.data,
+        scaledValue: 8,
+      })!.datum,
+    ).toEqual({ xVal: 8, yVal: '8' });
+  });
+});


### PR DESCRIPTION
#### :house: Internal

This PR builds on #825 and adds tests for all added components:

- `components/`
  - [x] `Tooltip`

- `hooks/`
  - [x] `useEventEmitter`

- `providers/`
  - [x] `EventEmitterProvider`
  - [x] `TooltipProvider`

- `utils/`
  - [x] `findNearestDatumXY`
  - [x] `findNearestDatumX`
  - [x] `findNearestDatumY`
  - [x] `findNearestDatumSingleDimension`

It also organizes the `test/` directory into subfolders to match `src/`

@kristw @hshoff 