### PR TITLE
Add `initialHeight` and `initialWidth` to `withParentSize`

### DIFF
--- a/packages/visx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSize.tsx
@@ -24,14 +24,14 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
   return class WrappedComponent extends React.Component<
     BaseComponentProps & WithParentSizeProvidedProps,
     WithParentSizeState
-  > {
+    > {
     static defaultProps = {
       debounceTime: 300,
       enableDebounceLeadingCall: true,
     };
     state = {
-      parentWidth: this.props.initialWidth,
-      parentHeight: this.props.initialHeight,
+      parentWidth: undefined,
+      parentHeight: undefined,
     };
     animationFrameID: number = 0;
     resizeObserver: ResizeObserver | undefined;
@@ -74,7 +74,8 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
     );
 
     render() {
-      const { parentWidth, parentHeight } = this.state;
+      const { initialWidth, initialHeight } = this.props;
+      const { parentWidth = initialWidth, parentHeight = initialHeight } = this.state;
       return (
         <div style={CONTAINER_STYLES} ref={this.setRef}>
           {parentWidth != null && parentHeight != null && (

--- a/packages/visx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSize.tsx
@@ -24,7 +24,7 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
   return class WrappedComponent extends React.Component<
     BaseComponentProps & WithParentSizeProvidedProps,
     WithParentSizeState
-    > {
+  > {
     static defaultProps = {
       debounceTime: 300,
       enableDebounceLeadingCall: true,

--- a/packages/visx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSize.tsx
@@ -12,6 +12,8 @@ export type WithParentSizeProps = {
 type WithParentSizeState = {
   parentWidth?: number;
   parentHeight?: number;
+  initialWidth?: number;
+  initialHeight?: number;
 };
 
 export type WithParentSizeProvidedProps = WithParentSizeState;
@@ -28,8 +30,8 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
       enableDebounceLeadingCall: true,
     };
     state = {
-      parentWidth: undefined,
-      parentHeight: undefined,
+      parentWidth: this.props.initialWidth,
+      parentHeight: this.props.initialHeight,
     };
     animationFrameID: number = 0;
     resizeObserver: ResizeObserver | undefined;


### PR DESCRIPTION
#### :rocket: Enhancements

Adds the ability to set `initialWidth/initialHeight` to `@visx/responsive`s `withParentSize`. Closes #554.
