### PR TITLE
[TooltipWithBounds] fix : overflowing its parent on small screens

### DIFF
--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -4,58 +4,68 @@ import { withBoundingRects, WithBoundingRectsProps } from '@visx/bounds';
 import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
 
 export type TooltipWithBoundsProps = {
-  offsetLeft?: number;
-  offsetTop?: number;
+	offsetLeft?: number;
+	offsetTop?: number;
 } & TooltipProps &
-  React.HTMLProps<HTMLDivElement> &
-  WithBoundingRectsProps;
+	React.HTMLProps<HTMLDivElement> &
+	WithBoundingRectsProps;
 
 function TooltipWithBounds({
-  left: initialLeft = 0,
-  top: initialTop = 0,
-  offsetLeft = 10,
-  offsetTop = 10,
-  children,
-  rect: ownBounds,
-  parentRect: parentBounds,
-  getRects,
-  style = defaultStyles,
-  unstyled = false,
-  ...otherProps
+	left: initialLeft = 0,
+	top: initialTop = 0,
+	offsetLeft = 10,
+	offsetTop = 10,
+	children,
+	rect: ownBounds,
+	parentRect: parentBounds,
+	getRects,
+	style = defaultStyles,
+	unstyled = false,
+	...otherProps
 }: TooltipWithBoundsProps) {
-  let left = initialLeft;
-  let top = initialTop;
+	let left = initialLeft;
+	let top = initialTop;
 
-  if (ownBounds && parentBounds) {
-    const placeTooltipLeft =
-      offsetLeft + ownBounds.right > parentBounds.right ||
-      offsetLeft + ownBounds.right > window.innerWidth;
+	if (ownBounds && parentBounds) {
+		if (left > parentBounds.width / 2) {
+			left = left - offsetLeft - ownBounds.width;
 
-    const placeTooltipUp =
-      offsetTop + ownBounds.bottom > parentBounds.bottom ||
-      offsetTop + ownBounds.bottom > window.innerHeight;
+			if (left < 0) {
+				left = 0;
+			}
+		} else {
+			if (left + offsetLeft + ownBounds.width > parentBounds.width) {
+				left = parentBounds.width - ownBounds.width;
+			}
+		}
+		if (top > parentBounds.height / 2) {
+			top = top - offsetTop - ownBounds.height;
+			if (top < 0) {
+				top = 0;
+			}
+		} else {
+			if (top + offsetTop + ownBounds.height > parentBounds.height) {
+				top = parentBounds.height - ownBounds.height;
+			}
+		}
+	}
 
-    left = placeTooltipLeft ? left - ownBounds.width - offsetLeft : left + offsetLeft;
-    top = placeTooltipUp ? top - ownBounds.height - offsetTop : top + offsetTop;
-  }
+	left = Math.round(left);
+	top = Math.round(top);
 
-  left = Math.round(left);
-  top = Math.round(top);
-
-  return (
-    <Tooltip
-      style={{
-        top: 0,
-        left: 0,
-        transform: `translate(${left}px, ${top}px)`,
-        ...(!unstyled && style),
-      }}
-      unstyled={unstyled}
-      {...otherProps}
-    >
-      {children}
-    </Tooltip>
-  );
+	return (
+		<Tooltip
+			style={{
+				top: 0,
+				left: 0,
+				transform: `translate(${left}px, ${top}px)`,
+				...(!unstyled && style),
+			}}
+			unstyled={unstyled}
+			{...otherProps}>
+			{children}
+		</Tooltip>
+	);
 }
 
 export default withBoundingRects(TooltipWithBounds);

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -27,23 +27,12 @@ function TooltipWithBounds({
   let top = initialTop;
 
   if (ownBounds && parentBounds) {
-    if (left > parentBounds.width / 2) {
-      left = left - offsetLeft - ownBounds.width;
+    const placeTooltipLeft = parentBounds.right - ownBounds.right < parentBounds.width * 0.01;
 
-      if (left < 0) {
-        left = 0;
-      }
-    } else if (left + offsetLeft + ownBounds.width > parentBounds.width) {
-      left = parentBounds.width - ownBounds.width;
-    }
-    if (top > parentBounds.height / 2) {
-      top = top - offsetTop - ownBounds.height;
-      if (top < 0) {
-        top = 0;
-      }
-    } else if (top + offsetTop + ownBounds.height > parentBounds.height) {
-      top = parentBounds.height - ownBounds.height;
-    }
+    const placeTooltipUp = parentBounds.bottom - ownBounds.bottom < parentBounds.height * 0.01;
+
+    left = placeTooltipLeft ? left - ownBounds.width - offsetLeft : left + offsetLeft;
+    top = placeTooltipUp ? top - ownBounds.height - offsetTop : top + offsetTop;
   }
 
   left = Math.round(left);

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -27,9 +27,29 @@ function TooltipWithBounds({
   let top = initialTop;
 
   if (ownBounds && parentBounds) {
-    const placeTooltipLeft = parentBounds.right - ownBounds.right < parentBounds.width * 0.01;
+    let placeTooltipLeft = false;
+    let placeTooltipUp = false;
 
-    const placeTooltipUp = parentBounds.bottom - ownBounds.bottom < parentBounds.height * 0.01;
+    if (parentBounds.width) {
+      const rightPlacementClippedPx = left + offsetLeft + ownBounds.width - parentBounds.width;
+      const leftPlacementClippedPx = ownBounds.width - left - offsetLeft;
+      placeTooltipLeft =
+        rightPlacementClippedPx > 0 && rightPlacementClippedPx > leftPlacementClippedPx;
+    } else {
+      const rightPlacementClippedPx = left + offsetLeft + ownBounds.width - window.innerWidth;
+      const leftPlacementClippedPx = ownBounds.width - left - offsetLeft;
+      placeTooltipLeft =
+        rightPlacementClippedPx > 0 && rightPlacementClippedPx > leftPlacementClippedPx;
+    }
+
+    if (parentBounds.height) {
+      const bottomPlacementClippedPx = top + offsetTop + ownBounds.height - parentBounds.height;
+      const topPlacementClippedPx = ownBounds.height - top - offsetTop;
+      placeTooltipUp =
+        bottomPlacementClippedPx > 0 && bottomPlacementClippedPx > topPlacementClippedPx;
+    } else {
+      placeTooltipUp = top + offsetTop + ownBounds.height > window.innerHeight;
+    }
 
     left = placeTooltipLeft ? left - ownBounds.width - offsetLeft : left + offsetLeft;
     top = placeTooltipUp ? top - ownBounds.height - offsetTop : top + offsetTop;

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -4,68 +4,65 @@ import { withBoundingRects, WithBoundingRectsProps } from '@visx/bounds';
 import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
 
 export type TooltipWithBoundsProps = {
-	offsetLeft?: number;
-	offsetTop?: number;
+  offsetLeft?: number;
+  offsetTop?: number;
 } & TooltipProps &
-	React.HTMLProps<HTMLDivElement> &
-	WithBoundingRectsProps;
+  React.HTMLProps<HTMLDivElement> &
+  WithBoundingRectsProps;
 
 function TooltipWithBounds({
-	left: initialLeft = 0,
-	top: initialTop = 0,
-	offsetLeft = 10,
-	offsetTop = 10,
-	children,
-	rect: ownBounds,
-	parentRect: parentBounds,
-	getRects,
-	style = defaultStyles,
-	unstyled = false,
-	...otherProps
+  left: initialLeft = 0,
+  top: initialTop = 0,
+  offsetLeft = 10,
+  offsetTop = 10,
+  children,
+  rect: ownBounds,
+  parentRect: parentBounds,
+  getRects,
+  style = defaultStyles,
+  unstyled = false,
+  ...otherProps
 }: TooltipWithBoundsProps) {
-	let left = initialLeft;
-	let top = initialTop;
+  let left = initialLeft;
+  let top = initialTop;
 
-	if (ownBounds && parentBounds) {
-		if (left > parentBounds.width / 2) {
-			left = left - offsetLeft - ownBounds.width;
+  if (ownBounds && parentBounds) {
+    if (left > parentBounds.width / 2) {
+      left = left - offsetLeft - ownBounds.width;
 
-			if (left < 0) {
-				left = 0;
-			}
-		} else {
-			if (left + offsetLeft + ownBounds.width > parentBounds.width) {
-				left = parentBounds.width - ownBounds.width;
-			}
-		}
-		if (top > parentBounds.height / 2) {
-			top = top - offsetTop - ownBounds.height;
-			if (top < 0) {
-				top = 0;
-			}
-		} else {
-			if (top + offsetTop + ownBounds.height > parentBounds.height) {
-				top = parentBounds.height - ownBounds.height;
-			}
-		}
-	}
+      if (left < 0) {
+        left = 0;
+      }
+    } else if (left + offsetLeft + ownBounds.width > parentBounds.width) {
+      left = parentBounds.width - ownBounds.width;
+    }
+    if (top > parentBounds.height / 2) {
+      top = top - offsetTop - ownBounds.height;
+      if (top < 0) {
+        top = 0;
+      }
+    } else if (top + offsetTop + ownBounds.height > parentBounds.height) {
+      top = parentBounds.height - ownBounds.height;
+    }
+  }
 
-	left = Math.round(left);
-	top = Math.round(top);
+  left = Math.round(left);
+  top = Math.round(top);
 
-	return (
-		<Tooltip
-			style={{
-				top: 0,
-				left: 0,
-				transform: `translate(${left}px, ${top}px)`,
-				...(!unstyled && style),
-			}}
-			unstyled={unstyled}
-			{...otherProps}>
-			{children}
-		</Tooltip>
-	);
+  return (
+    <Tooltip
+      style={{
+        top: 0,
+        left: 0,
+        transform: `translate(${left}px, ${top}px)`,
+        ...(!unstyled && style),
+      }}
+      unstyled={unstyled}
+      {...otherProps}
+    >
+      {children}
+    </Tooltip>
+  );
 }
 
 export default withBoundingRects(TooltipWithBounds);


### PR DESCRIPTION
#### :bug: Bug Fix

-  #466 : change logic to calculate position

![image](https://user-images.githubusercontent.com/48921721/94897223-daa8cb00-0497-11eb-980a-6ad09a9211cb.png)


![image](https://user-images.githubusercontent.com/48921721/94897144-b77e1b80-0497-11eb-8946-a5b126e474a4.png)



