### PR TITLE
Remove code duplication

### DIFF
--- a/packages/visx-pattern/src/patterns/Lines.tsx
+++ b/packages/visx-pattern/src/patterns/Lines.tsx
@@ -11,8 +11,6 @@ export function pathForOrientation({
   orientation: PatternOrientationType;
 }) {
   switch (orientation) {
-    case PatternOrientation.vertical:
-      return `M ${height / 2}, 0 l 0, ${height}`;
     case PatternOrientation.horizontal:
       return `M 0,${height / 2} l ${height},0`;
     case PatternOrientation.diagonal:

--- a/packages/visx-pattern/src/patterns/Lines.tsx
+++ b/packages/visx-pattern/src/patterns/Lines.tsx
@@ -21,6 +21,7 @@ export function pathForOrientation({
       return `M 0,0 l ${height},${height}
         M ${-height / 4},${(3 / 4) * height} l ${height / 2},${height / 2}
         M ${(3 / 4) * height},${-height / 4} l ${height / 2},${height / 2}`;
+    case PatternOrientation.vertical:
     default:
       return `M ${height / 2}, 0 l 0, ${height}`;
   }


### PR DESCRIPTION
#### 🏠 Internal

The body of this case clause on a line 26 duplicates the body of this case clause on a line 14. This may be caused by a copy-paste error. If this usage is intentional, consider using fall-through to remove code duplication.
