### PR TITLE
Set Line shapeRendering to crispEdges if rectilinear

### DIFF
--- a/packages/visx-shape/src/shapes/Line.tsx
+++ b/packages/visx-shape/src/shapes/Line.tsx
@@ -28,6 +28,7 @@ export default function Line({
   innerRef,
   ...restProps
 }: AddSVGProps<LineProps, SVGLineElement>) {
+  const isRectilinear = from.x === to.x || from.y === to.y;
   return (
     <line
       ref={innerRef}
@@ -37,6 +38,7 @@ export default function Line({
       x2={to.x}
       y2={to.y}
       fill={fill}
+      shapeRendering={isRectilinear ? 'crispEdges' : 'auto'}
       {...restProps}
     />
   );

--- a/packages/visx-shape/test/Line.test.tsx
+++ b/packages/visx-shape/test/Line.test.tsx
@@ -32,4 +32,35 @@ describe('<Line />', () => {
       );
     });
   });
+
+  test('it should set shapeRendering to auto if not rectilinear', () => {
+    expect(
+      LineWrapper({
+        to: {
+          x: 50,
+          y: 100,
+        },
+      }).prop('shapeRendering'),
+    ).toBe('auto');
+  });
+
+  test('it should set shapeRendering to crispEdges if rectilinear', () => {
+    expect(
+      LineWrapper({
+        to: {
+          x: 0,
+          y: 100,
+        },
+      }).prop('shapeRendering'),
+    ).toBe('crispEdges');
+
+    expect(
+      LineWrapper({
+        to: {
+          x: 100,
+          y: 0,
+        },
+      }).prop('shapeRendering'),
+    ).toBe('crispEdges');
+  });
 });


### PR DESCRIPTION
Resolves cases where rectilinear lines on non-high DPI screens have an extra semi-opaque pixel added to the width because the line is set between pixels: https://github.com/airbnb/visx/issues/656

#### :rocket: Enhancements

- Automatically set `shapeRendering` to `crispEdges` if rectilinear (completely horizontal or vertical).

I think this is the safest setting because using `crispEdges` on non-rectilinear lines may disable anti-aliasing, depending on the user agent.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering

> **crispEdges**
> This value indicates that the user agent shall attempt to emphasize the contrast between clean edges of artwork over rendering speed and geometric precision. To achieve crisp edges, **the user agent might turn off anti-aliasing** for all lines and curves or possibly just for straight lines which are close to vertical or horizontal. Also, **the user agent might adjust line positions and line widths to align edges with device pixels**.
