### PR TITLE
fix(computeStats) #427 Exception thrown when firstQuartile and thirdQuartile are equal

### DIFF
--- a/packages/visx-stats/src/util/computeStats.ts
+++ b/packages/visx-stats/src/util/computeStats.ts
@@ -3,8 +3,23 @@ import { BoxPlot, BinDatum } from '../types';
 export default function computeStats(numericalArray: number[]) {
   const points = [...numericalArray].sort((a, b) => a - b);
   const sampleSize = points.length;
-  const firstQuartile = points[Math.round(sampleSize / 4)];
-  const thirdQuartile = points[Math.round((3 * sampleSize) / 4)];
+
+  function calcMedian(dataSet: number[]) {
+    const half = Math.floor(dataSet.length / 2);
+    if (dataSet.length % 2) return dataSet[half];
+    return (dataSet[half - 1] + dataSet[half]) / 2;
+  }
+  const median = calcMedian(points);
+
+  // calculate median of first half i.e. firstQuartile
+  const lowerHalfLength = Math.floor(sampleSize / 2);
+  const lowerHalf = points.slice(0, lowerHalfLength);
+  const firstQuartile = calcMedian(lowerHalf);
+
+  // calculate median of first half i.e. secondQuartile
+  const upperHalfLength = Math.ceil(sampleSize / 2);
+  const upperHalf = points.slice(upperHalfLength);
+  const thirdQuartile = calcMedian(upperHalf);
   const IQR = thirdQuartile - firstQuartile;
 
   const min = firstQuartile - 1.5 * IQR;
@@ -38,7 +53,7 @@ export default function computeStats(numericalArray: number[]) {
   const boxPlot: BoxPlot = {
     min,
     firstQuartile,
-    median: points[Math.round(sampleSize / 2)],
+    median,
     thirdQuartile,
     max,
     outliers,

--- a/packages/visx-stats/src/util/computeStats.ts
+++ b/packages/visx-stats/src/util/computeStats.ts
@@ -1,14 +1,15 @@
 import { BoxPlot, BinDatum } from '../types';
 
+function calcMedian(dataSet: number[]) {
+  const half = Math.floor(dataSet.length / 2);
+  if (dataSet.length % 2) return dataSet[half];
+  return (dataSet[half - 1] + dataSet[half]) / 2;
+}
+
 export default function computeStats(numericalArray: number[]) {
   const points = [...numericalArray].sort((a, b) => a - b);
   const sampleSize = points.length;
 
-  function calcMedian(dataSet: number[]) {
-    const half = Math.floor(dataSet.length / 2);
-    if (dataSet.length % 2) return dataSet[half];
-    return (dataSet[half - 1] + dataSet[half]) / 2;
-  }
   const median = calcMedian(points);
 
   // calculate median of first half i.e. firstQuartile

--- a/packages/visx-stats/test/computeStats.test.ts
+++ b/packages/visx-stats/test/computeStats.test.ts
@@ -1,6 +1,7 @@
 import { computeStats } from '../src';
 
 const data = [1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 1];
+const edgeCaseData = [10000, 2400, 10000, 10000];
 
 describe('computeStats', () => {
   test('it should be defined', () => {
@@ -9,6 +10,12 @@ describe('computeStats', () => {
 
   test('it should have boxPlot and binData', () => {
     const stats = computeStats(data);
+    expect(stats.boxPlot).toBeDefined();
+    expect(stats.binData).toBeDefined();
+  });
+
+  test('it should have boxPlot and binData when first and third quartile are equal', () => {
+    const stats = computeStats(edgeCaseData);
     expect(stats.boxPlot).toBeDefined();
     expect(stats.binData).toBeDefined();
   });


### PR DESCRIPTION
#### :bug: Bug Fix

- Fixes #427 by changing method to calculate `firstQuartile` and `thirdQuartile`

![test-result](https://user-images.githubusercontent.com/48921721/95064697-c8819380-0708-11eb-9a33-1fcd35a3cb54.png)
*Test result*