### PR TITLE
simplify code contributions and reviews by fully automating the dev setup with Gitpod.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: yarn install 
+    command: yarn run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,17 @@ yarn
 yarn build
 ```
 
+## Online one-click setup
+
+You can playaround with the code, work on issues and make PRs online using Gitpod
+[Gitpod](https://www.gitpod.io/) (an Online Open Source VS Code-like IDE which is free for Open Source). With a single it will launch a workspace and automatically: 
+
+- clone the `visx` repo.
+- install the dependencies.
+- run `yarn build`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 #### Rebuild one package
 
 Upon modification of a single `package` you can run

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
   <a href="https://lernajs.io/" alt="lerna">
      <img src="https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg"/>
   </a>
+    <a href="https://gitpod.io/from-referrer/">
+    <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"/>
+  </a>
 </p>
 
 ### visx


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `visx` repo.
- install the dependencies.
- run `yarn build`.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://github.com/nisarhassan12/visx

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95143026-7f742280-078e-11eb-92b8-5a945e74186b.png)

 