### PR TITLE
new(xychart): refine TooltipContext + Tooltip functionality

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/CustomChartBackground.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/CustomChartBackground.tsx
@@ -5,7 +5,7 @@ import { DataContext } from '@visx/xychart';
 const patternId = 'xy-chart-pattern';
 
 export default function CustomChartBackground() {
-  const { theme, margin, width, height } = useContext(DataContext);
+  const { theme, margin, width, height, innerWidth, innerHeight } = useContext(DataContext);
 
   // early return values not available in context
   if (width == null || height == null || margin == null || theme == null) return null;
@@ -24,8 +24,8 @@ export default function CustomChartBackground() {
       <rect
         x={margin.left}
         y={margin.top}
-        width={width - margin.left - margin.right}
-        height={height - margin.top - margin.bottom}
+        width={innerWidth}
+        height={innerHeight}
         fill={`url(#${patternId})`}
         fillOpacity={0.3}
       />

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -96,8 +96,8 @@ export default function Example({ height }: Props) {
                 showVerticalCrosshair={showVerticalCrosshair}
                 snapTooltipToDatumX={snapTooltipToDatumX}
                 snapTooltipToDatumY={snapTooltipToDatumY}
-                showCircle={snapTooltipToDatumX || snapTooltipToDatumY}
-                showMultipleCircles={sharedTooltip}
+                showDatumCircle={snapTooltipToDatumX || snapTooltipToDatumY}
+                showSeriesCircles={sharedTooltip}
                 renderTooltip={({ tooltipData, colorScale }) => (
                   <>
                     {/** date */}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -21,7 +21,7 @@ const xScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const yScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
 const data = cityTemperature.slice(150, 225);
-const getDate = (d: CityTemperature) => d.date; // new Date(d.date);
+const getDate = (d: CityTemperature) => d.date;
 const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNyTemperature = (d: CityTemperature) => Number(d['New York']);
 
@@ -33,8 +33,14 @@ export default function Example({ height }: Props) {
         renderBarSeries,
         renderHorizontally,
         renderLineSeries,
+        sharedTooltip,
         showGridColumns,
         showGridRows,
+        showHorizontalCrosshair,
+        showTooltip,
+        showVerticalCrosshair,
+        snapTooltipToDatumX,
+        snapTooltipToDatumY,
         theme,
         xAxisOrientation,
         yAxisOrientation,
@@ -68,6 +74,7 @@ export default function Example({ height }: Props) {
                 data={data}
                 xAccessor={renderHorizontally ? getSfTemperature : getDate}
                 yAccessor={renderHorizontally ? getDate : getSfTemperature}
+                horizontal={!renderHorizontally}
               />
             )}
             <AnimatedAxis
@@ -83,30 +90,44 @@ export default function Example({ height }: Props) {
               numTicks={numTicks}
               animationTrajectory={animationTrajectory}
             />
-            <Tooltip<CityTemperature>
-              renderTooltip={({ tooltipData, colorScale }) => (
-                <>
-                  {tooltipData?.nearestDatum?.datum
-                    ? getDate(tooltipData?.nearestDatum?.datum)
-                    : 'No date'}
-                  <br />
-                  {Object.keys(tooltipData?.datumByKey ?? {}).map(key => (
-                    <div key={key}>
-                      <em
-                        style={{
-                          color: colorScale?.(key),
-                          textDecoration:
-                            tooltipData?.nearestDatum?.key === key ? 'underline' : undefined,
-                        }}
-                      >
-                        {key}
-                      </em>{' '}
-                      {tooltipData?.datumByKey[key].datum[key as keyof CityTemperature]}° F
-                    </div>
-                  ))}
-                </>
-              )}
-            />
+            {showTooltip && (
+              <Tooltip<CityTemperature>
+                showHorizontalCrosshair={showHorizontalCrosshair}
+                showVerticalCrosshair={showVerticalCrosshair}
+                snapTooltipToDatumX={snapTooltipToDatumX}
+                snapTooltipToDatumY={snapTooltipToDatumY}
+                showCircle={snapTooltipToDatumX || snapTooltipToDatumY}
+                showMultipleCircles={sharedTooltip}
+                renderTooltip={({ tooltipData, colorScale }) => (
+                  <>
+                    {/** date */}
+                    {tooltipData?.nearestDatum?.datum
+                      ? getDate(tooltipData?.nearestDatum?.datum)
+                      : 'No date'}
+                    <br />
+                    <br />
+                    {/** temperatures */}
+                    {((sharedTooltip
+                      ? Object.keys(tooltipData?.datumByKey ?? {})
+                      : [tooltipData?.nearestDatum?.key]
+                    ).filter(key => key) as string[]).map(key => (
+                      <div key={key}>
+                        <em
+                          style={{
+                            color: colorScale?.(key),
+                            textDecoration:
+                              tooltipData?.nearestDatum?.key === key ? 'underline' : undefined,
+                          }}
+                        >
+                          {key}
+                        </em>{' '}
+                        {tooltipData?.datumByKey[key].datum[key as keyof CityTemperature]}° F
+                      </div>
+                    ))}
+                  </>
+                )}
+              />
+            )}
           </XYChart>
         </DataProvider>
       )}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -96,8 +96,8 @@ export default function Example({ height }: Props) {
                 showVerticalCrosshair={showVerticalCrosshair}
                 snapTooltipToDatumX={snapTooltipToDatumX}
                 snapTooltipToDatumY={snapTooltipToDatumY}
-                showDatumCircle={snapTooltipToDatumX || snapTooltipToDatumY}
-                showSeriesCircles={sharedTooltip}
+                showDatumGlyph={snapTooltipToDatumX || snapTooltipToDatumY}
+                showSeriesGlyphs={sharedTooltip}
                 renderTooltip={({ tooltipData, colorScale }) => (
                   <>
                     {/** date */}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -55,7 +55,7 @@ export default function Example({ height }: Props) {
             />
             {renderBarSeries && (
               <BarSeries
-                dataKey="ny"
+                dataKey="New York"
                 data={data}
                 xAccessor={renderHorizontally ? getNyTemperature : getDate}
                 yAccessor={renderHorizontally ? getDate : getNyTemperature}
@@ -64,7 +64,7 @@ export default function Example({ height }: Props) {
             )}
             {renderLineSeries && (
               <LineSeries
-                dataKey="sf"
+                dataKey="San Francisco"
                 data={data}
                 xAccessor={renderHorizontally ? getSfTemperature : getDate}
                 yAccessor={renderHorizontally ? getDate : getSfTemperature}
@@ -83,8 +83,29 @@ export default function Example({ height }: Props) {
               numTicks={numTicks}
               animationTrajectory={animationTrajectory}
             />
-            <Tooltip
-              renderTooltip={({ tooltipData }) => <pre>{JSON.stringify(tooltipData, null, 2)}</pre>}
+            <Tooltip<CityTemperature>
+              renderTooltip={({ tooltipData, colorScale }) => (
+                <>
+                  {tooltipData?.nearestDatum?.datum
+                    ? getDate(tooltipData?.nearestDatum?.datum)
+                    : 'No date'}
+                  <br />
+                  {Object.keys(tooltipData?.datumByKey ?? {}).map(key => (
+                    <div key={key}>
+                      <em
+                        style={{
+                          color: colorScale?.(key),
+                          textDecoration:
+                            tooltipData?.nearestDatum?.key === key ? 'underline' : undefined,
+                        }}
+                      >
+                        {key}
+                      </em>{' '}
+                      {tooltipData?.datumByKey[key].datum[key as keyof CityTemperature]}° F
+                    </div>
+                  ))}
+                </>
+              )}
             />
           </XYChart>
         </DataProvider>

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -9,8 +9,14 @@ type ProvidedProps = {
   renderHorizontally: boolean;
   renderBarSeries: boolean;
   renderLineSeries: boolean;
+  sharedTooltip: boolean;
   showGridColumns: boolean;
   showGridRows: boolean;
+  showHorizontalCrosshair: boolean;
+  showTooltip: boolean;
+  showVerticalCrosshair: boolean;
+  snapTooltipToDatumX: boolean;
+  snapTooltipToDatumY: boolean;
   theme: XYChartTheme;
   xAxisOrientation: 'top' | 'bottom';
   yAxisOrientation: 'left' | 'right';
@@ -28,6 +34,12 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [xAxisOrientation, setXAxisOrientation] = useState<'top' | 'bottom'>('bottom');
   const [yAxisOrientation, setYAxisOrientation] = useState<'left' | 'right'>('right');
   const [renderHorizontally, setRenderHorizontally] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(true);
+  const [showVerticalCrosshair, setShowVerticalCrosshair] = useState(true);
+  const [showHorizontalCrosshair, setShowHorizontalCrosshair] = useState(false);
+  const [snapTooltipToDatumX, setSnapTooltipToDatumX] = useState(true);
+  const [snapTooltipToDatumY, setSnapTooltipToDatumY] = useState(true);
+  const [sharedTooltip, setSharedTooltip] = useState(true);
   const [renderBarSeries, setRenderBarSeries] = useState(true);
   const [renderLineSeries, setRenderLineSeries] = useState(true);
 
@@ -38,8 +50,14 @@ export default function ExampleControls({ children }: ControlsProps) {
         renderBarSeries,
         renderHorizontally,
         renderLineSeries,
+        sharedTooltip,
         showGridColumns,
         showGridRows,
+        showHorizontalCrosshair,
+        showTooltip,
+        showVerticalCrosshair,
+        snapTooltipToDatumX,
+        snapTooltipToDatumY,
         theme,
         xAxisOrientation,
         yAxisOrientation,
@@ -203,6 +221,63 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={animationTrajectory === 'max'}
             />{' '}
             from max
+          </label>
+        </div>
+        {/** tooltip */}
+        <div>
+          <strong>tooltip</strong>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setShowTooltip(!showTooltip)}
+              checked={showTooltip}
+            />{' '}
+            show tooltip
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setSnapTooltipToDatumX(!snapTooltipToDatumX)}
+              checked={showTooltip && snapTooltipToDatumX}
+            />{' '}
+            snap tooltip to datum x
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setSnapTooltipToDatumY(!snapTooltipToDatumY)}
+              checked={showTooltip && snapTooltipToDatumY}
+            />{' '}
+            snap tooltip to datum y
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setShowVerticalCrosshair(!showVerticalCrosshair)}
+              checked={showTooltip && showVerticalCrosshair}
+            />{' '}
+            vertical crosshair
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setShowHorizontalCrosshair(!showHorizontalCrosshair)}
+              checked={showTooltip && showHorizontalCrosshair}
+            />{' '}
+            horizontal crosshair
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setSharedTooltip(!sharedTooltip)}
+              checked={showTooltip && sharedTooltip}
+            />{' '}
+            shared tooltip
           </label>
         </div>
         {/** series */}

--- a/packages/visx-tooltip/src/hooks/useTooltipInPortal.tsx
+++ b/packages/visx-tooltip/src/hooks/useTooltipInPortal.tsx
@@ -5,7 +5,7 @@ import Portal from '../Portal';
 import Tooltip, { TooltipProps } from '../tooltips/Tooltip';
 import TooltipWithBounds from '../tooltips/TooltipWithBounds';
 
-export type TooltipInPortalProps = TooltipProps & { detectBounds?: boolean };
+export type TooltipInPortalProps = TooltipProps & Pick<UseTooltipPortalOptions, 'detectBounds'>;
 
 export type UseTooltipInPortal = {
   containerRef: (element: HTMLElement | SVGElement | null) => void;
@@ -38,7 +38,7 @@ export default function useTooltipInPortal({
     () => ({
       left: containerLeft = 0,
       top: containerTop = 0,
-      detectBounds: detectBoundsProp, // allow overrid at component level
+      detectBounds: detectBoundsProp, // allow override at component-level
       ...tooltipProps
     }: TooltipInPortalProps) => {
       const detectBounds = detectBoundsProp == null ? detectBoundsOption : detectBoundsProp;

--- a/packages/visx-tooltip/src/hooks/useTooltipInPortal.tsx
+++ b/packages/visx-tooltip/src/hooks/useTooltipInPortal.tsx
@@ -5,10 +5,12 @@ import Portal from '../Portal';
 import Tooltip, { TooltipProps } from '../tooltips/Tooltip';
 import TooltipWithBounds from '../tooltips/TooltipWithBounds';
 
+export type TooltipInPortalProps = TooltipProps & { detectBounds?: boolean };
+
 export type UseTooltipInPortal = {
   containerRef: (element: HTMLElement | SVGElement | null) => void;
   containerBounds: RectReadOnly;
-  TooltipInPortal: React.FC<TooltipProps>;
+  TooltipInPortal: React.FC<TooltipInPortalProps>;
 };
 
 export type UseTooltipPortalOptions = {
@@ -27,13 +29,19 @@ export type UseTooltipPortalOptions = {
  * Handles conversion of container coordinates to page coordinates using the container bounds.
  */
 export default function useTooltipInPortal({
-  detectBounds = true,
+  detectBounds: detectBoundsOption = true,
   ...useMeasureOptions
 }: UseTooltipPortalOptions | undefined = {}): UseTooltipInPortal {
   const [containerRef, containerBounds] = useMeasure(useMeasureOptions);
 
   const TooltipInPortal = useMemo(
-    () => ({ left: containerLeft = 0, top: containerTop = 0, ...tooltipProps }: TooltipProps) => {
+    () => ({
+      left: containerLeft = 0,
+      top: containerTop = 0,
+      detectBounds: detectBoundsProp, // allow overrid at component level
+      ...tooltipProps
+    }: TooltipInPortalProps) => {
+      const detectBounds = detectBoundsProp == null ? detectBoundsOption : detectBoundsProp;
       const TooltipComponent = detectBounds ? TooltipWithBounds : Tooltip;
       // convert container coordinates to page coordinates
       const portalLeft = containerLeft + (containerBounds.left || 0) + window.scrollX;
@@ -45,7 +53,7 @@ export default function useTooltipInPortal({
         </Portal>
       );
     },
-    [detectBounds, containerBounds.left, containerBounds.top],
+    [detectBoundsOption, containerBounds.left, containerBounds.top],
   );
 
   return {

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -41,7 +41,9 @@
   },
   "dependencies": {
     "@types/classnames": "^2.2.9",
+    "@types/lodash": "^4.14.146",
     "@types/react": "*",
+    "lodash": "^4.17.10",
     "@visx/axis": "1.0.0",
     "@visx/event": "1.0.0",
     "@visx/grid": "1.0.0",

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -8,6 +8,13 @@ import TooltipContext from '../context/TooltipContext';
 import DataContext from '../context/DataContext';
 import { TooltipContextType } from '../types';
 
+const CROSSHAIR_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  pointerEvents: 'none',
+  fontSize: 0,
+  lineHeight: 0,
+};
+
 export type RenderTooltipParams = TooltipContextType & {
   colorScale?: PickD3Scale<'ordinal', string, string>;
 };
@@ -19,6 +26,18 @@ export type TooltipProps = {
    * Content will be rendered in an HTML parent.
    */
   renderTooltip: (params: RenderTooltipParams) => React.ReactNode;
+  /** Whether to show a vertical line at tooltip position. */
+  showVerticalCrosshair?: boolean;
+  /** Whether to show a horizontal line at tooltip position. */
+  showHorizontalCrosshair?: boolean;
+  /** Whether to show a circle at the tooltip position. */
+  showPoint?: boolean;
+  /** Optional styles for the vertical crosshair, if visible. */
+  verticalCrosshairStyle?: React.SVGProps<SVGLineElement>;
+  /** Optional styles for the vertical crosshair, if visible. */
+  horizontalCrosshairStyle?: React.SVGProps<SVGLineElement>;
+  /** Optional styles for the point, if visible. */
+  pointStyle?: React.SVGProps<SVGCircleElement>;
   /**
    * Tooltip depends on ResizeObserver, which may be pollyfilled globally
    * or injected into this component.
@@ -38,14 +57,20 @@ const INVISIBLE_STYLES: React.CSSProperties = {
 };
 
 export default function Tooltip({
-  renderTooltip,
   debounce,
   detectBounds,
+  renderTooltip,
   resizeObserverPolyfill,
-  scroll,
+  scroll = true,
+  showHorizontalCrosshair = true,
+  showPoint = true,
+  showVerticalCrosshair = true,
+  verticalCrosshairStyle,
+  horizontalCrosshairStyle,
+  pointStyle,
   ...tooltipProps
 }: TooltipProps) {
-  const { colorScale, theme } = useContext(DataContext) || {};
+  const { colorScale, theme, innerHeight, innerWidth, margin } = useContext(DataContext) || {};
   const tooltipContext = useContext(TooltipContext);
   const { containerRef, TooltipInPortal } = useTooltipInPortal({
     debounce,
@@ -67,28 +92,99 @@ export default function Tooltip({
     ? renderTooltip({ ...tooltipContext, colorScale })
     : null;
 
+  const pointRadius = Number(pointStyle?.radius ?? 4);
+
   return (
     // Tooltip can be rendered as a child of SVG or HTML since its output is rendered in a Portal.
     // So use svg element to find container ref because it's a valid child of SVG and HTML parents.
     <>
       <svg ref={setContainerRef} style={INVISIBLE_STYLES} />
       {tooltipContext?.tooltipOpen && tooltipContent != null && (
-        <TooltipInPortal
-          left={tooltipContext?.tooltipLeft}
-          top={tooltipContext?.tooltipTop}
-          style={{
-            ...defaultStyles,
-            background: theme?.backgroundColor ?? 'white',
-            boxShadow: `0 1px 2px ${
-              theme?.htmlLabelStyles?.color ? `${theme?.htmlLabelStyles?.color}55` : '#22222255'
-            }`,
+        <>
+          {showVerticalCrosshair && (
+            <TooltipInPortal
+              className="visx-crosshair visx-crosshair--horizontal"
+              left={tooltipContext?.tooltipLeft}
+              top={margin?.top}
+              offsetLeft={0}
+              offsetTop={0}
+              detectBounds={false}
+              style={CROSSHAIR_STYLE}
+            >
+              <svg width="1" height={innerHeight}>
+                <line
+                  x1={0}
+                  x2={0}
+                  y1={0}
+                  y2={innerHeight}
+                  strokeWidth={1.5}
+                  stroke={theme?.gridStyles?.stroke ?? theme?.htmlLabelStyles?.color ?? '#222'}
+                  {...verticalCrosshairStyle}
+                />
+              </svg>
+            </TooltipInPortal>
+          )}
+          {showHorizontalCrosshair && (
+            <TooltipInPortal
+              className="visx-crosshair visx-crosshair--horizontal"
+              left={margin?.left}
+              top={tooltipContext?.tooltipTop}
+              offsetLeft={0}
+              offsetTop={0}
+              detectBounds={false}
+              style={CROSSHAIR_STYLE}
+            >
+              <svg width={innerWidth} height={1}>
+                <line
+                  x1={0}
+                  x2={innerWidth}
+                  y1={0}
+                  y2={0}
+                  strokeWidth={1.5}
+                  stroke={theme?.gridStyles?.stroke ?? theme?.htmlLabelStyles?.color ?? '#222'}
+                  {...horizontalCrosshairStyle}
+                />
+              </svg>
+            </TooltipInPortal>
+          )}
+          {showPoint && (
+            <TooltipInPortal
+              className="visx-crosshair visx-crosshair--horizontal"
+              left={(tooltipContext?.tooltipLeft ?? 0) - pointRadius}
+              top={(tooltipContext?.tooltipTop ?? 0) - pointRadius}
+              offsetLeft={0}
+              offsetTop={0}
+              detectBounds={false}
+              style={CROSSHAIR_STYLE}
+            >
+              <svg width={pointRadius * 2} height={pointRadius * 2}>
+                <circle
+                  cx={pointRadius}
+                  cy={pointRadius}
+                  r={pointRadius}
+                  fill={theme?.gridStyles?.stroke ?? theme?.htmlLabelStyles?.color ?? '#222'}
+                  {...pointStyle}
+                />
+              </svg>
+            </TooltipInPortal>
+          )}
+          <TooltipInPortal
+            left={tooltipContext?.tooltipLeft}
+            top={tooltipContext?.tooltipTop}
+            style={{
+              ...defaultStyles,
+              background: theme?.backgroundColor ?? 'white',
+              boxShadow: `0 1px 2px ${
+                theme?.htmlLabelStyles?.color ? `${theme?.htmlLabelStyles?.color}55` : '#22222255'
+              }`,
 
-            ...theme?.htmlLabelStyles,
-          }}
-          {...tooltipProps}
-        >
-          {tooltipContent}
-        </TooltipInPortal>
+              ...theme?.htmlLabelStyles,
+            }}
+            {...tooltipProps}
+          >
+            {tooltipContent}
+          </TooltipInPortal>
+        </>
       )}
     </>
   );

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -83,7 +83,7 @@ export default function Tooltip<Datum extends object>({
   scroll = true,
   showHorizontalCrosshair = false,
   showSeriesCircles = false,
-  showDatumCircle = true,
+  showDatumCircle = false,
   showVerticalCrosshair = false,
   snapTooltipToDatumX = false,
   snapTooltipToDatumY = false,
@@ -121,16 +121,23 @@ export default function Tooltip<Datum extends object>({
   const xScaleBandwidth = xScale ? getScaleBandwidth(xScale) : 0;
   const yScaleBandwidth = yScale ? getScaleBandwidth(yScale) : 0;
 
-  const getDatumLeftTop = (key: string, datum: Datum) => {
-    const entry = dataRegistry?.get(key);
-    const xAccessor = entry?.xAccessor;
-    const yAccessor = entry?.yAccessor;
-    const left =
-      xScale && xAccessor ? Number(xScale(xAccessor(datum))) + xScaleBandwidth / 2 ?? 0 : undefined;
-    const top =
-      yScale && yAccessor ? Number(yScale(yAccessor(datum))) + yScaleBandwidth / 2 ?? 0 : undefined;
-    return { left, top };
-  };
+  const getDatumLeftTop = useCallback(
+    (key: string, datum: Datum) => {
+      const entry = dataRegistry?.get(key);
+      const xAccessor = entry?.xAccessor;
+      const yAccessor = entry?.yAccessor;
+      const left =
+        xScale && xAccessor
+          ? Number(xScale(xAccessor(datum))) + xScaleBandwidth / 2 ?? 0
+          : undefined;
+      const top =
+        yScale && yAccessor
+          ? Number(yScale(yAccessor(datum))) + yScaleBandwidth / 2 ?? 0
+          : undefined;
+      return { left, top };
+    },
+    [dataRegistry, xScaleBandwidth, yScaleBandwidth, xScale, yScale],
+  );
 
   const nearestDatum = tooltipContext?.tooltipData?.nearestDatum;
   const nearestDatumKey = nearestDatum?.key ?? '';
@@ -184,7 +191,7 @@ export default function Tooltip<Datum extends object>({
     // So use svg element to find container ref because it's a valid child of SVG and HTML parents.
     <>
       <svg ref={setContainerRef} style={INVISIBLE_STYLES} />
-      {tooltipContext?.tooltipOpen && tooltipContent != null && (
+      {showTooltip && (
         <>
           {/** To correctly position crosshair / circles in a Portal, we leverage the logic in TooltipInPortal */}
           {showVerticalCrosshair && (

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -15,17 +15,17 @@ const CROSSHAIR_STYLE: React.CSSProperties = {
   lineHeight: 0,
 };
 
-export type RenderTooltipParams = TooltipContextType & {
+export type RenderTooltipParams<Datum extends object> = TooltipContextType<Datum> & {
   colorScale?: PickD3Scale<'ordinal', string, string>;
 };
 
-export type TooltipProps = {
+export type TooltipProps<Datum extends object> = {
   /**
    * When TooltipContext.tooltipOpen=true, this function is invoked and if the
    * return value is non-null, its content is rendered inside the tooltip container.
    * Content will be rendered in an HTML parent.
    */
-  renderTooltip: (params: RenderTooltipParams) => React.ReactNode;
+  renderTooltip: (params: RenderTooltipParams<Datum>) => React.ReactNode;
   /** Whether to show a vertical line at tooltip position. */
   showVerticalCrosshair?: boolean;
   /** Whether to show a horizontal line at tooltip position. */
@@ -56,7 +56,7 @@ const INVISIBLE_STYLES: React.CSSProperties = {
   pointerEvents: 'none',
 };
 
-export default function Tooltip({
+export default function Tooltip<Datum extends object>({
   debounce,
   detectBounds,
   renderTooltip,
@@ -69,7 +69,7 @@ export default function Tooltip({
   horizontalCrosshairStyle,
   pointStyle,
   ...tooltipProps
-}: TooltipProps) {
+}: TooltipProps<Datum>) {
   const { colorScale, theme, innerHeight, innerWidth, margin } = useContext(DataContext) || {};
   const tooltipContext = useContext(TooltipContext);
   const { containerRef, TooltipInPortal } = useTooltipInPortal({

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -147,7 +147,7 @@ export default function Tooltip<Datum extends object>({
 
   if (showTooltip && (showDatumCircle || showSeriesCircles)) {
     const radius = Number(circleStyle?.radius ?? 4);
-    const strokeWidth = Number(circleStyle?.strokeWidth ?? 4);
+    const strokeWidth = Number(circleStyle?.strokeWidth ?? 1.5);
 
     if (showSeriesCircles) {
       Object.values(tooltipContext?.tooltipData?.datumByKey ?? {}).forEach(({ key, datum }) => {

--- a/packages/visx-xychart/src/components/series/BarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/BarSeries.tsx
@@ -104,9 +104,9 @@ function BarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ext
         });
         if (datum) {
           showTooltip({
-            tooltipData: datum.datum,
-            tooltipLeft: svgPoint.x,
-            tooltipTop: svgPoint.y,
+            key: dataKey,
+            ...datum,
+            svgPoint,
           });
         }
       }

--- a/packages/visx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/LineSeries.tsx
@@ -8,12 +8,16 @@ import getScaledValueFactory from '../../utils/getScaledValueFactory';
 import useEventEmitter, { HandlerParams } from '../../hooks/useEventEmitter';
 import findNearestDatumX from '../../utils/findNearestDatumX';
 import TooltipContext from '../../context/TooltipContext';
+import findNearestDatumY from '../../utils/findNearestDatumY';
 
 type LineSeriesProps<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
-> = SeriesProps<XScale, YScale, Datum>;
+> = SeriesProps<XScale, YScale, Datum> & {
+  /** Whether line should be rendered horizontally instead of vertically. */
+  horizontal?: boolean;
+};
 
 function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   data,
@@ -22,6 +26,7 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
   xScale,
   yAccessor,
   yScale,
+  horizontal = true,
   ...lineProps
 }: LineSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
@@ -34,7 +39,7 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
     (params: HandlerParams | undefined) => {
       const { svgPoint } = params || {};
       if (svgPoint && width && height && showTooltip) {
-        const datum = findNearestDatumX({
+        const datum = (horizontal ? findNearestDatumX : findNearestDatumY)({
           point: svgPoint,
           key: dataKey,
           data,
@@ -54,7 +59,7 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
         }
       }
     },
-    [dataKey, data, xScale, yScale, xAccessor, yAccessor, width, height, showTooltip],
+    [dataKey, data, xScale, yScale, xAccessor, yAccessor, width, height, showTooltip, horizontal],
   );
   useEventEmitter('mousemove', handleMouseMove);
   useEventEmitter('mouseout', hideTooltip);

--- a/packages/visx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/LineSeries.tsx
@@ -6,7 +6,7 @@ import { SeriesProps } from '../../types';
 import withRegisteredData, { WithRegisteredDataProps } from '../../enhancers/withRegisteredData';
 import getScaledValueFactory from '../../utils/getScaledValueFactory';
 import useEventEmitter, { HandlerParams } from '../../hooks/useEventEmitter';
-import findNearestDatumXY from '../../utils/findNearestDatumXY';
+import findNearestDatumX from '../../utils/findNearestDatumX';
 import TooltipContext from '../../context/TooltipContext';
 
 type LineSeriesProps<
@@ -34,7 +34,7 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
     (params: HandlerParams | undefined) => {
       const { svgPoint } = params || {};
       if (svgPoint && width && height && showTooltip) {
-        const datum = findNearestDatumXY({
+        const datum = findNearestDatumX({
           point: svgPoint,
           key: dataKey,
           data,
@@ -47,9 +47,9 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
         });
         if (datum) {
           showTooltip({
-            tooltipData: datum.datum,
-            tooltipLeft: svgPoint.x,
-            tooltipTop: svgPoint.y,
+            key: dataKey,
+            ...datum,
+            svgPoint,
           });
         }
       }

--- a/packages/visx-xychart/src/context/TooltipContext.tsx
+++ b/packages/visx-xychart/src/context/TooltipContext.tsx
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
 import { TooltipContextType } from '../types';
 
-const TooltipContext = createContext<TooltipContextType | null>(null);
+// @TODO infer Datum
+const TooltipContext = createContext<TooltipContextType<object> | null>(null);
 
 export default TooltipContext;

--- a/packages/visx-xychart/src/context/TooltipContext.tsx
+++ b/packages/visx-xychart/src/context/TooltipContext.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { createContext } from 'react';
 import { TooltipContextType } from '../types';
 
-// @TODO infer Datum
-const TooltipContext = createContext<TooltipContextType<object> | null>(null);
+type InferTooltipContext<D extends object = any> = D extends TooltipContextType<infer D> ? D : any;
+
+const TooltipContext = createContext<InferTooltipContext>(null);
 
 export default TooltipContext;

--- a/packages/visx-xychart/src/providers/TooltipProvider.tsx
+++ b/packages/visx-xychart/src/providers/TooltipProvider.tsx
@@ -1,21 +1,27 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
+import debounce from 'lodash/debounce';
 import { useTooltip } from '@visx/tooltip';
 import TooltipContext from '../context/TooltipContext';
 import { ShowTooltipParams, TooltipData } from '../types';
 
 type TooltipProviderProps = {
+  /** Debounce time for when `hideTooltip` is invoked. */
+  hideTooltipDebounceMs?: number;
   children: React.ReactNode;
 };
 
 /** Simple wrapper around useTooltip, to provide tooltip data via context. */
-export default function TooltipProvider<Datum extends object>({ children }: TooltipProviderProps) {
+export default function TooltipProvider<Datum extends object>({
+  hideTooltipDebounceMs = 400,
+  children,
+}: TooltipProviderProps) {
   const {
     tooltipOpen,
     tooltipLeft,
     tooltipTop,
     tooltipData,
     updateTooltip,
-    hideTooltip,
+    hideTooltip: privateHideTooltip,
   } = useTooltip<TooltipData<Datum>>(undefined);
 
   const showTooltip = useRef(
@@ -47,6 +53,10 @@ export default function TooltipProvider<Datum extends object>({ children }: Tool
       }));
     },
   );
+
+  const hideTooltip = useCallback(debounce(privateHideTooltip, hideTooltipDebounceMs), [
+    privateHideTooltip,
+  ]);
 
   return (
     <TooltipContext.Provider

--- a/packages/visx-xychart/src/providers/TooltipProvider.tsx
+++ b/packages/visx-xychart/src/providers/TooltipProvider.tsx
@@ -1,10 +1,66 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTooltip } from '@visx/tooltip';
 import TooltipContext from '../context/TooltipContext';
-import { TooltipData } from '../types';
+import { ShowTooltipParams, TooltipData } from '../types';
+
+type TooltipProviderProps = {
+  children: React.ReactNode;
+};
 
 /** Simple wrapper around useTooltip, to provide tooltip data via context. */
-export default function TooltipProvider({ children }: { children: React.ReactNode }) {
-  const tooltip = useTooltip<TooltipData>();
-  return <TooltipContext.Provider value={tooltip}>{children}</TooltipContext.Provider>;
+export default function TooltipProvider<Datum extends object>({ children }: TooltipProviderProps) {
+  const {
+    tooltipOpen,
+    tooltipLeft,
+    tooltipTop,
+    tooltipData,
+    updateTooltip,
+    hideTooltip,
+  } = useTooltip<TooltipData<Datum>>(undefined);
+
+  const showTooltip = useRef(
+    ({ svgPoint, index, key, datum, distanceX, distanceY }: ShowTooltipParams<Datum>) => {
+      const distance =
+        distanceX == null || distanceY == null
+          ? Infinity
+          : Math.sqrt(distanceX ** 2 + distanceY ** 2);
+
+      updateTooltip(({ tooltipData: currData }) => ({
+        tooltipOpen: true,
+        tooltipLeft: svgPoint?.x,
+        tooltipTop: svgPoint?.y,
+        tooltipData: {
+          nearestDatum:
+            (currData?.nearestDatum?.key ?? '') !== key &&
+            (currData?.nearestDatum?.distance ?? Infinity) < distance
+              ? currData?.nearestDatum
+              : { key, index, datum, distance },
+          datumByKey: {
+            ...currData?.datumByKey,
+            [key]: {
+              datum,
+              index,
+              key,
+            },
+          },
+        },
+      }));
+    },
+  );
+
+  return (
+    <TooltipContext.Provider
+      value={{
+        tooltipOpen,
+        tooltipLeft,
+        tooltipTop,
+        tooltipData,
+        updateTooltip,
+        showTooltip: showTooltip.current,
+        hideTooltip,
+      }}
+    >
+      {children}
+    </TooltipContext.Provider>
+  );
 }

--- a/packages/visx-xychart/src/types/tooltip.ts
+++ b/packages/visx-xychart/src/types/tooltip.ts
@@ -26,8 +26,6 @@ export type ShowTooltipParams<Datum> = {
 };
 
 export type TooltipData<Datum extends object = object> = {
-  /** Coordinates of the event in svg space. */
-  svgPoint?: { x: number; y: number };
   /** Nearest Datum to event across all Series. */
   nearestDatum?: TooltipDatum<Datum> & { distance: number };
   /** Nearest Datum to event across for each Series. */

--- a/packages/visx-xychart/src/types/tooltip.ts
+++ b/packages/visx-xychart/src/types/tooltip.ts
@@ -9,6 +9,7 @@ export type TooltipDatum<Datum extends object> = {
   datum: Datum;
 };
 
+/** Call signature of `TooltipContext.showTooltip` */
 export type ShowTooltipParams<Datum> = {
   /** Series key that datum belongs to. */
   key: string;
@@ -27,7 +28,9 @@ export type ShowTooltipParams<Datum> = {
 export type TooltipData<Datum extends object = object> = {
   /** Coordinates of the event in svg space. */
   svgPoint?: { x: number; y: number };
+  /** Nearest Datum to event across all Series. */
   nearestDatum?: TooltipDatum<Datum> & { distance: number };
+  /** Nearest Datum to event across for each Series. */
   datumByKey: {
     [key: string]: TooltipDatum<Datum>;
   };

--- a/packages/visx-xychart/src/types/tooltip.ts
+++ b/packages/visx-xychart/src/types/tooltip.ts
@@ -1,5 +1,38 @@
 import { UseTooltipParams } from '@visx/tooltip/lib/hooks/useTooltip';
 
-export type TooltipData = {};
+export type TooltipDatum<Datum extends object> = {
+  /** Series key that datum belongs to. */
+  key: string;
+  /** Index of datum in series data array. */
+  index: number;
+  /** Datum. */
+  datum: Datum;
+};
 
-export type TooltipContextType = UseTooltipParams<TooltipData>;
+export type ShowTooltipParams<Datum> = {
+  /** Series key that datum belongs to. */
+  key: string;
+  /** Index of datum in series data array. */
+  index: number;
+  /** Datum. */
+  datum: Datum;
+  /** Optional distance of datum x value to event x value. Used to determine closest datum. */
+  distanceX?: number;
+  /** Optional distance of datum y value to event y value. Used to determine closest datum. */
+  distanceY?: number;
+  /** Coordinates of the event in svg space. */
+  svgPoint?: { x: number; y: number };
+};
+
+export type TooltipData<Datum extends object = object> = {
+  /** Coordinates of the event in svg space. */
+  svgPoint?: { x: number; y: number };
+  nearestDatum?: TooltipDatum<Datum> & { distance: number };
+  datumByKey: {
+    [key: string]: TooltipDatum<Datum>;
+  };
+};
+
+export type TooltipContextType<Datum extends object> = UseTooltipParams<TooltipData<Datum>> & {
+  showTooltip: (params: ShowTooltipParams<Datum>) => void;
+};

--- a/packages/visx-xychart/src/utils/findNearestDatumX.ts
+++ b/packages/visx-xychart/src/utils/findNearestDatumX.ts
@@ -9,6 +9,8 @@ export default function findNearestDatumX<
 >({
   xScale: scale,
   xAccessor: accessor,
+  yScale,
+  yAccessor,
   point,
   data,
 }: NearestDatumArgs<XScale, YScale, Datum>): {
@@ -30,8 +32,8 @@ export default function findNearestDatumX<
     ? {
         datum: nearestDatum.datum,
         index: nearestDatum.index,
-        distanceY: nearestDatum.distance,
-        distanceX: 0,
+        distanceX: nearestDatum.distance,
+        distanceY: Math.abs(Number(yScale(yAccessor(nearestDatum.datum))) - point.y),
       }
     : null;
 }

--- a/packages/visx-xychart/src/utils/findNearestDatumY.ts
+++ b/packages/visx-xychart/src/utils/findNearestDatumY.ts
@@ -9,6 +9,8 @@ export default function findNearestDatumY<
 >({
   yScale: scale,
   yAccessor: accessor,
+  xScale,
+  xAccessor,
   point,
   data,
 }: NearestDatumArgs<XScale, YScale, Datum>): {
@@ -31,7 +33,7 @@ export default function findNearestDatumY<
         datum: nearestDatum.datum,
         index: nearestDatum.index,
         distanceY: nearestDatum.distance,
-        distanceX: 0,
+        distanceX: Math.abs(Number(xScale(xAccessor(nearestDatum.datum))) - point.x),
       }
     : null;
 }

--- a/packages/visx-xychart/test/components/Tooltip.test.tsx
+++ b/packages/visx-xychart/test/components/Tooltip.test.tsx
@@ -8,8 +8,8 @@ import { TooltipProps } from '../../src/components/Tooltip';
 describe('<Tooltip />', () => {
   type SetupProps =
     | {
-        props?: Partial<TooltipProps>;
-        context?: Partial<TooltipContextType>;
+        props?: Partial<TooltipProps<object>>;
+        context?: Partial<TooltipContextType<object>>;
       }
     | undefined;
   function setup({ props, context }: SetupProps = {}) {

--- a/packages/visx-xychart/test/components/Tooltip.test.tsx
+++ b/packages/visx-xychart/test/components/Tooltip.test.tsx
@@ -2,29 +2,42 @@ import React from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
 import { mount } from 'enzyme';
 import { Tooltip as BaseTooltip } from '@visx/tooltip';
-import { Tooltip, TooltipContext, TooltipContextType } from '../../src';
+import { DataContext, Tooltip, TooltipContext, TooltipContextType } from '../../src';
 import { TooltipProps } from '../../src/components/Tooltip';
+import getDataContext from '../mocks/getDataContext';
 
 describe('<Tooltip />', () => {
   type SetupProps =
     | {
         props?: Partial<TooltipProps<object>>;
         context?: Partial<TooltipContextType<object>>;
+        Parent?: ({ children }: { children: React.ReactElement }) => React.ReactElement;
       }
     | undefined;
-  function setup({ props, context }: SetupProps = {}) {
+
+  function setup({
+    props,
+    context,
+    Parent = ({ children }: { children: React.ReactElement }) => children,
+  }: SetupProps = {}) {
     const wrapper = mount(
-      <TooltipContext.Provider
-        value={{
-          tooltipOpen: false,
-          showTooltip: jest.fn(),
-          updateTooltip: jest.fn(),
-          hideTooltip: jest.fn(),
-          ...context,
-        }}
-      >
-        <Tooltip resizeObserverPolyfill={ResizeObserver} renderTooltip={() => null} {...props} />
-      </TooltipContext.Provider>,
+      <Parent>
+        <TooltipContext.Provider
+          value={{
+            tooltipOpen: false,
+            showTooltip: jest.fn(),
+            updateTooltip: jest.fn(),
+            hideTooltip: jest.fn(),
+            ...context,
+          }}
+        >
+          <Tooltip
+            resizeObserverPolyfill={ResizeObserver}
+            renderTooltip={() => <div />}
+            {...props}
+          />
+        </TooltipContext.Provider>
+      </Parent>,
     );
     return wrapper;
   }
@@ -38,13 +51,13 @@ describe('<Tooltip />', () => {
   });
 
   it('should not render a BaseTooltip when TooltipContext.tooltipOpen=true and renderTooltip returns false', () => {
-    const wrapper = setup({ context: { tooltipOpen: true } });
+    const wrapper = setup({ context: { tooltipOpen: true }, props: { renderTooltip: () => null } });
     expect(wrapper.find(BaseTooltip)).toHaveLength(0);
   });
 
   it('should render a BaseTooltip when TooltipContext.tooltipOpen=true and renderTooltip returns non-null', () => {
     const wrapper = setup({
-      props: { renderTooltip: () => <div /> },
+      props: { renderTooltip: () => <div />, snapTooltipToDatumX: true },
       context: { tooltipOpen: true },
     });
     expect(wrapper.find(BaseTooltip)).toHaveLength(1);
@@ -65,5 +78,81 @@ describe('<Tooltip />', () => {
       context: { tooltipOpen: true },
     });
     expect(renderTooltip).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render a vertical crosshair if showVerticalCrossHair=true', () => {
+    const wrapper = setup({
+      props: { showVerticalCrosshair: true },
+      context: { tooltipOpen: true },
+    });
+    expect(wrapper.find('div.visx-crosshair-vertical')).toHaveLength(1);
+  });
+
+  it('should render a horizontal crosshair if showVerticalCrossHair=true', () => {
+    const wrapper = setup({
+      props: { showHorizontalCrosshair: true },
+      context: { tooltipOpen: true },
+    });
+    expect(wrapper.find('div.visx-crosshair-horizontal')).toHaveLength(1);
+  });
+
+  it('should not render a glyph if showDatumGlyph=true and there is no nearestDatum', () => {
+    const wrapper = setup({
+      props: { showDatumGlyph: true },
+      context: { tooltipOpen: true },
+    });
+    expect(wrapper.find('div.visx-tooltip-glyph')).toHaveLength(0);
+  });
+  it('should render a glyph if showDatumGlyph=true if there is a nearestDatum', () => {
+    const wrapper = setup({
+      props: { showDatumGlyph: true },
+      context: {
+        tooltipOpen: true,
+        tooltipData: {
+          nearestDatum: { distance: 1, key: '', index: 0, datum: {} },
+          datumByKey: {},
+        },
+      },
+    });
+    expect(wrapper.find('div.visx-tooltip-glyph')).toHaveLength(1);
+  });
+  it('should render a glyph for each series if showSeriesGlyphs=true', () => {
+    const wrapper = setup({
+      props: { showSeriesGlyphs: true },
+      context: {
+        tooltipOpen: true,
+        tooltipData: {
+          datumByKey: {
+            d1: { key: 'd1', index: 0, datum: {} },
+            d2: { key: 'd2', index: 1, datum: {} },
+          },
+        },
+      },
+      Parent: (
+        { children }, // glyphs snap to data points, so scales/accessors must exist
+      ) => (
+        <DataContext.Provider
+          value={{
+            ...getDataContext([
+              {
+                key: 'd1',
+                xAccessor: () => 3,
+                yAccessor: () => 7,
+                data: [{}],
+              },
+              {
+                key: 'd2',
+                xAccessor: () => 3,
+                yAccessor: () => 7,
+                data: [{}],
+              },
+            ]),
+          }}
+        >
+          {children}
+        </DataContext.Provider>
+      ),
+    });
+    expect(wrapper.find('div.visx-tooltip-glyph')).toHaveLength(2);
   });
 });

--- a/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
@@ -1,18 +1,70 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { mount } from 'enzyme';
-import { TooltipProvider, TooltipContext } from '../../src';
+import { TooltipProvider, TooltipContext, TooltipData } from '../../src';
 
 describe('<TooltipProvider />', () => {
   it('should be defined', () => {
     expect(TooltipProvider).toBeDefined();
   });
 
-  it('should provide an emitter for subscribing and emitting events', () => {
+  it('should provide tooltip state', () => {
     expect.assertions(1);
 
     const TooltipConsumer = () => {
       const tooltipContext = useContext(TooltipContext);
-      expect(tooltipContext).toBeDefined();
+      expect(tooltipContext).toMatchObject({
+        tooltipOpen: expect.any(Boolean),
+        showTooltip: expect.any(Function),
+        updateTooltip: expect.any(Function),
+        hideTooltip: expect.any(Function),
+      });
+
+      return null;
+    };
+
+    mount(
+      <TooltipProvider>
+        <TooltipConsumer />
+      </TooltipProvider>,
+    );
+  });
+
+  it('showTooltip should update tooltipData.nearestDatum/datumByKey', () => {
+    expect.assertions(1);
+
+    const TooltipConsumer = () => {
+      const tooltipContext = useContext(TooltipContext);
+      const tooltipOpen = tooltipContext?.tooltipOpen;
+      const showTooltip = tooltipContext?.showTooltip;
+
+      useEffect(() => {
+        // this triggers a re-render of the component which triggers the assertion block
+        if (!tooltipOpen && showTooltip) {
+          showTooltip({
+            key: 'near',
+            index: 0,
+            distanceX: 0,
+            distanceY: 0,
+            datum: { hi: 'hello' },
+          });
+          showTooltip({
+            key: 'far',
+            index: 1,
+            datum: { good: 'bye' },
+            // no distance = Infinity
+          });
+        }
+      }, [tooltipOpen, showTooltip]);
+
+      if (tooltipOpen) {
+        expect(tooltipContext?.tooltipData).toMatchObject({
+          nearestDatum: { key: 'near', index: 0, distance: 0, datum: { hi: 'hello' } },
+          datumByKey: {
+            near: { key: 'near', index: 0, datum: { hi: 'hello' } },
+            far: { key: 'far', index: 1, datum: { good: 'bye' } },
+          },
+        } as TooltipData<object>);
+      }
 
       return null;
     };


### PR DESCRIPTION
**TODO**
- [x] add tests (separate PR for review #852)

#### :rocket: Enhancements

**`@visx/tooltip`**
allow function signatures for `useTooltip`'s `updateTooltip` + `showTooltip`
```tsx
// before
showTooltip({ tooltipData, ... });

//after 
showTooltip(currentState => ({ _logic based on currentState_ }));
```

**why?** this mirrors how `react` `setState` works, and was needed to implement tooltip data merging properly in `xychart/TooltipProvider`. when `TooltipProvider` tries to merge `tooltipData` when the hook state is updated in quick succession, the hook-provided value may be stale.

<hr />

**`@visx/xychart`**
Builds on #825 and adds more fully-featured `Tooltip` functionality:

- `TooltipProvider` no longer simply returns the `useTooltip` hook state, but adds additional functionality so that `TooltipContext.tooltipData` now includes both the _**globally closest datum**_ as well as the closest datum **_per-Series_**. Functionally this allows
  - for more comprehensive tooltip data to be rendered in the tooltip (i.e., data for _**all**_ Series, see demo)
  - `Tooltip` to snap to data values instead of simply following the cursor
- `Tooltip` now supports the following `props`
  - `snapTooltipToDatumX`, `snapTooltipToDatumY` (tooltip position snaps to data coord instead of mouse coord)
  - `showVerticalCrosshair`, `showHorizontalCrosshair`
  - `showDatumCircle`, `showSeriesCircles`
  - `verticalCrosshairStyle`, `horizontalCrosshairStyle`, `circleStyle`
- adds a `debounce` to `hideTooltip` for better UX

<hr />

**`@visx/demo`**

Updates the `XYChart` demo with all `Tooltip` controls

<img src="https://user-images.githubusercontent.com/4496521/95154161-15378f80-0746-11eb-9f65-e3a4c8e3a1b6.png" width="600" />

Also want to demo how you can do cool things like linked tooltips trivially with a shared `EventEmitterContext` which is TIGHT 🔥🔥

<img src="https://user-images.githubusercontent.com/4496521/95154102-e7eae180-0745-11eb-97ee-29be7bae9f38.gif" width="600" />

@kristw @hshoff @techniq 