### PR TITLE
fix(network): apply fill and radius props to circle element in DefaultNode

### DIFF
--- a/packages/visx-network/src/DefaultNode.tsx
+++ b/packages/visx-network/src/DefaultNode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 export type NodeProps = {
   cx?: number;
@@ -7,8 +7,8 @@ export type NodeProps = {
 
 export default function DefaultNode({
   r = 15,
-  fill = '#21DfFD',
+  fill = "#21D4FD",
   ...rest
 }: NodeProps & Omit<React.SVGProps<SVGCircleElement>, keyof NodeProps>) {
-  return <circle r={15} fill="#21D4FD" {...rest} />;
+  return <circle r={r} fill={fill} {...rest} />;
 }

--- a/packages/visx-network/src/DefaultNode.tsx
+++ b/packages/visx-network/src/DefaultNode.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 export type NodeProps = {
   cx?: number;
@@ -7,7 +7,7 @@ export type NodeProps = {
 
 export default function DefaultNode({
   r = 15,
-  fill = "#21D4FD",
+  fill = '#21D4FD',
   ...rest
 }: NodeProps & Omit<React.SVGProps<SVGCircleElement>, keyof NodeProps>) {
   return <circle r={r} fill={fill} {...rest} />;


### PR DESCRIPTION
#### Bug Fix

Apply the `r` and `fill` props to the `circle` svg element. Please feel free to close if this isn't the direction the library was planning to go, but it seems like one might wish to use the DefaultNode but simply change the radius and colour, especially as it was already being defaulted to a value.