### PR TITLE
new(xychart): add BarStack series

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/customTheme.ts
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/customTheme.ts
@@ -2,7 +2,7 @@ import { buildChartTheme } from '@visx/xychart';
 
 export default buildChartTheme({
   backgroundColor: '#f09ae9',
-  colors: ['rgba(255,231,143,0.8)', '#6a097d', '#ffc1fa'],
+  colors: ['rgba(255,231,143,0.8)', '#6a097d', '#d6e0f0'],
   gridColor: '#336d88',
   gridColorDark: '#1d1b38',
   labelStyles: { fill: '#1d1b38' },

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -55,7 +55,8 @@
     "@visx/tooltip": "1.0.0",
     "@visx/voronoi": "1.0.0",
     "classnames": "^2.2.5",
-    "d3-array": "2.6.0",
+    "d3-array": "^2.6.0",
+    "d3-shape":"^2.0.0",
     "mitt": "^2.1.0",
     "prop-types": "^15.6.2"
   },

--- a/packages/visx-xychart/src/components/series/BarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/BarSeries.tsx
@@ -11,7 +11,7 @@ import findNearestDatumY from '../../utils/findNearestDatumY';
 import useEventEmitter, { HandlerParams } from '../../hooks/useEventEmitter';
 import TooltipContext from '../../context/TooltipContext';
 
-type BarSeriesProps<
+export type BarSeriesProps<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
@@ -88,12 +88,11 @@ function BarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ext
 
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const handleMouseMove = useCallback(
-    (params: HandlerParams | undefined) => {
+    (params?: HandlerParams) => {
       const { svgPoint } = params || {};
       if (svgPoint && width && height && showTooltip) {
         const datum = (horizontal ? findNearestDatumY : findNearestDatumX)({
           point: svgPoint,
-          key: dataKey,
           data,
           xScale,
           yScale,

--- a/packages/visx-xychart/src/components/series/BarStack.tsx
+++ b/packages/visx-xychart/src/components/series/BarStack.tsx
@@ -1,0 +1,223 @@
+import React, { useContext, useCallback, useMemo, useEffect } from 'react';
+import { SeriesPoint, stack as d3stack } from 'd3-shape';
+import { PositionScale, StackPathConfig } from '@visx/shape/lib/types';
+import { getFirstItem, getSecondItem } from '@visx/shape/lib/util/accessors';
+import stackOffset from '@visx/shape/lib/util/stackOffset';
+import stackOrder from '@visx/shape/lib/util/stackOrder';
+
+import { extent } from 'd3-array';
+import getBandwidth from '@visx/shape/lib/util/getBandwidth';
+import { BarSeriesProps } from './BarSeries';
+import DataContext from '../../context/DataContext';
+import { BarStackDatum, CombinedStackData, DataContextType } from '../../types';
+import TooltipContext from '../../context/TooltipContext';
+import useEventEmitter, { HandlerParams } from '../../hooks/useEventEmitter';
+import isValidNumber from '../../typeguards/isValidNumber';
+import isChildWithProps from '../../typeguards/isChildWithProps';
+import combineBarBarStackData, { getStackValue } from '../../utils/combineBarStackData';
+import getBarStackRegistryData from '../../utils/getBarStackRegistryData';
+import findNearestStackDatum from '../../utils/findNearestStackDatum';
+
+export type BarStackProps<Datum extends object> = {
+  /** Whether to render the Stack horizontally instead of vertically. */
+  horizontal?: boolean;
+  /** `BarSeries` elements */
+  children: JSX.Element | JSX.Element[];
+} & Pick<StackPathConfig<Datum, string>, 'offset' | 'order'>;
+
+function BarStack<
+  XScale extends PositionScale,
+  YScale extends PositionScale,
+  Datum extends object
+>({ children, horizontal, order, offset }: BarStackProps<Datum>) {
+  type StackBar = SeriesPoint<CombinedStackData<XScale, YScale>>;
+  const {
+    xScale,
+    yScale,
+    colorScale,
+    dataRegistry,
+    registerData,
+    unregisterData,
+    width,
+    height,
+  } = (useContext(DataContext) as unknown) as DataContextType<
+    XScale,
+    YScale,
+    BarStackDatum<XScale, YScale>
+  >;
+
+  const barSeriesChildren = useMemo(
+    () =>
+      React.Children.toArray(children).filter(child =>
+        isChildWithProps<BarSeriesProps<XScale, YScale, Datum>>(child),
+      ),
+    [children],
+  ) as React.ReactElement<BarSeriesProps<XScale, YScale, Datum>>[];
+
+  // extract data keys from child series
+  const dataKeys: string[] = useMemo(
+    () => barSeriesChildren.filter(child => child.props.dataKey).map(child => child.props.dataKey),
+    [barSeriesChildren],
+  );
+
+  // group all child data by stack value (`x` for vertical, `y` for horizontal)
+  // this format is needed by d3Stack
+  const combinedData = useMemo(
+    () => combineBarBarStackData<XScale, YScale, Datum>(barSeriesChildren, horizontal),
+    [horizontal, barSeriesChildren],
+  );
+
+  // update the domain to account for the (directional) stacked value
+  const comprehensiveDomain = useMemo(
+    () =>
+      extent(
+        (extent(combinedData, d => d.positiveSum) as [number, number]).concat(
+          extent(combinedData, d => d.negativeSum) as [number, number],
+        ),
+      ) as [number, number],
+    [combinedData],
+  );
+
+  // stack data
+  const stackedData = useMemo(() => {
+    const hasSomeNegativeValues =
+      comprehensiveDomain.length > 0 && comprehensiveDomain.some(num => num < 0);
+
+    const stack = d3stack<CombinedStackData<XScale, YScale>, string>();
+    stack.keys(dataKeys);
+    if (order) stack.order(stackOrder(order));
+    if (offset || hasSomeNegativeValues) stack.offset(stackOffset(offset || 'diverging'));
+
+    return stack(combinedData);
+  }, [combinedData, dataKeys, comprehensiveDomain, order, offset]);
+
+  // register all child data using the stack-transformed values
+  useEffect(() => {
+    const dataToRegister = getBarStackRegistryData(stackedData, comprehensiveDomain, horizontal);
+    registerData(dataToRegister);
+
+    // unregister data on unmount
+    return () => unregisterData(Object.keys(dataToRegister));
+  }, [
+    comprehensiveDomain,
+    horizontal,
+    stackedData,
+    registerData,
+    unregisterData,
+    barSeriesChildren,
+  ]);
+
+  // register mouse listeners
+  const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
+
+  const handleMouseMove = useCallback(
+    (params: HandlerParams | undefined) => {
+      const { svgPoint } = params || {};
+
+      // invoke showTooltip for each key so all data is available in context,
+      // and let Tooltip find the nearest point among them
+      dataKeys.forEach(key => {
+        const entry = dataRegistry.get(key);
+        const childData = barSeriesChildren.find(child => child.props.dataKey === key)?.props.data;
+        if (childData && svgPoint && width && height && showTooltip) {
+          const datum = findNearestStackDatum(
+            {
+              point: svgPoint,
+              data: entry.data,
+              xScale,
+              yScale,
+              xAccessor: entry.xAccessor,
+              yAccessor: entry.yAccessor,
+              width,
+              height,
+            },
+            childData,
+            horizontal,
+          );
+
+          if (datum) {
+            showTooltip({
+              key,
+              svgPoint,
+              ...datum,
+            });
+          }
+        }
+      });
+    },
+    [
+      barSeriesChildren,
+      dataRegistry,
+      dataKeys,
+      horizontal,
+      xScale,
+      yScale,
+      width,
+      height,
+      showTooltip,
+    ],
+  );
+  useEventEmitter('mousemove', handleMouseMove);
+  useEventEmitter('mouseout', hideTooltip);
+
+  // if scales and data are not available in the registry, bail
+  if (dataKeys.some(key => dataRegistry.get(key) == null) || !xScale || !yScale || !colorScale) {
+    return null;
+  }
+
+  const barThickness = getBandwidth(horizontal ? yScale : xScale);
+  const halfBarThickness = barThickness / 2;
+
+  let getWidth: (bar: StackBar) => number | undefined;
+  let getHeight: (bar: StackBar) => number | undefined;
+  let getX: (bar: StackBar) => number | undefined;
+  let getY: (bar: StackBar) => number | undefined;
+
+  if (horizontal) {
+    getWidth = bar => (xScale(getSecondItem(bar)) || 0) - (xScale(getFirstItem(bar)) || 0);
+    getHeight = () => barThickness;
+    getX = bar => xScale(getFirstItem(bar));
+    getY = bar =>
+      'bandwidth' in yScale
+        ? yScale(getStackValue(bar.data))
+        : Math.max((yScale(getStackValue(bar.data)) || 0) - halfBarThickness);
+  } else {
+    getWidth = () => barThickness;
+    getHeight = bar => (yScale(getFirstItem(bar)) || 0) - (yScale(getSecondItem(bar)) || 0);
+    getX = bar =>
+      'bandwidth' in xScale
+        ? xScale(getStackValue(bar.data))
+        : Math.max((xScale(getStackValue(bar.data)) || 0) - halfBarThickness);
+    getY = bar => yScale(getSecondItem(bar));
+  }
+
+  return (
+    <g className="visx-bar-stack">
+      {stackedData.map((barStack, stackIndex) => {
+        const entry = dataRegistry.get(barStack.key);
+        if (!entry) return null;
+
+        return barStack.map((bar, index) => {
+          const barX = getX(bar);
+          if (!isValidNumber(barX)) return null;
+          const barY = getY(bar);
+          if (!isValidNumber(barY)) return null;
+
+          return (
+            <rect
+              key={`${stackIndex}-${barStack.key}-${index}`}
+              x={barX}
+              y={barY}
+              width={getWidth(bar)}
+              height={getHeight(bar)}
+              fill={colorScale(barStack.key)}
+              stroke="transparent"
+            />
+          );
+        });
+      })}
+    </g>
+  );
+}
+
+export default BarStack;

--- a/packages/visx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/LineSeries.tsx
@@ -36,12 +36,11 @@ function LineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum ex
   const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';
 
   const handleMouseMove = useCallback(
-    (params: HandlerParams | undefined) => {
+    (params?: HandlerParams) => {
       const { svgPoint } = params || {};
       if (svgPoint && width && height && showTooltip) {
         const datum = (horizontal ? findNearestDatumX : findNearestDatumY)({
           point: svgPoint,
-          key: dataKey,
           data,
           xScale,
           yScale,

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -31,11 +31,9 @@ export default function withRegisteredData<
       >,
   ) {
     const { dataKey, data, xAccessor, yAccessor } = props;
-    const { xScale, yScale, dataRegistry } = useContext(DataContext) as DataContextType<
-      XAxis,
-      YAxis,
-      Datum
-    >;
+    const { xScale, yScale, dataRegistry } = (useContext(
+      DataContext,
+    ) as unknown) as DataContextType<XAxis, YAxis, Datum>;
 
     useEffect(() => {
       if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });

--- a/packages/visx-xychart/src/hooks/useDataRegistry.ts
+++ b/packages/visx-xychart/src/hooks/useDataRegistry.ts
@@ -1,23 +1,32 @@
 import { AxisScale } from '@visx/axis';
 import { useMemo, useState } from 'react';
 import DataRegistry from '../classes/DataRegistry';
+import { DataContextType } from '../types';
 
 /** Hook that returns an API equivalent to DataRegistry but which updates as needed for use as a hook. */
 export default function useDataRegistry<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
->() {
+>(): DataContextType<XScale, YScale, Datum>['dataRegistry'] {
   const [, forceUpdate] = useState(Math.random());
   const privateRegistry = useMemo(() => new DataRegistry<XScale, YScale, Datum>(), []);
 
   return useMemo(
     () => ({
-      registerData: (...params: Parameters<typeof DataRegistry.prototype.registerData>) => {
+      registerData: (
+        ...params: Parameters<
+          DataContextType<XScale, YScale, Datum>['dataRegistry']['registerData']
+        >
+      ) => {
         privateRegistry.registerData(...params);
         forceUpdate(Math.random());
       },
-      unregisterData: (...params: Parameters<typeof DataRegistry.prototype.unregisterData>) => {
+      unregisterData: (
+        ...params: Parameters<
+          DataContextType<XScale, YScale, Datum>['dataRegistry']['unregisterData']
+        >
+      ) => {
         privateRegistry.unregisterData(...params);
         forceUpdate(Math.random());
       },

--- a/packages/visx-xychart/src/hooks/useDimensions.ts
+++ b/packages/visx-xychart/src/hooks/useDimensions.ts
@@ -6,11 +6,16 @@ const INITIAL_DIMENSIONS = {
   margin: { top: 0, right: 0, bottom: 0, left: 0 },
 };
 
-type Dimensions = typeof INITIAL_DIMENSIONS;
+export type Dimensions = typeof INITIAL_DIMENSIONS;
 
 /** A hook for accessing and setting memoized width, height, and margin chart dimensions. */
-export default function useDimensions(): [Dimensions, (dims: Dimensions) => void] {
-  const [dimensions, privateSetDimensions] = useState<Dimensions>(INITIAL_DIMENSIONS);
+export default function useDimensions(
+  initialDimensions?: Partial<Dimensions>,
+): [Dimensions, (dims: Dimensions) => void] {
+  const [dimensions, privateSetDimensions] = useState<Dimensions>({
+    ...INITIAL_DIMENSIONS,
+    ...initialDimensions,
+  });
 
   // expose a setter with better memoization logic
   const publicSetDimensions = useCallback(

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -8,6 +8,7 @@ export { default as XYChart } from './components/XYChart';
 
 // series components
 export { default as BarSeries } from './components/series/BarSeries';
+export { default as BarStack } from './components/series/BarStack';
 export { default as LineSeries } from './components/series/LineSeries';
 
 // context

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -7,7 +7,7 @@ import { XYChartTheme } from '../types';
 import ThemeContext from '../context/ThemeContext';
 import DataContext from '../context/DataContext';
 import useDataRegistry from '../hooks/useDataRegistry';
-import useDimensions from '../hooks/useDimensions';
+import useDimensions, { Dimensions } from '../hooks/useDimensions';
 import useScales from '../hooks/useScales';
 
 /** Props that can be passed to initialize/update the provider config. */
@@ -15,6 +15,7 @@ export type DataProviderProps<
   XScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>,
   YScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>
 > = {
+  initialDimensions?: Partial<Dimensions>;
   theme?: XYChartTheme;
   xScale: XScaleConfig;
   yScale: YScaleConfig;
@@ -26,6 +27,7 @@ export default function DataProvider<
   YScaleConfig extends ScaleConfig<AxisScaleOutput>,
   Datum extends object
 >({
+  initialDimensions,
   theme: propsTheme,
   xScale: xScaleConfig,
   yScale: yScaleConfig,
@@ -36,7 +38,7 @@ export default function DataProvider<
   // a ThemeProvider is not present.
   const contextTheme = useContext(ThemeContext);
   const theme = propsTheme || contextTheme;
-  const [{ width, height, margin }, setDimensions] = useDimensions();
+  const [{ width, height, margin }, setDimensions] = useDimensions(initialDimensions);
   const innerWidth = width - (margin?.left ?? 0) - (margin?.right ?? 0);
   const innerHeight = height - (margin?.top ?? 0) - (margin?.bottom ?? 0);
 

--- a/packages/visx-xychart/src/typeguards/isChildWithProps.ts
+++ b/packages/visx-xychart/src/typeguards/isChildWithProps.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+/** Returns whether the React.ReactNode has props (and therefore is an `Element` versus primative type) */
+export default function isChildWithProps<P extends object>(
+  child: React.ReactNode,
+): child is React.ComponentType<P> {
+  return !!child && typeof child === 'object' && 'props' in child && child.props != null;
+}

--- a/packages/visx-xychart/src/types/data.ts
+++ b/packages/visx-xychart/src/types/data.ts
@@ -1,5 +1,5 @@
-import { AxisScale, AxisScaleOutput } from '@visx/axis';
-import { ScaleTypeToD3Scale, ScaleInput, D3Scale } from '@visx/scale';
+import { AxisScale } from '@visx/axis';
+import { ScaleTypeToD3Scale, ScaleInput } from '@visx/scale';
 import DataRegistry from '../classes/DataRegistry';
 import { XYChartTheme } from './theme';
 
@@ -24,9 +24,9 @@ export interface DataRegistryEntry<XScale extends AxisScale, YScale extends Axis
   /** whether the entry supports mouse events. */
   mouseEvents?: boolean;
   /** Optionally update the xScale. */
-  xScale?: <Scale extends D3Scale<AxisScaleOutput>>(xScale: Scale) => Scale;
+  xScale?: <Scale extends AxisScale>(xScale: Scale) => Scale;
   /** Optionally update the yScale. */
-  yScale?: <Scale extends D3Scale<AxisScaleOutput>>(yScale: Scale) => Scale;
+  yScale?: <Scale extends AxisScale>(yScale: Scale) => Scale;
   /** Legend shape for the data key. */
   legendShape?: LegendShape;
 }

--- a/packages/visx-xychart/src/types/event.ts
+++ b/packages/visx-xychart/src/types/event.ts
@@ -14,7 +14,6 @@ export type NearestDatumArgs<
   xAccessor: (d: Datum) => ScaleInput<XScale>;
   yAccessor: (d: Datum) => ScaleInput<YScale>;
   data: Datum[];
-  key: string;
   width: number;
   height: number;
   xScale: XScale;

--- a/packages/visx-xychart/src/types/series.ts
+++ b/packages/visx-xychart/src/types/series.ts
@@ -1,5 +1,6 @@
 import { AxisScale } from '@visx/axis';
 import { ScaleInput } from '@visx/scale';
+import { Series, SeriesPoint } from 'd3-shape';
 
 export type SeriesProps<
   XScale extends AxisScale,
@@ -15,3 +16,17 @@ export type SeriesProps<
   /** Given a Datum, returns the y-scale value. */
   yAccessor: (d: Datum) => ScaleInput<YScale>;
 };
+
+// BarStack transforms its child series Datum into CombinedData<XScale, YScale>
+export type BarStackDatum<XScale extends AxisScale, YScale extends AxisScale> = SeriesPoint<
+  CombinedStackData<XScale, YScale>
+>;
+
+export type BarStackData<XScale extends AxisScale, YScale extends AxisScale> = Series<
+  CombinedStackData<XScale, YScale>,
+  string
+>[];
+
+export type CombinedStackData<XScale extends AxisScale, YScale extends AxisScale> = {
+  [dataKey: string]: ScaleInput<XScale> | ScaleInput<YScale>;
+} & { stack: ScaleInput<XScale> | ScaleInput<YScale>; positiveSum: number; negativeSum: number };

--- a/packages/visx-xychart/src/utils/combineBarStackData.ts
+++ b/packages/visx-xychart/src/utils/combineBarStackData.ts
@@ -1,0 +1,48 @@
+import React from 'react';
+import { AxisScale } from '@visx/axis';
+import { BarSeriesProps } from '../components/series/BarSeries';
+import { CombinedStackData } from '../types';
+
+/** Returns the value which forms a stack group. */
+export const getStackValue = <XScale extends AxisScale, YScale extends AxisScale>(
+  d: Pick<CombinedStackData<XScale, YScale>, 'stack'>,
+) => d.stack;
+
+/**
+ * Merges `BarSeries` `data` by their `stack` value which forms the stack grouping
+ * (`x` if vertical, `y` if horizontal) and returns `CombinedStackData[]`.
+ */
+export default function combineBarStackData<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>(
+  barSeriesChildren: React.ReactElement<BarSeriesProps<XScale, YScale, Datum>>[],
+  horizontal?: boolean,
+): CombinedStackData<XScale, YScale>[] {
+  const dataByStackValue: {
+    [stackValue: string]: CombinedStackData<XScale, YScale>;
+  } = {};
+
+  barSeriesChildren.forEach(child => {
+    const { dataKey, data, xAccessor, yAccessor } = child.props;
+
+    // this should exist but double check
+    if (!xAccessor || !yAccessor) return;
+
+    const [stackFn, valueFn] = horizontal ? [yAccessor, xAccessor] : [xAccessor, yAccessor];
+
+    data.forEach(d => {
+      const stack = stackFn(d);
+      const numericValue = valueFn(d);
+      const stackKey = String(stack);
+      if (!dataByStackValue[stackKey]) {
+        dataByStackValue[stackKey] = { stack, positiveSum: 0, negativeSum: 0 };
+      }
+      dataByStackValue[stackKey][dataKey] = numericValue;
+      dataByStackValue[stackKey][numericValue >= 0 ? 'positiveSum' : 'negativeSum'] += numericValue;
+    });
+  });
+
+  return Object.values(dataByStackValue);
+}

--- a/packages/visx-xychart/src/utils/findNearestStackDatum.ts
+++ b/packages/visx-xychart/src/utils/findNearestStackDatum.ts
@@ -1,0 +1,44 @@
+import { AxisScale } from '@visx/axis';
+import { getFirstItem, getSecondItem } from '@visx/shape/lib/util/accessors';
+import findNearestDatumY from './findNearestDatumY';
+import findNearestDatumX from './findNearestDatumX';
+import { BarStackDatum, NearestDatumArgs } from '../types';
+
+/**
+ * This is a wrapper around findNearestDatumX/Y for BarStack, accounting for a
+ * Bar's d0 and d1, not just d1 (which findNearestDatum uses). Additionally,
+ * returns the BarSeries original `Datum`, not the `BarStackDatum` so
+ * Tooltip typing is correct.
+ */
+export default function findNearestStackDatum<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>(
+  nearestDatumArgs: NearestDatumArgs<XScale, YScale, BarStackDatum<XScale, YScale>>,
+  barSeriesData: Datum[],
+  horizontal?: boolean,
+) {
+  const { xScale, yScale, point } = nearestDatumArgs;
+  const datum = (horizontal ? findNearestDatumY : findNearestDatumX)(nearestDatumArgs);
+  const barSeriesDatum = datum?.index == null ? null : barSeriesData[datum.index];
+
+  return datum && barSeriesDatum && point
+    ? {
+        index: datum.index,
+        datum: barSeriesDatum,
+        distanceX: horizontal // if mouse is ON the bar, set 0 distance
+          ? point.x >= (xScale(getFirstItem(datum.datum)) ?? Infinity) &&
+            point.x <= (xScale(getSecondItem(datum.datum)) ?? -Infinity)
+            ? 0
+            : datum.distanceX
+          : datum.distanceX,
+        distanceY: horizontal
+          ? datum.distanceY // if mouse is ON the bar, set 0 distance
+          : point.y <= (yScale(getFirstItem(datum.datum)) ?? -Infinity) &&
+            point.y >= (yScale(getSecondItem(datum.datum)) ?? Infinity)
+          ? 0
+          : datum.distanceY,
+      }
+    : null;
+}

--- a/packages/visx-xychart/src/utils/getBarStackRegistryData.ts
+++ b/packages/visx-xychart/src/utils/getBarStackRegistryData.ts
@@ -1,0 +1,47 @@
+import { AxisScale } from '@visx/axis';
+import { getSecondItem } from '@visx/shape/lib/util/accessors';
+import { extent } from 'd3-array';
+import { BarStackData, BarStackDatum, DataRegistryEntry } from '../types';
+
+const getStack = <XScale extends AxisScale, YScale extends AxisScale>(
+  bar: BarStackDatum<XScale, YScale>,
+) => bar?.data?.stack;
+
+const getNumericValue = <XScale extends AxisScale, YScale extends AxisScale>(
+  bar: BarStackDatum<XScale, YScale>,
+) => getSecondItem(bar); // corresponds to y1, the upper value (topline).
+
+/** Constructs the `DataRegistryEntry`s for a BarStack, using the stacked data. */
+export default function getBarStackRegistryData<XScale extends AxisScale, YScale extends AxisScale>(
+  stackedData: BarStackData<XScale, YScale>,
+  comprehensiveDomain: [number, number],
+  horizontal?: boolean,
+) {
+  const [xAccessor, yAccessor] = horizontal
+    ? [getNumericValue, getStack]
+    : [getStack, getNumericValue];
+  return stackedData
+    .map((data, index) => {
+      const entry: DataRegistryEntry<XScale, YScale, BarStackDatum<XScale, YScale>> = {
+        key: data.key,
+        data,
+        xAccessor,
+        yAccessor,
+      };
+
+      // update the numeric domain to account for full data stack
+      // only need to do this for one key
+      if (comprehensiveDomain.length > 0 && index === 0) {
+        if (horizontal) {
+          entry.xScale = scale =>
+            scale.domain(extent(scale.domain().concat(comprehensiveDomain))) as typeof scale;
+        } else {
+          entry.yScale = scale =>
+            scale.domain(extent(scale.domain().concat(comprehensiveDomain))) as typeof scale;
+        }
+      }
+
+      return entry;
+    })
+    .filter(entry => entry) as DataRegistryEntry<XScale, YScale, BarStackDatum<XScale, YScale>>[];
+}

--- a/packages/visx-xychart/test/components/BarStack.test.tsx
+++ b/packages/visx-xychart/test/components/BarStack.test.tsx
@@ -1,0 +1,83 @@
+import React, { useContext } from 'react';
+import { mount } from 'enzyme';
+import { BarStack, BarSeries, DataProvider, DataContext } from '../../src';
+
+const providerProps = {
+  initialDimensions: { width: 100, height: 100 },
+  xScale: { type: 'linear' },
+  yScale: { type: 'linear' },
+} as const;
+
+const accessors = {
+  xAccessor: (d: { x: number }) => d.x,
+  yAccessor: (d: { y: number }) => d.y,
+};
+
+const series1 = {
+  key: 'bar1',
+  data: [
+    { x: 10, y: 5 },
+    { x: 7, y: 5 },
+  ],
+  ...accessors,
+};
+
+const series2 = {
+  key: 'bar2',
+  data: [
+    { x: 10, y: 5 },
+    { x: 7, y: 20 },
+  ],
+  ...accessors,
+};
+
+describe('<BarStack />', () => {
+  it('should be defined', () => {
+    expect(BarSeries).toBeDefined();
+  });
+
+  it('should render rects', () => {
+    const wrapper = mount(
+      <DataProvider {...providerProps}>
+        <svg>
+          <BarStack horizontal>
+            <BarSeries dataKey={series1.key} {...series1} />
+            <BarSeries dataKey={series2.key} {...series2} />
+          </BarStack>
+        </svg>
+      </DataProvider>,
+    );
+    expect(wrapper.find('rect')).toHaveLength(4);
+  });
+
+  it('should update scale domain to include stack sums including negative values', () => {
+    expect.hasAssertions();
+
+    function Assertion() {
+      const { yScale, dataRegistry } = useContext(DataContext);
+      if (yScale && dataRegistry?.keys().length === 2) {
+        expect(yScale.domain()).toEqual([-20, 10]);
+      }
+      return null;
+    }
+
+    mount(
+      <DataProvider {...providerProps}>
+        <svg>
+          <BarStack>
+            <BarSeries dataKey={series1.key} {...series1} />
+            <BarSeries
+              dataKey={series2.key}
+              {...series2}
+              data={[
+                { x: 10, y: 5 },
+                { x: 7, y: -20 },
+              ]}
+            />
+          </BarStack>
+        </svg>
+        <Assertion />
+      </DataProvider>,
+    );
+  });
+});

--- a/packages/visx-xychart/test/mocks/getDataContext.ts
+++ b/packages/visx-xychart/test/mocks/getDataContext.ts
@@ -8,16 +8,18 @@ const height = 10;
 const margin = { top: 0, right: 0, bottom: 0, left: 0 };
 const noOp = () => {};
 
-const getDataContext = (
-  entries?: Parameters<typeof DataRegistry.prototype.registerData>[0],
-): DataContextType<any, any, any> => {
+function getDataContext(entries?: Parameters<typeof DataRegistry.prototype.registerData>[0]) {
   const dataRegistry = new DataRegistry();
   if (entries) dataRegistry.registerData(entries);
 
-  const mockContext = {
+  const mockContext: DataContextType<any, any, any> = {
     dataRegistry,
-    registerData: dataRegistry.registerData,
-    unregisterData: dataRegistry.unregisterData,
+    registerData: data => {
+      dataRegistry.registerData(data);
+    },
+    unregisterData: keys => {
+      dataRegistry.unregisterData(keys);
+    },
     xScale: scaleLinear({ domain: [0, 10], range: [0, width] }),
     yScale: scaleLinear({ domain: [0, 10], range: [0, height] }),
     colorScale: scaleOrdinal({ domain: ['sf', 'ny', 'la'], range: ['purple', 'violet', 'grape'] }),
@@ -31,6 +33,6 @@ const getDataContext = (
   };
 
   return mockContext;
-};
+}
 
 export default getDataContext;

--- a/packages/visx-xychart/test/utils/combineBarStackData.test.tsx
+++ b/packages/visx-xychart/test/utils/combineBarStackData.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { BarSeries } from '../../src';
+import combineBarStackData from '../../src/utils/combineBarStackData';
+
+const accessors = {
+  xAccessor: (d: { x: number }) => d.x,
+  yAccessor: (d: { y: number }) => d.y,
+};
+
+const series1 = {
+  dataKey: 'bar1',
+  data: [
+    { x: 10, y: 5 },
+    { x: 7, y: -5 },
+  ],
+  ...accessors,
+};
+
+const series2 = {
+  dataKey: 'bar2',
+  data: [
+    { x: 10, y: 5 },
+    { x: 7, y: 20 },
+  ],
+  ...accessors,
+};
+
+const seriesChildren = [
+  <BarSeries key={series1.dataKey} {...series1} />,
+  <BarSeries key={series2.dataKey} {...series2} />,
+];
+
+describe('combineBarStackData', () => {
+  it('should be defined', () => {
+    expect(combineBarStackData).toBeDefined();
+  });
+
+  it('should combine data by x stack value when horizontal=false', () => {
+    expect(combineBarStackData(seriesChildren)).toEqual([
+      { stack: 7, bar1: -5, bar2: 20, positiveSum: 20, negativeSum: -5 },
+      { stack: 10, bar1: 5, bar2: 5, positiveSum: 10, negativeSum: 0 },
+    ]);
+  });
+  it('should combine data by y stack value when horizontal=true', () => {
+    expect(combineBarStackData(seriesChildren, true)).toEqual([
+      { stack: 5, bar1: 10, bar2: 10, positiveSum: 20, negativeSum: 0 },
+      { stack: 20, bar1: undefined, bar2: 7, positiveSum: 7, negativeSum: 0 },
+      { stack: -5, bar1: 7, bar2: undefined, positiveSum: 7, negativeSum: 0 },
+    ]);
+  });
+});

--- a/packages/visx-xychart/test/utils/findNearestDatum.test.ts
+++ b/packages/visx-xychart/test/utils/findNearestDatum.test.ts
@@ -9,7 +9,6 @@ import { NearestDatumArgs } from '../../lib';
 type Datum = { xVal: number; yVal: string };
 
 const params: NearestDatumArgs<AxisScale, AxisScale, Datum> = {
-  key: 'visx',
   width: 10,
   height: 10,
   point: { x: 3, y: 8 },

--- a/packages/visx-xychart/test/utils/findNearestDatum.test.ts
+++ b/packages/visx-xychart/test/utils/findNearestDatum.test.ts
@@ -4,7 +4,8 @@ import findNearestDatumX from '../../src/utils/findNearestDatumX';
 import findNearestDatumY from '../../src/utils/findNearestDatumY';
 import findNearestDatumXY from '../../src/utils/findNearestDatumXY';
 import findNearestDatumSingleDimension from '../../src/utils/findNearestDatumSingleDimension';
-import { NearestDatumArgs } from '../../lib';
+import findNearestStackDatum from '../../src/utils/findNearestStackDatum';
+import { BarStackDatum, NearestDatumArgs } from '../../src';
 
 type Datum = { xVal: number; yVal: string };
 
@@ -107,5 +108,30 @@ describe('findNearestDatumSingleDimension', () => {
         scaledValue: 8,
       })!.datum,
     ).toEqual({ xVal: 8, yVal: '8' });
+  });
+});
+
+describe('findNearestStackDatum', () => {
+  it('should be defined', () => {
+    expect(findNearestStackDatum).toBeDefined();
+  });
+
+  it('should find the nearest datum', () => {
+    const d1 = { yVal: '🍌' };
+    const d2 = { yVal: '🚀' };
+    expect(
+      findNearestStackDatum(
+        ({
+          ...params,
+          // type is not technically correct, but coerce for test
+        } as unknown) as NearestDatumArgs<
+          AxisScale,
+          AxisScale,
+          BarStackDatum<AxisScale, AxisScale>
+        >,
+        [d1, d2],
+        true,
+      )!.datum,
+    ).toEqual(d2); // nearest datum index=1
   });
 });


### PR DESCRIPTION
**TODO**
- [x] Add tests (separate PR for reviewability #866 )

#### :rocket: Enhancements

This PR adds `BarStack` to `@visx/xychart` with an API that wraps `BarSeries` (this was planned in the POC, but could simplify in the future): 

```tsx
<BarStack>
  <BarSeries dataKey="sf" data={..} />
  <BarSeries dataKey="ny" data={..} />
</BarStack>
```

It also updates the `/xychart` demo
- adds option to render `BarStack` (in the demo this is not compatible with `LineSeries`/`BarSeries` because they share `dataKey`s so controls are disabled accordingly)
- adds option to render _negative values_. this lets me test that negative stacks work correctly (ditto for other Series types)

**Tooltip**
<img src="https://user-images.githubusercontent.com/4496521/95639733-73b68380-0a4e-11eb-8dc2-70f399bce60e.gif" width="600" />

**Negative values**
<img src="https://user-images.githubusercontent.com/4496521/95639736-774a0a80-0a4e-11eb-8c50-5261a6133d67.gif" width="600" />

**Horizontal**
<img src="https://user-images.githubusercontent.com/4496521/95639742-84ff9000-0a4e-11eb-9172-2fd592157fa6.png" width="600" />


Some notes on the implementation
- The general flow is:
  1) collect `props.data` from child `BarSeries`
  2) create combined stacked data structure (using child `props.dataKey`)
  3) register data in the `DataContext` for each child `dataKey`, but update `data` + `x/yAccessor` to use the stacked data (so that scales are computed correctly)
  4) render `BarStack` using data + scales from `DataContext`

- I first wrote this using `@visx/shape`s `BarStack(Horizontal)`, but it doesn't allow us to use the stacked data independently of their scaled values (i.e., it creates the stack data structure **and** scales the stacked values). For the `DataContext` scales + `findNearestDatum` functions (`TooltipContext`), we need to add the stacked data itself as described in prev point

- `BarStack`s implementation is currently is incompatible with `Tooltip.snapTooltipToDatumX/Y`. 
  - This is tricky because `Tooltip` attempts to use `DataContext` for `data` + `x/yAccessor`s to map the `TooltipContext.tooltipData` to the scaled positions. However `tooltipData` is typed as `Datum`, and the `x/yAccessor`s + `x/yScale`s from `DataContext` use the stacked `SeriesDatum` type. Will noodle on this more.

@kristw @techniq 