### PR TITLE
new(xychart): add BarGroup

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -4,6 +4,7 @@ import {
   AnimatedAxis,
   AnimatedGrid,
   DataProvider,
+  BarGroup,
   BarSeries,
   BarStack,
   LineSeries,
@@ -29,6 +30,7 @@ export default function Example({ height }: Props) {
         config,
         data,
         numTicks,
+        renderBarGroup,
         renderBarSeries,
         renderBarStack,
         renderHorizontally,
@@ -56,28 +58,48 @@ export default function Example({ height }: Props) {
               numTicks={numTicks}
             />
             {renderBarStack && (
-              <g fillOpacity={renderLineSeries ? 0.5 : 1}>
-                <BarStack horizontal={renderHorizontally}>
-                  <BarSeries
-                    dataKey="New York"
-                    data={data}
-                    xAccessor={accessors.x['New York']}
-                    yAccessor={accessors.y['New York']}
-                  />
-                  <BarSeries
-                    dataKey="San Francisco"
-                    data={data}
-                    xAccessor={accessors.x['San Francisco']}
-                    yAccessor={accessors.y['San Francisco']}
-                  />
-                  <BarSeries
-                    dataKey="Austin"
-                    data={data}
-                    xAccessor={accessors.x.Austin}
-                    yAccessor={accessors.y.Austin}
-                  />
-                </BarStack>
-              </g>
+              <BarStack horizontal={renderHorizontally}>
+                <BarSeries
+                  dataKey="New York"
+                  data={data}
+                  xAccessor={accessors.x['New York']}
+                  yAccessor={accessors.y['New York']}
+                />
+                <BarSeries
+                  dataKey="San Francisco"
+                  data={data}
+                  xAccessor={accessors.x['San Francisco']}
+                  yAccessor={accessors.y['San Francisco']}
+                />
+                <BarSeries
+                  dataKey="Austin"
+                  data={data}
+                  xAccessor={accessors.x.Austin}
+                  yAccessor={accessors.y.Austin}
+                />
+              </BarStack>
+            )}
+            {renderBarGroup && (
+              <BarGroup horizontal={renderHorizontally}>
+                <BarSeries
+                  dataKey="New York"
+                  data={data}
+                  xAccessor={accessors.x['New York']}
+                  yAccessor={accessors.y['New York']}
+                />
+                <BarSeries
+                  dataKey="San Francisco"
+                  data={data}
+                  xAccessor={accessors.x['San Francisco']}
+                  yAccessor={accessors.y['San Francisco']}
+                />
+                <BarSeries
+                  dataKey="Austin"
+                  data={data}
+                  xAccessor={accessors.x.Austin}
+                  yAccessor={accessors.y.Austin}
+                />
+              </BarGroup>
             )}
             {renderBarSeries && (
               <BarSeries
@@ -125,8 +147,8 @@ export default function Example({ height }: Props) {
                 showVerticalCrosshair={showVerticalCrosshair}
                 snapTooltipToDatumX={snapTooltipToDatumX}
                 snapTooltipToDatumY={snapTooltipToDatumY}
-                showDatumGlyph={snapTooltipToDatumX || snapTooltipToDatumY}
-                showSeriesGlyphs={sharedTooltip}
+                showDatumGlyph={(snapTooltipToDatumX || snapTooltipToDatumY) && !renderBarGroup}
+                showSeriesGlyphs={sharedTooltip && !renderBarGroup}
                 renderTooltip={({ tooltipData, colorScale }) => (
                   <>
                     {/** date */}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -9,7 +9,7 @@ const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const temperatureScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
 const data = cityTemperature.slice(200, 275);
-const dataSmall = data.slice(25);
+const dataSmall = data.slice(0, 25);
 const getDate = (d: CityTemperature) => d.date;
 const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNegativeSFTemperature = (d: CityTemperature) => -getSfTemperature(d);
@@ -42,6 +42,7 @@ type ProvidedProps = {
   renderHorizontally: boolean;
   renderBarSeries: boolean;
   renderBarStack: boolean;
+  renderBarGroup: boolean;
   renderLineSeries: boolean;
   sharedTooltip: boolean;
   showGridColumns: boolean;
@@ -74,7 +75,9 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [snapTooltipToDatumX, setSnapTooltipToDatumX] = useState(true);
   const [snapTooltipToDatumY, setSnapTooltipToDatumY] = useState(true);
   const [sharedTooltip, setSharedTooltip] = useState(true);
-  const [renderBarOrBarStack, setRenderBarOrBarStack] = useState<'bar' | 'barstack'>('barstack');
+  const [renderBarStackOrGroup, setRenderBarStackOrGroup] = useState<'bar' | 'stack' | 'group'>(
+    'group',
+  );
   const [renderLineSeries, setRenderLineSeries] = useState(false);
   const [negativeValues, setNegativeValues] = useState(false);
 
@@ -117,20 +120,21 @@ export default function ExampleControls({ children }: ControlsProps) {
         accessors,
         animationTrajectory,
         config,
-        data: renderBarOrBarStack === 'bar' ? data : dataSmall,
+        data: renderBarStackOrGroup === 'bar' ? data : dataSmall,
         numTicks,
-        renderBarSeries: renderBarOrBarStack === 'bar',
-        renderBarStack: renderBarOrBarStack === 'barstack',
+        renderBarGroup: renderBarStackOrGroup === 'group',
+        renderBarSeries: renderBarStackOrGroup === 'bar',
+        renderBarStack: renderBarStackOrGroup === 'stack',
         renderHorizontally,
-        renderLineSeries: renderBarOrBarStack === 'bar' && renderLineSeries,
+        renderLineSeries: renderBarStackOrGroup === 'bar' && renderLineSeries,
         sharedTooltip,
         showGridColumns,
         showGridRows,
         showHorizontalCrosshair,
         showTooltip,
         showVerticalCrosshair,
-        snapTooltipToDatumX: renderBarOrBarStack === 'bar' && snapTooltipToDatumX,
-        snapTooltipToDatumY: renderBarOrBarStack === 'bar' && snapTooltipToDatumY,
+        snapTooltipToDatumX: renderBarStackOrGroup !== 'stack' && snapTooltipToDatumX,
+        snapTooltipToDatumY: renderBarStackOrGroup !== 'stack' && snapTooltipToDatumY,
         theme,
         xAxisOrientation,
         yAxisOrientation,
@@ -310,7 +314,7 @@ export default function ExampleControls({ children }: ControlsProps) {
           <label>
             <input
               type="checkbox"
-              disabled={!showTooltip || renderBarOrBarStack === 'barstack'}
+              disabled={!showTooltip || renderBarStackOrGroup === 'stack'}
               onChange={() => setSnapTooltipToDatumX(!snapTooltipToDatumX)}
               checked={showTooltip && snapTooltipToDatumX}
             />{' '}
@@ -319,7 +323,7 @@ export default function ExampleControls({ children }: ControlsProps) {
           <label>
             <input
               type="checkbox"
-              disabled={!showTooltip || renderBarOrBarStack === 'barstack'}
+              disabled={!showTooltip || renderBarStackOrGroup === 'stack'}
               onChange={() => setSnapTooltipToDatumY(!snapTooltipToDatumY)}
               checked={showTooltip && snapTooltipToDatumY}
             />{' '}
@@ -359,26 +363,36 @@ export default function ExampleControls({ children }: ControlsProps) {
           <label>
             <input
               type="checkbox"
+              disabled={renderBarStackOrGroup !== 'bar'}
               onChange={() => setRenderLineSeries(!renderLineSeries)}
               checked={renderLineSeries}
             />{' '}
             line
           </label>
+          &nbsp;&nbsp;&nbsp;&nbsp;
           <label>
             <input
               type="radio"
-              onChange={() => setRenderBarOrBarStack('bar')}
-              checked={renderBarOrBarStack === 'bar'}
+              onChange={() => setRenderBarStackOrGroup('bar')}
+              checked={renderBarStackOrGroup === 'bar'}
             />{' '}
             bar
           </label>
           <label>
             <input
               type="radio"
-              onChange={() => setRenderBarOrBarStack('barstack')}
-              checked={renderBarOrBarStack === 'barstack'}
+              onChange={() => setRenderBarStackOrGroup('stack')}
+              checked={renderBarStackOrGroup === 'stack'}
             />{' '}
             bar stack
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderBarStackOrGroup('group')}
+              checked={renderBarStackOrGroup === 'group'}
+            />{' '}
+            bar group
           </label>
         </div>
         {/** data */}

--- a/packages/visx-xychart/src/components/series/BarGroup.tsx
+++ b/packages/visx-xychart/src/components/series/BarGroup.tsx
@@ -83,7 +83,6 @@ export default function BarGroup<
       // and let Tooltip find the nearest point among them
       dataKeys.forEach(key => {
         const entry = dataRegistry.get(key);
-
         if (entry && svgPoint && width && height && showTooltip) {
           const datum = (horizontal ? findNearestDatumY : findNearestDatumX)({
             point: svgPoint,

--- a/packages/visx-xychart/src/components/series/BarGroup.tsx
+++ b/packages/visx-xychart/src/components/series/BarGroup.tsx
@@ -1,0 +1,177 @@
+import React, { useContext, useCallback, useMemo, useEffect } from 'react';
+import { PositionScale } from '@visx/shape/lib/types';
+import { scaleBand } from '@visx/scale';
+import isChildWithProps from '../../typeguards/isChildWithProps';
+import { BarSeriesProps } from './BarSeries';
+import { DataContextType } from '../../types';
+import DataContext from '../../context/DataContext';
+import getScaleBandwidth from '../../utils/getScaleBandwidth';
+import isValidNumber from '../../typeguards/isValidNumber';
+import findNearestDatumY from '../../utils/findNearestDatumY';
+import findNearestDatumX from '../../utils/findNearestDatumX';
+import useEventEmitter, { HandlerParams } from '../../hooks/useEventEmitter';
+import TooltipContext from '../../context/TooltipContext';
+
+export type BarGroupProps = {
+  /** Whether to render the Stack horizontally instead of vertically. */
+  horizontal?: boolean;
+  /** `BarSeries` elements */
+  children: JSX.Element | JSX.Element[];
+  /** Group band scale padding, [0, 1] where 0 = no padding, 1 = no bar. */
+  padding?: number;
+  /** Comparator function to sort `dataKeys` within a bar group. By default the DOM rendering order of `BarGroup`s `children` is used. */
+  sortBars?: (dataKeyA: string, dataKeyB: string) => number;
+};
+
+export default function BarGroup<
+  XScale extends PositionScale,
+  YScale extends PositionScale,
+  Datum extends object
+>({ children, horizontal, padding = 0.1, sortBars }: BarGroupProps) {
+  const {
+    xScale,
+    yScale,
+    colorScale,
+    dataRegistry,
+    registerData,
+    unregisterData,
+    width,
+    height,
+  } = (useContext(DataContext) as unknown) as DataContextType<XScale, YScale, Datum>;
+
+  const barSeriesChildren = useMemo(
+    () =>
+      React.Children.toArray(children).filter(child =>
+        isChildWithProps<BarSeriesProps<XScale, YScale, Datum>>(child),
+      ),
+    [children],
+  ) as React.ReactElement<BarSeriesProps<XScale, YScale, Datum>>[];
+
+  // extract data keys from child series
+  const dataKeys: string[] = useMemo(
+    () => barSeriesChildren.map(child => child.props.dataKey ?? '').filter(key => key),
+    [barSeriesChildren],
+  );
+
+  // register all child data
+  useEffect(() => {
+    const dataToRegister = barSeriesChildren.map(child => {
+      const { dataKey: key, data, xAccessor, yAccessor } = child.props;
+      return { key, data, xAccessor, yAccessor };
+    });
+
+    registerData(dataToRegister);
+    return () => unregisterData(dataKeys);
+  }, [registerData, unregisterData, barSeriesChildren, dataKeys]);
+
+  // create group scale
+  const groupScale = useMemo(
+    () =>
+      scaleBand<string>({
+        domain: sortBars ? [...dataKeys].sort(sortBars) : dataKeys,
+        range: [0, getScaleBandwidth(horizontal ? yScale : xScale)],
+        padding,
+      }),
+    [sortBars, dataKeys, xScale, yScale, horizontal, padding],
+  );
+
+  const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
+  const handleMouseMove = useCallback(
+    (params?: HandlerParams) => {
+      const { svgPoint } = params || {};
+      // invoke showTooltip for each key so all data is available in context,
+      // and let Tooltip find the nearest point among them
+      dataKeys.forEach(key => {
+        const entry = dataRegistry.get(key);
+
+        if (entry && svgPoint && width && height && showTooltip) {
+          const datum = (horizontal ? findNearestDatumY : findNearestDatumX)({
+            point: svgPoint,
+            data: entry.data,
+            xScale,
+            yScale,
+            xAccessor: entry.xAccessor,
+            yAccessor: entry.yAccessor,
+            width,
+            height,
+          });
+          if (datum) {
+            showTooltip({
+              key,
+              ...datum,
+              svgPoint,
+            });
+          }
+        }
+      });
+    },
+    [dataKeys, dataRegistry, horizontal, xScale, yScale, width, height, showTooltip],
+  );
+  useEventEmitter('mousemove', handleMouseMove);
+  useEventEmitter('mouseout', hideTooltip);
+
+  const registryEntries = dataKeys.map(key => dataRegistry.get(key));
+
+  // if scales and data are not available in the registry, bail
+  if (registryEntries.some(entry => entry == null) || !xScale || !yScale || !colorScale) {
+    return null;
+  }
+
+  const [xMin, xMax] = xScale.range().map(Number);
+  const [yMax, yMin] = yScale.range().map(Number);
+
+  // try to figure out the 0 baseline for correct rendering of negative values
+  // we aren't sure if these are numeric scales or not ahead of time
+  const maybeXZero = xScale(0) ?? 0;
+  const maybeYZero = yScale(0) ?? 0;
+  const xZeroPosition = isValidNumber(maybeXZero)
+    ? // if maybeXZero _is_ a number, but the scale is not clamped and it's outside the domain
+      // fallback to the scale's minimum
+      Math.max(maybeXZero, Math.min(xMin, xMax))
+    : Math.min(xMin, xMax);
+  const yZeroPosition = isValidNumber(maybeYZero)
+    ? Math.min(maybeYZero, Math.max(yMin, yMax))
+    : Math.max(yMin, yMax);
+
+  const barThickness = getScaleBandwidth(groupScale);
+
+  return (
+    <g className="visx-bar-group">
+      {registryEntries.map(({ xAccessor, yAccessor, data, key }) => {
+        const getLength = (d: Datum) =>
+          horizontal
+            ? (xScale(xAccessor(d)) ?? 0) - xZeroPosition
+            : (yScale(yAccessor(d)) ?? 0) - yZeroPosition;
+
+        const getGroupPosition = horizontal
+          ? (d: Datum) => yScale(yAccessor(d)) ?? 0
+          : (d: Datum) => xScale(xAccessor(d)) ?? 0;
+
+        const withinGroupPosition = groupScale(key) ?? 0;
+
+        const getX = horizontal
+          ? (d: Datum) => xZeroPosition + Math.min(0, getLength(d))
+          : (d: Datum) => getGroupPosition(d) + withinGroupPosition;
+
+        const getY = horizontal
+          ? (d: Datum) => getGroupPosition(d) + withinGroupPosition
+          : (d: Datum) => yZeroPosition + Math.min(0, getLength(d));
+
+        const getWidth = horizontal ? (d: Datum) => Math.abs(getLength(d)) : () => barThickness;
+        const getHeight = horizontal ? () => barThickness : (d: Datum) => Math.abs(getLength(d));
+
+        return data.map((datum, index) => (
+          <rect
+            key={`${key}-${index}`}
+            x={getX(datum)}
+            y={getY(datum)}
+            width={getWidth(datum)}
+            height={getHeight(datum)}
+            fill={colorScale(key)}
+            stroke="transparent"
+          />
+        ));
+      })}
+    </g>
+  );
+}

--- a/packages/visx-xychart/src/components/series/BarStack.tsx
+++ b/packages/visx-xychart/src/components/series/BarStack.tsx
@@ -97,8 +97,9 @@ function BarStack<
     registerData(dataToRegister);
 
     // unregister data on unmount
-    return () => unregisterData(Object.keys(dataToRegister));
+    return () => unregisterData(dataKeys);
   }, [
+    dataKeys,
     comprehensiveDomain,
     horizontal,
     stackedData,

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -7,6 +7,7 @@ export { default as Tooltip } from './components/Tooltip';
 export { default as XYChart } from './components/XYChart';
 
 // series components
+export { default as BarGroup } from './components/series/BarGroup';
 export { default as BarSeries } from './components/series/BarSeries';
 export { default as BarStack } from './components/series/BarStack';
 export { default as LineSeries } from './components/series/LineSeries';

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -24,6 +24,9 @@ export { default as EventEmitterProvider } from './providers/EventEmitterProvide
 export { default as ThemeProvider } from './providers/ThemeProvider';
 export { default as TooltipProvider } from './providers/TooltipProvider';
 
+// hooks
+export { default as useEventEmitter } from './hooks/useEventEmitter';
+
 // themes
 export { default as lightTheme } from './theme/themes/light';
 export { default as darkTheme } from './theme/themes/dark';

--- a/packages/visx-xychart/test/__mocks__/@visx/event.ts
+++ b/packages/visx-xychart/test/__mocks__/@visx/event.ts
@@ -1,0 +1,8 @@
+export function localPoint() {
+  return {
+    x: 5,
+    y: 3,
+    value: () => ({ x: 5, y: 3 }),
+    toArray: () => [5, 3],
+  };
+}

--- a/packages/visx-xychart/test/components/BarGroup.test.tsx
+++ b/packages/visx-xychart/test/components/BarGroup.test.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { mount } from 'enzyme';
-import { BarStack, BarSeries, DataProvider, DataContext, useEventEmitter } from '../../src';
+import { BarGroup, BarSeries, DataProvider, useEventEmitter } from '../../src';
 import setupTooltipTest from '../mocks/setupTooltipTest';
 
 const providerProps = {
@@ -32,7 +32,7 @@ const series2 = {
   ...accessors,
 };
 
-describe('<BarStack />', () => {
+describe('<BarGroup />', () => {
   it('should be defined', () => {
     expect(BarSeries).toBeDefined();
   });
@@ -41,45 +41,14 @@ describe('<BarStack />', () => {
     const wrapper = mount(
       <DataProvider {...providerProps}>
         <svg>
-          <BarStack horizontal>
+          <BarGroup horizontal>
             <BarSeries dataKey={series1.key} {...series1} />
             <BarSeries dataKey={series2.key} {...series2} />
-          </BarStack>
+          </BarGroup>
         </svg>
       </DataProvider>,
     );
     expect(wrapper.find('rect')).toHaveLength(4);
-  });
-
-  it('should update scale domain to include stack sums including negative values', () => {
-    expect.hasAssertions();
-
-    function Assertion() {
-      const { yScale, dataRegistry } = useContext(DataContext);
-      if (yScale && dataRegistry?.keys().length === 2) {
-        expect(yScale.domain()).toEqual([-20, 10]);
-      }
-      return null;
-    }
-
-    mount(
-      <DataProvider {...providerProps}>
-        <svg>
-          <BarStack>
-            <BarSeries dataKey={series1.key} {...series1} />
-            <BarSeries
-              dataKey={series2.key}
-              {...series2}
-              data={[
-                { x: 10, y: 5 },
-                { x: 7, y: -20 },
-              ]}
-            />
-          </BarStack>
-        </svg>
-        <Assertion />
-      </DataProvider>,
-    );
   });
 
   it('should invoke showTooltip/hideTooltip on mousemove/mouseout', () => {
@@ -108,10 +77,10 @@ describe('<BarStack />', () => {
 
     setupTooltipTest(
       <>
-        <BarStack horizontal>
+        <BarGroup horizontal>
           <BarSeries dataKey={series1.key} {...series1} />
           <BarSeries dataKey={series2.key} {...series2} />
-        </BarStack>
+        </BarGroup>
         <EventEmitter />
       </>,
       { showTooltip, hideTooltip },

--- a/packages/visx-xychart/test/components/BarSeries.test.tsx
+++ b/packages/visx-xychart/test/components/BarSeries.test.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { mount } from 'enzyme';
-import { DataContext, BarSeries } from '../../src';
+import { DataContext, BarSeries, useEventEmitter } from '../../src';
 import getDataContext from '../mocks/getDataContext';
+import setupTooltipTest from '../mocks/setupTooltipTest';
+
+const series = { key: 'bar', data: [{}, {}], xAccessor: () => 0, yAccessor: () => 10 };
 
 describe('<BarSeries />', () => {
   it('should be defined', () => {
     expect(BarSeries).toBeDefined();
   });
 
-  it('should render a LinePath', () => {
-    const series = { key: 'bar', data: [{}, {}], xAccessor: () => 0, yAccessor: () => 10 };
+  it('should render rects', () => {
     const wrapper = mount(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
@@ -18,5 +20,45 @@ describe('<BarSeries />', () => {
       </DataContext.Provider>,
     );
     expect(wrapper.find('rect')).toHaveLength(2);
+  });
+
+  it('should invoke showTooltip/hideTooltip on mousemove/mouseout', () => {
+    expect.assertions(2);
+
+    const showTooltip = jest.fn();
+    const hideTooltip = jest.fn();
+
+    const ConditionalEventEmitter = () => {
+      const { dataRegistry } = useContext(DataContext);
+      // BarSeries won't render until its data is registered
+      // wait for that to emit the events
+      return dataRegistry?.get(series.key) ? <EventEmitter /> : null;
+    };
+
+    const EventEmitter = () => {
+      const emit = useEventEmitter();
+
+      useEffect(() => {
+        if (emit) {
+          // @ts-ignore not a React.MouseEvent
+          emit('mousemove', new MouseEvent('mousemove'));
+          expect(showTooltip).toHaveBeenCalledTimes(1);
+
+          // @ts-ignore not a React.MouseEvent
+          emit('mouseout', new MouseEvent('mouseout'));
+          expect(showTooltip).toHaveBeenCalledTimes(1);
+        }
+      });
+
+      return null;
+    };
+
+    setupTooltipTest(
+      <>
+        <BarSeries dataKey={series.key} {...series} />
+        <ConditionalEventEmitter />
+      </>,
+      { showTooltip, hideTooltip },
+    );
   });
 });

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { mount } from 'enzyme';
 import { LinePath } from '@visx/shape';
-import { DataContext, LineSeries } from '../../src';
+import { DataContext, LineSeries, useEventEmitter } from '../../src';
 import getDataContext from '../mocks/getDataContext';
+import setupTooltipTest from '../mocks/setupTooltipTest';
+
+const series = { key: 'line', data: [{}], xAccessor: () => 4, yAccessor: () => 7 };
 
 describe('<LineSeries />', () => {
   it('should be defined', () => {
@@ -10,7 +13,6 @@ describe('<LineSeries />', () => {
   });
 
   it('should render a LinePath', () => {
-    const series = { key: 'line', data: [], xAccessor: () => 'x', yAccessor: () => '7' };
     const wrapper = mount(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
@@ -20,5 +22,45 @@ describe('<LineSeries />', () => {
     );
     // @ts-ignore produces a union type that is too complex to represent.ts(2590)
     expect(wrapper.find(LinePath)).toHaveLength(1);
+  });
+
+  it('should invoke showTooltip/hideTooltip on mousemove/mouseout', () => {
+    expect.assertions(2);
+
+    const showTooltip = jest.fn();
+    const hideTooltip = jest.fn();
+
+    const ConditionalEventEmitter = () => {
+      const { dataRegistry } = useContext(DataContext);
+      // LineSeries won't render until its data is registered
+      // wait for that to emit the events
+      return dataRegistry?.get(series.key) ? <EventEmitter /> : null;
+    };
+
+    const EventEmitter = () => {
+      const emit = useEventEmitter();
+
+      useEffect(() => {
+        if (emit) {
+          // @ts-ignore not a React.MouseEvent
+          emit('mousemove', new MouseEvent('mousemove'));
+          expect(showTooltip).toHaveBeenCalledTimes(1);
+
+          // @ts-ignore not a React.MouseEvent
+          emit('mouseout', new MouseEvent('mouseout'));
+          expect(showTooltip).toHaveBeenCalledTimes(1);
+        }
+      });
+
+      return null;
+    };
+
+    setupTooltipTest(
+      <>
+        <LineSeries dataKey={series.key} {...series} />
+        <ConditionalEventEmitter />
+      </>,
+      { showTooltip, hideTooltip },
+    );
   });
 });

--- a/packages/visx-xychart/test/mocks/setupTooltipTest.tsx
+++ b/packages/visx-xychart/test/mocks/setupTooltipTest.tsx
@@ -1,0 +1,35 @@
+/* eslint import/no-extraneous-dependencies: 'off' */
+import React from 'react';
+import { mount } from 'enzyme';
+import { DataProvider, EventEmitterProvider, TooltipContext, TooltipContextType } from '../../src';
+
+const providerProps = {
+  initialDimensions: { width: 100, height: 100 },
+  xScale: { type: 'linear' },
+  yScale: { type: 'linear' },
+} as const;
+
+const defaultTooltipContext = {
+  tooltipOpen: false,
+  /* eslint-disable no-undef */
+  showTooltip: jest.fn(), // eslint doesn't know jest is in context in non-.test file
+  updateTooltip: jest.fn(),
+  hideTooltip: jest.fn(),
+  /* eslint-enable no-undef */
+};
+
+// sets up boilerplate context for testing tooltips
+export default function setupTooltipTest(
+  children: React.ReactNode,
+  tooltipContext?: Partial<TooltipContextType<object>>,
+) {
+  return mount(
+    <DataProvider {...providerProps}>
+      <EventEmitterProvider>
+        <TooltipContext.Provider value={{ ...defaultTooltipContext, ...tooltipContext }}>
+          <svg>{children}</svg>
+        </TooltipContext.Provider>
+      </EventEmitterProvider>
+    </DataProvider>,
+  );
+}


### PR DESCRIPTION
**TODO**
- [x] update base branch to `master` when `BarStack` #865 is merged 
- [x] add tests (#871, separate PR for ease of review)

#### :rocket: Enhancements

This adds a `BarGroup` series to `@visx/xychart` which supports tooltips, negative values, and horizontal rendering like other `*Series`. It updates the `/xychart` demo to include it.

<img src="https://user-images.githubusercontent.com/4496521/95930446-526dd400-0d7b-11eb-80a7-f2dd5ed49edd.gif" width="600" />

@kristw @techniq