### PR TITLE
fix(demo/areas): handle non-zero margins

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-area/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-area/Example.tsx
@@ -60,19 +60,19 @@ export default withTooltip<AreaProps, TooltipData>(
     const dateScale = useMemo(
       () =>
         scaleTime({
-          range: [margin.left, width - margin.right],
+          range: [margin.left, innerWidth + margin.left],
           domain: extent(stock, getDate) as [Date, Date],
         }),
-      [width, margin.left, margin.right],
+      [innerWidth, margin.left],
     );
     const stockValueScale = useMemo(
       () =>
         scaleLinear({
-          range: [height - margin.bottom, margin.top],
+          range: [innerHeight + margin.top, margin.top],
           domain: [0, (max(stock, getStockValue) || 0) + innerHeight / 3],
           nice: true,
         }),
-      [height, margin.bottom, margin.top, innerHeight],
+      [margin.top, innerHeight],
     );
 
     // tooltip handler
@@ -140,8 +140,8 @@ export default withTooltip<AreaProps, TooltipData>(
           <Bar
             x={margin.left}
             y={margin.top}
-            width={width - margin.left - margin.right}
-            height={height - margin.top - margin.bottom}
+            width={innerWidth}
+            height={innerHeight}
             fill="transparent"
             rx={14}
             onTouchStart={handleTooltip}

--- a/packages/visx-demo/src/sandboxes/visx-area/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-area/Example.tsx
@@ -4,7 +4,7 @@ import appleStock, { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
 import { curveMonotoneX } from '@visx/curve';
 import { GridRows, GridColumns } from '@visx/grid';
 import { scaleTime, scaleLinear } from '@visx/scale';
-import { withTooltip, Tooltip, defaultStyles } from '@visx/tooltip';
+import { withTooltip, Tooltip, TooltipWithBounds, defaultStyles } from '@visx/tooltip';
 import { WithTooltipProvidedProps } from '@visx/tooltip/lib/enhancers/withTooltip';
 import { localPoint } from '@visx/event';
 import { LinearGradient } from '@visx/gradient';
@@ -53,26 +53,26 @@ export default withTooltip<AreaProps, TooltipData>(
     if (width < 10) return null;
 
     // bounds
-    const xMax = width - margin.left - margin.right;
-    const yMax = height - margin.top - margin.bottom;
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
 
     // scales
     const dateScale = useMemo(
       () =>
         scaleTime({
-          range: [0, xMax],
+          range: [margin.left, width - margin.right],
           domain: extent(stock, getDate) as [Date, Date],
         }),
-      [xMax],
+      [width, margin.left, margin.right],
     );
     const stockValueScale = useMemo(
       () =>
         scaleLinear({
-          range: [yMax, 0],
-          domain: [0, (max(stock, getStockValue) || 0) + yMax / 3],
+          range: [height - margin.bottom, margin.top],
+          domain: [0, (max(stock, getStockValue) || 0) + innerHeight / 3],
           nice: true,
         }),
-      [yMax],
+      [height, margin.bottom, margin.top, innerHeight],
     );
 
     // tooltip handler
@@ -110,16 +110,18 @@ export default withTooltip<AreaProps, TooltipData>(
           <LinearGradient id="area-background-gradient" from={background} to={background2} />
           <LinearGradient id="area-gradient" from={accentColor} to={accentColor} toOpacity={0.1} />
           <GridRows
+            left={margin.left}
             scale={stockValueScale}
-            width={xMax}
+            width={innerWidth}
             strokeDasharray="3,3"
             stroke={accentColor}
             strokeOpacity={0.3}
             pointerEvents="none"
           />
           <GridColumns
+            top={margin.top}
             scale={dateScale}
-            height={yMax}
+            height={innerHeight}
             strokeDasharray="3,3"
             stroke={accentColor}
             strokeOpacity={0.3}
@@ -136,10 +138,10 @@ export default withTooltip<AreaProps, TooltipData>(
             curve={curveMonotoneX}
           />
           <Bar
-            x={0}
-            y={0}
-            width={width}
-            height={height}
+            x={margin.left}
+            y={margin.top}
+            width={width - margin.left - margin.right}
+            height={height - margin.top - margin.bottom}
             fill="transparent"
             rx={14}
             onTouchStart={handleTooltip}
@@ -150,8 +152,8 @@ export default withTooltip<AreaProps, TooltipData>(
           {tooltipData && (
             <g>
               <Line
-                from={{ x: tooltipLeft, y: 0 }}
-                to={{ x: tooltipLeft, y: yMax }}
+                from={{ x: tooltipLeft, y: margin.top }}
+                to={{ x: tooltipLeft, y: innerHeight + margin.top }}
                 stroke={accentColorDark}
                 strokeWidth={2}
                 pointerEvents="none"
@@ -182,11 +184,16 @@ export default withTooltip<AreaProps, TooltipData>(
         </svg>
         {tooltipData && (
           <div>
-            <Tooltip top={tooltipTop - 12} left={tooltipLeft + 12} style={tooltipStyles}>
+            <TooltipWithBounds
+              key={Math.random()}
+              top={tooltipTop - 12}
+              left={tooltipLeft + 12}
+              style={tooltipStyles}
+            >
               {`$${getStockValue(tooltipData)}`}
-            </Tooltip>
+            </TooltipWithBounds>
             <Tooltip
-              top={yMax - 14}
+              top={innerHeight + margin.top - 14}
               left={tooltipLeft}
               style={{
                 ...defaultStyles,


### PR DESCRIPTION
#### :bug: Bug Fix

This fixes an issue with the `/areas` demo where it doesn't correctly handle non-zero margins (note: the demo isn't updated with non-zero margins, it just handles them correctly if users tweak them in the sandbox, etc.)

Can play with the updated sandbox [here](https://codesandbox.io/s/github/airbnb/visx/tree/chris--fix-areas-demo/packages/visx-demo/src/sandboxes/visx-area?file=/Example.tsx) (link will break when PR is merged)

**before**
![areas-before](https://user-images.githubusercontent.com/4496521/96307191-0b1f5780-0fb6-11eb-998a-97069bb7e268.gif)

**after**
![areas-after](https://user-images.githubusercontent.com/4496521/96307188-08bcfd80-0fb6-11eb-98b6-2178c1775cf0.gif)

@kristw @hshoff