### PR TITLE
new(xychart): add AreaSeries + AnimatedAreaSeries

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -120,7 +120,7 @@ export default function Example({ height }: Props) {
                   xAccessor={accessors.x.Austin}
                   yAccessor={accessors.y.Austin}
                   horizontal={renderHorizontally}
-                  fillOpacity={0.2}
+                  fillOpacity={0.3}
                 />
                 <AnimatedAreaSeries
                   dataKey="San Francisco"
@@ -128,7 +128,7 @@ export default function Example({ height }: Props) {
                   xAccessor={accessors.x['San Francisco']}
                   yAccessor={accessors.y['San Francisco']}
                   horizontal={renderHorizontally}
-                  fillOpacity={0.2}
+                  fillOpacity={0.3}
                 />
               </>
             )}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CityTemperature } from '@visx/mock-data/lib/mocks/cityTemperature';
 import {
+  AnimatedAreaSeries,
   AnimatedAxis,
   AnimatedBarGroup,
   AnimatedBarSeries,
@@ -34,6 +35,7 @@ export default function Example({ height }: Props) {
         renderBarSeries,
         renderBarStack,
         renderHorizontally,
+        renderAreaSeries,
         renderLineSeries,
         sharedTooltip,
         showGridColumns,
@@ -110,21 +112,41 @@ export default function Example({ height }: Props) {
                 horizontal={renderHorizontally}
               />
             )}
-            {renderLineSeries && (
+            {renderAreaSeries && (
               <>
-                <AnimatedLineSeries
+                <AnimatedAreaSeries
+                  dataKey="Austin"
+                  data={renderBarStack ? data : data}
+                  xAccessor={accessors.x.Austin}
+                  yAccessor={accessors.y.Austin}
+                  horizontal={renderHorizontally}
+                  fillOpacity={0.2}
+                />
+                <AnimatedAreaSeries
                   dataKey="San Francisco"
                   data={renderBarStack ? data : data}
                   xAccessor={accessors.x['San Francisco']}
                   yAccessor={accessors.y['San Francisco']}
-                  horizontal={!renderHorizontally}
+                  horizontal={renderHorizontally}
+                  fillOpacity={0.2}
                 />
+              </>
+            )}
+            {renderLineSeries && (
+              <>
                 <AnimatedLineSeries
                   dataKey="Austin"
                   data={renderBarStack ? data : data}
                   xAccessor={accessors.x.Austin}
                   yAccessor={accessors.y.Austin}
-                  horizontal={!renderHorizontally}
+                  horizontal={renderHorizontally}
+                />
+                <AnimatedLineSeries
+                  dataKey="San Francisco"
+                  data={renderBarStack ? data : data}
+                  xAccessor={accessors.x['San Francisco']}
+                  yAccessor={accessors.y['San Francisco']}
+                  horizontal={renderHorizontally}
                 />
               </>
             )}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -8,8 +8,7 @@ import customTheme from './customTheme';
 const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const temperatureScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
-const data = cityTemperature.slice(200, 275);
-const dataSmall = data.slice(0, 20);
+const data = cityTemperature.slice(225, 275);
 const getDate = (d: CityTemperature) => d.date;
 const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNegativeSfTemperature = (d: CityTemperature) => -getSfTemperature(d);
@@ -40,9 +39,10 @@ type ProvidedProps = {
   data: CityTemperature[];
   numTicks: number;
   renderHorizontally: boolean;
+  renderAreaSeries: boolean;
+  renderBarGroup: boolean;
   renderBarSeries: boolean;
   renderBarStack: boolean;
-  renderBarGroup: boolean;
   renderLineSeries: boolean;
   sharedTooltip: boolean;
   showGridColumns: boolean;
@@ -75,10 +75,12 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [snapTooltipToDatumX, setSnapTooltipToDatumX] = useState(true);
   const [snapTooltipToDatumY, setSnapTooltipToDatumY] = useState(true);
   const [sharedTooltip, setSharedTooltip] = useState(true);
-  const [renderBarStackOrGroup, setRenderBarStackOrGroup] = useState<'bar' | 'stack' | 'group'>(
-    'bar',
+  const [renderBarStackOrGroup, setRenderBarStackOrGroup] = useState<
+    'bar' | 'stack' | 'group' | 'none'
+  >('bar');
+  const [renderLineOrAreaSeries, setRenderLineOrAreaSeries] = useState<'line' | 'area' | 'none'>(
+    'area',
   );
-  const [renderLineSeries, setRenderLineSeries] = useState(false);
   const [negativeValues, setNegativeValues] = useState(false);
 
   const accessors = useMemo(
@@ -114,19 +116,22 @@ export default function ExampleControls({ children }: ControlsProps) {
     [renderHorizontally],
   );
 
+  const canRenderLineOrArea = renderBarStackOrGroup === 'bar' || renderBarStackOrGroup === 'none';
+
   return (
     <>
       {children({
         accessors,
         animationTrajectory,
         config,
-        data: renderBarStackOrGroup === 'bar' ? data : dataSmall,
+        data,
         numTicks,
         renderBarGroup: renderBarStackOrGroup === 'group',
         renderBarSeries: renderBarStackOrGroup === 'bar',
         renderBarStack: renderBarStackOrGroup === 'stack',
         renderHorizontally,
-        renderLineSeries: renderBarStackOrGroup === 'bar' && renderLineSeries,
+        renderAreaSeries: canRenderLineOrArea && renderLineOrAreaSeries === 'area',
+        renderLineSeries: canRenderLineOrArea && renderLineOrAreaSeries === 'line',
         sharedTooltip,
         showGridColumns,
         showGridRows,
@@ -359,17 +364,37 @@ export default function ExampleControls({ children }: ControlsProps) {
         </div>
         {/** series */}
         <div>
-          <strong>series</strong>
+          <strong>line series</strong>
           <label>
             <input
-              type="checkbox"
-              disabled={renderBarStackOrGroup !== 'bar'}
-              onChange={() => setRenderLineSeries(!renderLineSeries)}
-              checked={renderLineSeries}
+              type="radio"
+              disabled={!canRenderLineOrArea}
+              onChange={() => setRenderLineOrAreaSeries('line')}
+              checked={canRenderLineOrArea && renderLineOrAreaSeries === 'line'}
             />{' '}
             line
           </label>
-          &nbsp;&nbsp;&nbsp;&nbsp;
+          <label>
+            <input
+              type="radio"
+              disabled={!canRenderLineOrArea}
+              onChange={() => setRenderLineOrAreaSeries('area')}
+              checked={canRenderLineOrArea && renderLineOrAreaSeries === 'area'}
+            />{' '}
+            area
+          </label>
+          <label>
+            <input
+              type="radio"
+              disabled={!canRenderLineOrArea}
+              onChange={() => setRenderLineOrAreaSeries('none')}
+              checked={renderLineOrAreaSeries === 'none' || !canRenderLineOrArea}
+            />{' '}
+            none
+          </label>
+        </div>
+        <div>
+          <strong>bar series</strong>
           <label>
             <input
               type="radio"
@@ -393,6 +418,14 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={renderBarStackOrGroup === 'group'}
             />{' '}
             bar group
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderBarStackOrGroup('none')}
+              checked={renderBarStackOrGroup === 'none'}
+            />{' '}
+            none
           </label>
         </div>
         {/** data */}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -79,7 +79,7 @@ export default function ExampleControls({ children }: ControlsProps) {
     'bar' | 'stack' | 'group' | 'none'
   >('bar');
   const [renderLineOrAreaSeries, setRenderLineOrAreaSeries] = useState<'line' | 'area' | 'none'>(
-    'area',
+    'line',
   );
   const [negativeValues, setNegativeValues] = useState(false);
 

--- a/packages/visx-xychart/src/components/series/AnimatedAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/AnimatedAreaSeries.tsx
@@ -1,0 +1,12 @@
+import { AxisScale } from '@visx/axis';
+import React from 'react';
+import AnimatedPath from './private/AnimatedPath';
+import BaseAreaSeries, { BaseAreaSeriesProps } from './private/BaseAreaSeries';
+
+export default function AnimatedAreaSeries<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>({ ...props }: Omit<BaseAreaSeriesProps<XScale, YScale, Datum>, 'PathComponent'>) {
+  return <BaseAreaSeries<XScale, YScale, Datum> {...props} PathComponent={AnimatedPath} />;
+}

--- a/packages/visx-xychart/src/components/series/AreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/AreaSeries.tsx
@@ -1,0 +1,11 @@
+import { AxisScale } from '@visx/axis';
+import React from 'react';
+import BaseAreaSeries, { BaseAreaSeriesProps } from './private/BaseAreaSeries';
+
+export default function AreaSeries<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>({ ...props }: Omit<BaseAreaSeriesProps<XScale, YScale, Datum>, 'PathComponent'>) {
+  return <BaseAreaSeries<XScale, YScale, Datum> {...props} />;
+}

--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -4,8 +4,9 @@ import { animated, useSpring } from 'react-spring';
 export default function AnimatedPath({
   d,
   stroke,
+  fill,
   ...lineProps
 }: Omit<React.SVGProps<SVGPathElement>, 'ref'>) {
-  const tweened = useSpring({ d, stroke, config: { precision: 0.01 } });
-  return <animated.path d={tweened.d} stroke={tweened.stroke} fill="transparent" {...lineProps} />;
+  const tweened = useSpring({ d, stroke, fill });
+  return <animated.path d={tweened.d} stroke={tweened.stroke} fill={tweened.fill} {...lineProps} />;
 }

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useCallback, useMemo } from 'react';
 import { AxisScale } from '@visx/axis';
-import Area, { AreaProps } from '@visx/shape/lib/shapes/Area';
+import Area from '@visx/shape/lib/shapes/Area';
 import LinePath, { LinePathProps } from '@visx/shape/lib/shapes/LinePath';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';
@@ -25,7 +25,7 @@ export type BaseAreaSeriesProps<
   lineProps?: Omit<LinePathProps<Datum>, 'data' | 'x' | 'y' | 'children' | 'defined'>;
   /** Rendered component which is passed path props by BaseAreaSeries after processing. */
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
-};
+} & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
 
 function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   data,
@@ -39,9 +39,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   PathComponent = 'path',
   lineProps,
   ...areaProps
-}: BaseAreaSeriesProps<XScale, YScale, Datum> &
-  WithRegisteredDataProps<XScale, YScale, Datum> &
-  Omit<AreaProps<Datum>, 'data' | 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'children'>) {
+}: BaseAreaSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -22,7 +22,7 @@ export type BaseAreaSeriesProps<
   /** Whether to render a Line on top of the Area shape (fill only). */
   renderLine?: boolean;
   /** Props to be passed to the Line, if rendered. */
-  lineProps?: Omit<LinePathProps<Datum>, 'data' | 'x' | 'y'>;
+  lineProps?: Omit<LinePathProps<Datum>, 'data' | 'x' | 'y' | 'children' | 'defined'>;
   /** Rendered component which is passed path props by BaseAreaSeries after processing. */
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
 };
@@ -41,7 +41,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   ...areaProps
 }: BaseAreaSeriesProps<XScale, YScale, Datum> &
   WithRegisteredDataProps<XScale, YScale, Datum> &
-  Omit<AreaProps<Datum>, 'data' | 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1'>) {
+  Omit<AreaProps<Datum>, 'data' | 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'children'>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
@@ -103,7 +103,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
         )}
       </Area>
       {renderLine && (
-        <LinePath
+        <LinePath<Datum>
           data={data}
           x={getScaledX}
           y={getScaledY}

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -38,7 +38,9 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   PathComponent = 'path',
   lineProps,
   ...areaProps
-}: BaseAreaSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
+}: BaseAreaSeriesProps<XScale, YScale, Datum> &
+  WithRegisteredDataProps<XScale, YScale, Datum> &
+  Omit<React.SVGProps<SVGPathElement>, keyof BaseAreaSeriesProps<XScale, YScale, Datum> | 'ref'>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useCallback, useMemo } from 'react';
 import { AxisScale } from '@visx/axis';
-import { Area, LinePath } from '@visx/shape';
+import Area, { AreaProps } from '@visx/shape/lib/shapes/Area';
+import LinePath, { LinePathProps } from '@visx/shape/lib/shapes/LinePath';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';
 import withRegisteredData, { WithRegisteredDataProps } from '../../../enhancers/withRegisteredData';
@@ -21,7 +22,7 @@ export type BaseAreaSeriesProps<
   /** Whether to render a Line on top of the Area shape (fill only). */
   renderLine?: boolean;
   /** Props to be passed to the Line, if rendered. */
-  lineProps?: React.SVGProps<SVGPathElement>;
+  lineProps?: Omit<LinePathProps<Datum>, 'data' | 'x' | 'y'>;
   /** Rendered component which is passed path props by BaseAreaSeries after processing. */
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
 };
@@ -40,7 +41,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   ...areaProps
 }: BaseAreaSeriesProps<XScale, YScale, Datum> &
   WithRegisteredDataProps<XScale, YScale, Datum> &
-  Omit<React.SVGProps<SVGPathElement>, keyof BaseAreaSeriesProps<XScale, YScale, Datum> | 'ref'>) {
+  Omit<AreaProps<Datum>, 'data' | 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1'>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -1,0 +1,139 @@
+import React, { useContext, useCallback, useMemo } from 'react';
+import { AxisScale } from '@visx/axis';
+import { Area, LinePath } from '@visx/shape';
+import { coerceNumber } from '@visx/scale';
+import DataContext from '../../../context/DataContext';
+import { SeriesProps } from '../../../types';
+import withRegisteredData, { WithRegisteredDataProps } from '../../../enhancers/withRegisteredData';
+import getScaledValueFactory from '../../../utils/getScaledValueFactory';
+import useEventEmitter, { HandlerParams } from '../../../hooks/useEventEmitter';
+import findNearestDatumX from '../../../utils/findNearestDatumX';
+import TooltipContext from '../../../context/TooltipContext';
+import findNearestDatumY from '../../../utils/findNearestDatumY';
+import isValidNumber from '../../../typeguards/isValidNumber';
+
+export type BaseAreaSeriesProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> = SeriesProps<XScale, YScale, Datum> & {
+  /** Whether area should be rendered horizontally instead of vertically. */
+  horizontal?: boolean;
+  /** Whether to render a Line on top of the Area shape (fill only). */
+  renderLine?: boolean;
+  /** Props to be passed to the Line, if rendered. */
+  lineProps?: React.SVGProps<SVGPathElement>;
+  /** Rendered component which is passed path props by BaseAreaSeries after processing. */
+  PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
+};
+
+function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
+  data,
+  dataKey,
+  horizontal,
+  xAccessor,
+  xScale,
+  yAccessor,
+  yScale,
+  renderLine = true,
+  PathComponent = 'path',
+  lineProps,
+  ...areaProps
+}: BaseAreaSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
+  const { colorScale, theme, width, height } = useContext(DataContext);
+  const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
+  const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
+  const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
+  const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';
+
+  const handleMouseMove = useCallback(
+    (params?: HandlerParams) => {
+      const { svgPoint } = params || {};
+      if (svgPoint && width && height && showTooltip) {
+        const datum = (horizontal ? findNearestDatumY : findNearestDatumX)({
+          point: svgPoint,
+          data,
+          xScale,
+          yScale,
+          xAccessor,
+          yAccessor,
+          width,
+          height,
+        });
+        if (datum) {
+          showTooltip({
+            key: dataKey,
+            ...datum,
+            svgPoint,
+          });
+        }
+      }
+    },
+    [dataKey, data, xScale, yScale, xAccessor, yAccessor, width, height, showTooltip, horizontal],
+  );
+  useEventEmitter('mousemove', handleMouseMove);
+  useEventEmitter('mouseout', hideTooltip);
+
+  const numericScaleBaseline = useMemo(() => {
+    const numericScale = horizontal ? xScale : yScale;
+    const [a, b] = numericScale.range().map(rangeBoundary => coerceNumber(rangeBoundary) ?? 0);
+    const isDescending = a != null && b != null && b < a;
+    const maybeScaleZero = numericScale(0);
+    const [scaleMin, scaleMax] = isDescending ? [b, a] : [a, b];
+
+    // if maybeScaleZero _is_ a number, but the scale is not clamped and it's outside the domain
+    // fallback to the scale's minimum
+    return isDescending
+      ? isValidNumber(maybeScaleZero)
+        ? Math.min(maybeScaleZero, scaleMax)
+        : scaleMax
+      : isValidNumber(maybeScaleZero)
+      ? Math.max(maybeScaleZero, scaleMin)
+      : scaleMin;
+  }, [horizontal, xScale, yScale]);
+
+  const xAccessors = horizontal
+    ? {
+        x0: numericScaleBaseline,
+        x1: getScaledX,
+      }
+    : { x: getScaledX };
+
+  const yAccessors = horizontal
+    ? {
+        y: getScaledY,
+      }
+    : { y0: numericScaleBaseline, y1: getScaledY };
+
+  return (
+    <>
+      <Area data={data} {...xAccessors} {...yAccessors} {...areaProps}>
+        {({ path }) => (
+          <PathComponent stroke="transparent" fill={color} {...areaProps} d={path(data) || ''} />
+        )}
+      </Area>
+      {renderLine && (
+        <LinePath
+          data={data}
+          x={getScaledX}
+          y={getScaledY}
+          stroke={color}
+          strokeWidth={2}
+          {...lineProps}
+        >
+          {({ path }) => (
+            <PathComponent
+              fill="transparent"
+              stroke={color}
+              strokeWidth={2}
+              {...lineProps}
+              d={path(data) || ''}
+            />
+          )}
+        </LinePath>
+      )}
+    </>
+  );
+}
+
+export default withRegisteredData(BaseAreaSeries);

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useCallback, useMemo } from 'react';
 import { AxisScale } from '@visx/axis';
 import { Area, LinePath } from '@visx/shape';
-import { coerceNumber } from '@visx/scale';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';
 import withRegisteredData, { WithRegisteredDataProps } from '../../../enhancers/withRegisteredData';
@@ -10,7 +9,6 @@ import useEventEmitter, { HandlerParams } from '../../../hooks/useEventEmitter';
 import findNearestDatumX from '../../../utils/findNearestDatumX';
 import TooltipContext from '../../../context/TooltipContext';
 import findNearestDatumY from '../../../utils/findNearestDatumY';
-import isValidNumber from '../../../typeguards/isValidNumber';
 import getScaleBaseline from '../../../utils/getScaleBaseline';
 
 export type BaseAreaSeriesProps<

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -11,6 +11,7 @@ import findNearestDatumX from '../../../utils/findNearestDatumX';
 import TooltipContext from '../../../context/TooltipContext';
 import findNearestDatumY from '../../../utils/findNearestDatumY';
 import isValidNumber from '../../../typeguards/isValidNumber';
+import getScaleBaseline from '../../../utils/getScaleBaseline';
 
 export type BaseAreaSeriesProps<
   XScale extends AxisScale,
@@ -74,23 +75,11 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   useEventEmitter('mousemove', handleMouseMove);
   useEventEmitter('mouseout', hideTooltip);
 
-  const numericScaleBaseline = useMemo(() => {
-    const numericScale = horizontal ? xScale : yScale;
-    const [a, b] = numericScale.range().map(rangeBoundary => coerceNumber(rangeBoundary) ?? 0);
-    const isDescending = a != null && b != null && b < a;
-    const maybeScaleZero = numericScale(0);
-    const [scaleMin, scaleMax] = isDescending ? [b, a] : [a, b];
-
-    // if maybeScaleZero _is_ a number, but the scale is not clamped and it's outside the domain
-    // fallback to the scale's minimum
-    return isDescending
-      ? isValidNumber(maybeScaleZero)
-        ? Math.min(maybeScaleZero, scaleMax)
-        : scaleMax
-      : isValidNumber(maybeScaleZero)
-      ? Math.max(maybeScaleZero, scaleMin)
-      : scaleMin;
-  }, [horizontal, xScale, yScale]);
+  const numericScaleBaseline = useMemo(() => getScaleBaseline(horizontal ? xScale : yScale), [
+    horizontal,
+    xScale,
+    yScale,
+  ]);
 
   const xAccessors = horizontal
     ? {

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback } from 'react';
-import LinePath, { LinePathProps } from '@visx/shape/lib/shapes/LinePath';
+import LinePath from '@visx/shape/lib/shapes/LinePath';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -33,7 +33,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   ...lineProps
 }: BaseLineSeriesProps<XScale, YScale, Datum> &
   WithRegisteredDataProps<XScale, YScale, Datum> &
-  Omit<LinePathProps<Datum>, 'data' | 'x' | 'y'>) {
+  Omit<LinePathProps<Datum>, 'data' | 'x' | 'y' | 'children'>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -9,7 +9,6 @@ import useEventEmitter, { HandlerParams } from '../../../hooks/useEventEmitter';
 import findNearestDatumX from '../../../utils/findNearestDatumX';
 import TooltipContext from '../../../context/TooltipContext';
 import findNearestDatumY from '../../../utils/findNearestDatumY';
-import isValidNumber from '../../../typeguards/isValidNumber';
 
 export type BaseLineSeriesProps<
   XScale extends AxisScale,
@@ -32,7 +31,9 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   horizontal,
   PathComponent = 'path',
   ...lineProps
-}: BaseLineSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
+}: BaseLineSeriesProps<XScale, YScale, Datum> &
+  WithRegisteredDataProps<XScale, YScale, Datum> &
+  Omit<React.SVGProps<SVGPathElement>, keyof BaseLineSeriesProps<XScale, YScale, Datum> | 'ref'>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback } from 'react';
-import LinePath from '@visx/shape/lib/shapes/LinePath';
+import LinePath, { LinePathProps } from '@visx/shape/lib/shapes/LinePath';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';
@@ -33,7 +33,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   ...lineProps
 }: BaseLineSeriesProps<XScale, YScale, Datum> &
   WithRegisteredDataProps<XScale, YScale, Datum> &
-  Omit<React.SVGProps<SVGPathElement>, keyof BaseLineSeriesProps<XScale, YScale, Datum> | 'ref'>) {
+  Omit<LinePathProps<Datum>, 'data' | 'x' | 'y'>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -9,6 +9,7 @@ import useEventEmitter, { HandlerParams } from '../../../hooks/useEventEmitter';
 import findNearestDatumX from '../../../utils/findNearestDatumX';
 import TooltipContext from '../../../context/TooltipContext';
 import findNearestDatumY from '../../../utils/findNearestDatumY';
+import isValidNumber from '../../../typeguards/isValidNumber';
 
 export type BaseLineSeriesProps<
   XScale extends AxisScale,
@@ -28,7 +29,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   xScale,
   yAccessor,
   yScale,
-  horizontal = true,
+  horizontal,
   PathComponent = 'path',
   ...lineProps
 }: BaseLineSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
@@ -42,7 +43,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
     (params?: HandlerParams) => {
       const { svgPoint } = params || {};
       if (svgPoint && width && height && showTooltip) {
-        const datum = (horizontal ? findNearestDatumX : findNearestDatumY)({
+        const datum = (horizontal ? findNearestDatumY : findNearestDatumX)({
           point: svgPoint,
           data,
           xScale,
@@ -76,7 +77,13 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
       {...lineProps}
     >
       {({ path }) => (
-        <PathComponent stroke={color} strokeWidth={2} {...lineProps} d={path(data) || ''} />
+        <PathComponent
+          stroke={color}
+          strokeWidth={2}
+          fill="transparent"
+          {...lineProps}
+          d={path(data) || ''}
+        />
       )}
     </LinePath>
   );

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -19,7 +19,7 @@ export type BaseLineSeriesProps<
   horizontal?: boolean;
   /** Rendered component which is passed path props by BaseLineSeries after processing. */
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
-};
+} & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
 
 function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   data,
@@ -31,9 +31,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   horizontal,
   PathComponent = 'path',
   ...lineProps
-}: BaseLineSeriesProps<XScale, YScale, Datum> &
-  WithRegisteredDataProps<XScale, YScale, Datum> &
-  Omit<LinePathProps<Datum>, 'data' | 'x' | 'y' | 'children'>) {
+}: BaseLineSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
   const { colorScale, theme, width, height } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -7,12 +7,14 @@ export { default as Tooltip } from './components/Tooltip';
 export { default as XYChart } from './components/XYChart';
 
 // series components
+export { default as AreaSeries } from './components/series/AreaSeries';
 export { default as BarGroup } from './components/series/BarGroup';
 export { default as BarSeries } from './components/series/BarSeries';
 export { default as BarStack } from './components/series/BarStack';
 export { default as LineSeries } from './components/series/LineSeries';
 
 // animated series components
+export { default as AnimatedAreaSeries } from './components/series/AnimatedAreaSeries';
 export { default as AnimatedBarSeries } from './components/series/AnimatedBarSeries';
 export { default as AnimatedBarStack } from './components/series/AnimatedBarStack';
 export { default as AnimatedBarGroup } from './components/series/AnimatedBarGroup';

--- a/packages/visx-xychart/src/utils/getScaleBaseline.ts
+++ b/packages/visx-xychart/src/utils/getScaleBaseline.ts
@@ -16,7 +16,7 @@ export default function getScaleBaseline<Scale extends AxisScale>(scale: Scale) 
   // fallback to the scale's minimum
   return isDescending
     ? isValidNumber(maybeScaleZero)
-      ? Math.min(maybeScaleZero, maxOutput)
+      ? Math.min(Math.max(minOutput, maybeScaleZero), maxOutput)
       : maxOutput
     : isValidNumber(maybeScaleZero)
     ? Math.max(maybeScaleZero, minOutput)

--- a/packages/visx-xychart/src/utils/getScaleBaseline.ts
+++ b/packages/visx-xychart/src/utils/getScaleBaseline.ts
@@ -1,0 +1,24 @@
+import { AxisScale } from '@visx/axis';
+import { coerceNumber } from '@visx/scale';
+import isValidNumber from '../typeguards/isValidNumber';
+
+/**
+ * Returns the output value of a scale's baseline value, which is either zero
+ * or the minimum scale value if its domain doesn't include zero.
+ */
+export default function getScaleBaseline<Scale extends AxisScale>(scale: Scale) {
+  const [a, b] = scale.range().map(rangeBoundary => coerceNumber(rangeBoundary) ?? 0);
+  const isDescending = a != null && b != null && b < a;
+  const maybeScaleZero = scale(0);
+  const [minOutput, maxOutput] = isDescending ? [b, a] : [a, b];
+
+  // if maybeScaleZero _is_ a number, but the scale is not clamped and it's outside the domain
+  // fallback to the scale's minimum
+  return isDescending
+    ? isValidNumber(maybeScaleZero)
+      ? Math.min(maybeScaleZero, maxOutput)
+      : maxOutput
+    : isValidNumber(maybeScaleZero)
+    ? Math.max(maybeScaleZero, minOutput)
+    : minOutput;
+}

--- a/packages/visx-xychart/test/components/AreaSeries.test.tsx
+++ b/packages/visx-xychart/test/components/AreaSeries.test.tsx
@@ -1,0 +1,95 @@
+import React, { useContext, useEffect } from 'react';
+import { animated } from 'react-spring';
+import { mount } from 'enzyme';
+import { Area, LinePath } from '@visx/shape';
+import { AnimatedAreaSeries, DataContext, AreaSeries, useEventEmitter } from '../../src';
+import getDataContext from '../mocks/getDataContext';
+import setupTooltipTest from '../mocks/setupTooltipTest';
+
+const series = { key: 'line', data: [{}], xAccessor: () => 4, yAccessor: () => 7 };
+
+describe('<AreaSeries />', () => {
+  it('should be defined', () => {
+    expect(AreaSeries).toBeDefined();
+  });
+
+  it('should render an Area', () => {
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <AreaSeries dataKey={series.key} {...series} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
+    expect(wrapper.find(Area)).toHaveLength(1);
+  });
+
+  it('should render a LinePath is renderLine=true', () => {
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <AreaSeries renderLine dataKey={series.key} {...series} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
+    expect(wrapper.find(LinePath)).toHaveLength(1);
+  });
+
+  it('should invoke showTooltip/hideTooltip on mousemove/mouseout', () => {
+    expect.assertions(2);
+
+    const showTooltip = jest.fn();
+    const hideTooltip = jest.fn();
+
+    const ConditionalEventEmitter = () => {
+      const { dataRegistry } = useContext(DataContext);
+      // AreaSeries won't render until its data is registered
+      // wait for that to emit the events
+      return dataRegistry?.get(series.key) ? <EventEmitter /> : null;
+    };
+
+    const EventEmitter = () => {
+      const emit = useEventEmitter();
+
+      useEffect(() => {
+        if (emit) {
+          // @ts-ignore not a React.MouseEvent
+          emit('mousemove', new MouseEvent('mousemove'));
+          expect(showTooltip).toHaveBeenCalledTimes(1);
+
+          // @ts-ignore not a React.MouseEvent
+          emit('mouseout', new MouseEvent('mouseout'));
+          expect(showTooltip).toHaveBeenCalledTimes(1);
+        }
+      });
+
+      return null;
+    };
+
+    setupTooltipTest(
+      <>
+        <AreaSeries dataKey={series.key} {...series} />
+        <ConditionalEventEmitter />
+      </>,
+      { showTooltip, hideTooltip },
+    );
+  });
+});
+
+describe('<AnimatedAreaSeries />', () => {
+  it('should be defined', () => {
+    expect(AnimatedAreaSeries).toBeDefined();
+  });
+  it('should render an animated.path', () => {
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <AnimatedAreaSeries renderLine={false} dataKey={series.key} {...series} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    expect(wrapper.find(animated.path)).toHaveLength(1);
+  });
+});

--- a/packages/visx-xychart/test/utils/getScaleBaseline.test.ts
+++ b/packages/visx-xychart/test/utils/getScaleBaseline.test.ts
@@ -1,0 +1,41 @@
+import { scaleLinear } from '@visx/scale';
+import getScaleBaseline from '../../src/utils/getScaleBaseline';
+
+describe('getScaleBaseline', () => {
+  it('should be defined', () => {
+    expect(getScaleBaseline).toBeDefined();
+  });
+
+  it('should work for ascending ranges', () => {
+    expect(
+      getScaleBaseline(
+        scaleLinear({
+          domain: [0, 100],
+          range: [50, 100],
+        }),
+      ),
+    ).toBe(50);
+  });
+
+  it('should work for descending ranges', () => {
+    expect(
+      getScaleBaseline(
+        scaleLinear({
+          domain: [0, 100],
+          range: [100, 50],
+        }),
+      ),
+    ).toBe(100);
+  });
+
+  it("should use a scale's minimum even if its not clamped to exclude zero", () => {
+    expect(
+      getScaleBaseline(
+        scaleLinear({
+          domain: [100, 200],
+          range: [50, 100],
+        }),
+      ),
+    ).toBe(50);
+  });
+});

--- a/packages/visx-xychart/test/utils/getScaleBaseline.test.ts
+++ b/packages/visx-xychart/test/utils/getScaleBaseline.test.ts
@@ -33,9 +33,17 @@ describe('getScaleBaseline', () => {
       getScaleBaseline(
         scaleLinear({
           domain: [100, 200],
-          range: [50, 100],
+          range: [50, 100], // ascending
         }),
       ),
     ).toBe(50);
+    expect(
+      getScaleBaseline(
+        scaleLinear({
+          domain: [100, 200],
+          range: [100, 50], // descending
+        }),
+      ),
+    ).toBe(100);
   });
 });


### PR DESCRIPTION
#### :rocket: Enhancements

This PR 
- adds `AreaSeries`, `AnimatedAreaSeries`, and `BaseAreaSeries` for a common implementation
- adds tests for new files
- updates the `xychart` demo to group line + bar series separately.

**new demo**
<img src="https://user-images.githubusercontent.com/4496521/96309901-16c14d00-0fbb-11eb-9ef6-d19ba56e0e73.gif" width="600" />

**renders horizontal negative values correctly**
<img src="https://user-images.githubusercontent.com/4496521/96309797-dcf04680-0fba-11eb-8274-1b20736d6dba.png" width="600" />

@kristw @techniq 