### PR TITLE
Remove data requirement from arc

### DIFF
--- a/packages/visx-shape/src/shapes/Arc.tsx
+++ b/packages/visx-shape/src/shapes/Arc.tsx
@@ -7,8 +7,6 @@ import { arc } from '../util/D3ShapeFactories';
 export type ArcProps<Datum> = {
   /** className applied to path element. */
   className?: string;
-  /** A Datum for which to generate an arc. */
-  data?: Datum;
   /** Override render function which is passed the configured arc generator as input. */
   children?: (args: { path: ArcType<$TSFIXME, Datum> }) => React.ReactNode;
   /** React ref to the path element. */
@@ -17,7 +15,6 @@ export type ArcProps<Datum> = {
 
 export default function Arc<Datum>({
   className,
-  data,
   innerRadius,
   outerRadius,
   cornerRadius,
@@ -41,13 +38,12 @@ export default function Arc<Datum>({
 
   // eslint-disable-next-line react/jsx-no-useless-fragment
   if (children) return <>{children({ path })}</>;
-  if (!data) return null;
 
   return (
     <path
       ref={innerRef}
       className={cx('visx-arc', className)}
-      d={path(data) || ''}
+      d={path() || ''}
       {...restProps}
     />
   );


### PR DESCRIPTION
`arc` from d3-shape does not take any arguments: https://github.com/d3/d3-shape/blob/master/src/arc.js#L87

Fixes #886