### PR TITLE
new(xychart): handle rendering + tweening missing values

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -63,7 +63,7 @@ export default function Example({ height }: Props) {
               numTicks={numTicks}
             />
             {renderBarStack && (
-              <AnimatedBarStack horizontal={renderHorizontally}>
+              <AnimatedBarStack>
                 <AnimatedBarSeries
                   dataKey="New York"
                   data={data}
@@ -85,7 +85,7 @@ export default function Example({ height }: Props) {
               </AnimatedBarStack>
             )}
             {renderBarGroup && (
-              <AnimatedBarGroup horizontal={renderHorizontally}>
+              <AnimatedBarGroup>
                 <AnimatedBarSeries
                   dataKey="New York"
                   data={data}
@@ -112,7 +112,6 @@ export default function Example({ height }: Props) {
                 data={data}
                 xAccessor={accessors.x['New York']}
                 yAccessor={accessors.y['New York']}
-                horizontal={renderHorizontally}
               />
             )}
             {renderAreaSeries && (
@@ -122,16 +121,14 @@ export default function Example({ height }: Props) {
                   data={data}
                   xAccessor={accessors.x.Austin}
                   yAccessor={accessors.y.Austin}
-                  horizontal={renderHorizontally}
-                  fillOpacity={0.3}
+                  fillOpacity={0.5}
                 />
                 <AnimatedAreaSeries
                   dataKey="San Francisco"
                   data={data}
                   xAccessor={accessors.x['San Francisco']}
                   yAccessor={accessors.y['San Francisco']}
-                  horizontal={renderHorizontally}
-                  fillOpacity={0.3}
+                  fillOpacity={0.5}
                 />
               </>
             )}
@@ -142,14 +139,12 @@ export default function Example({ height }: Props) {
                   data={data}
                   xAccessor={accessors.x.Austin}
                   yAccessor={accessors.y.Austin}
-                  horizontal={renderHorizontally}
                 />
                 <AnimatedLineSeries
                   dataKey="San Francisco"
                   data={data}
                   xAccessor={accessors.x['San Francisco']}
                   yAccessor={accessors.y['San Francisco']}
-                  horizontal={renderHorizontally}
                 />
               </>
             )}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -12,7 +12,11 @@ const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const temperatureScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
 const data = cityTemperature.slice(225, 275);
-const dataMissingValues = data.map((d, i) => (i === 10 ? { ...d, 'San Francisco': NaN } : d));
+const dataMissingValues = data.map((d, i) =>
+  i === 10 || i === 11
+    ? { ...d, 'San Francisco': 'nope', 'New York': 'notanumber', Austin: 'null' }
+    : d,
+);
 const dataSmall = data.slice(0, 15);
 const dataSmallMissingValues = dataMissingValues.slice(0, 15);
 const getDate = (d: CityTemperature) => d.date;
@@ -551,8 +555,11 @@ export default function ExampleControls({ children }: ControlsProps) {
           font-size: 13px;
           line-height: 1.5em;
         }
+        .controls > div {
+          margin-bottom: 8px;
+        }
         label {
-          font-size: 11px;
+          font-size: 12px;
         }
         input[type='radio'] {
           height: 10px;

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -12,6 +12,9 @@ const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const temperatureScaleConfig = { type: 'linear' } as const;
 const numTicks = 4;
 const data = cityTemperature.slice(225, 275);
+const dataMissingValues = data.map((d, i) => (i === 10 ? { ...d, 'San Francisco': NaN } : d));
+const dataSmall = data.slice(0, 15);
+const dataSmallMissingValues = dataMissingValues.slice(0, 15);
 const getDate = (d: CityTemperature) => d.date;
 const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNegativeSfTemperature = (d: CityTemperature) => -getSfTemperature(d);
@@ -82,12 +85,14 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [sharedTooltip, setSharedTooltip] = useState(true);
   const [renderBarStackOrGroup, setRenderBarStackOrGroup] = useState<
     'bar' | 'stack' | 'group' | 'none'
-  >('none');
+  >('bar');
   const [renderLineOrAreaSeries, setRenderLineOrAreaSeries] = useState<'line' | 'area' | 'none'>(
     'line',
   );
-  const [renderGlyphSeries, setRenderGlyphSeries] = useState(true);
+  const [renderGlyphSeries, setRenderGlyphSeries] = useState(false);
   const [negativeValues, setNegativeValues] = useState(false);
+  const [fewerDatum, setFewerDatum] = useState(false);
+  const [missingValues, setMissingValues] = useState(false);
   const [glyphComponent, setGlyphComponent] = useState<'star' | 'cross' | 'circle' | '🍍'>('star');
   const themeBackground = theme.backgroundColor;
   const renderGlyph = useCallback(
@@ -151,7 +156,13 @@ export default function ExampleControls({ children }: ControlsProps) {
         accessors,
         animationTrajectory,
         config,
-        data,
+        data: fewerDatum
+          ? missingValues
+            ? dataSmallMissingValues
+            : dataSmall
+          : missingValues
+          ? dataMissingValues
+          : data,
         numTicks,
         renderBarGroup: renderBarStackOrGroup === 'group',
         renderBarSeries: renderBarStackOrGroup === 'bar',
@@ -516,6 +527,22 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={negativeValues}
             />
             negative values (SF)
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setMissingValues(!missingValues)}
+              checked={missingValues}
+            />
+            missing values
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setFewerDatum(!fewerDatum)}
+              checked={fewerDatum}
+            />
+            fewer datum
           </label>
         </div>
       </div>

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -57,6 +57,7 @@
     "@visx/voronoi": "1.0.0",
     "classnames": "^2.2.5",
     "d3-array": "^2.6.0",
+    "d3-interpolate-path": "2.2.1",
     "d3-shape": "^2.0.0",
     "lodash": "^4.17.10",
     "mitt": "^2.1.0",

--- a/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
@@ -1,8 +1,8 @@
 import { AxisScale } from '@visx/axis';
-import { coerceNumber } from '@visx/scale';
 import React, { useMemo } from 'react';
 import { animated, useTransition } from 'react-spring';
 import { Bar, BarsProps } from '../../../types';
+import getScaleBaseline from '../../../utils/getScaleBaseline';
 
 function enterUpdate({ x, y, width, height, fill }: Bar) {
   return {
@@ -26,14 +26,12 @@ function useBarTransitionConfig<Scale extends AxisScale>({
 }: BarTransitionConfig<Scale>) {
   const shouldAnimateX = !!horizontal;
   return useMemo(() => {
-    const [a, b] = scale.range().map(coerceNumber);
-    const isDescending = b != null && a != null && b < a;
-    const [scaleMin, scaleMax] = isDescending ? [b, a] : [a, b];
+    const scaleBaseline = getScaleBaseline(scale);
 
     function fromLeave({ x, y, width, height, fill }: Bar) {
       return {
-        x: shouldAnimateX ? scaleMin ?? 0 : x,
-        y: shouldAnimateX ? y : scaleMax ?? 0,
+        x: shouldAnimateX ? scaleBaseline ?? 0 : x,
+        y: shouldAnimateX ? y : scaleBaseline ?? 0,
         width: shouldAnimateX ? 0 : width,
         height: shouldAnimateX ? height : 0,
         fill,

--- a/packages/visx-xychart/src/components/series/private/AnimatedGlyphs.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedGlyphs.tsx
@@ -71,12 +71,13 @@ export default function AnimatedGlyphs<
     <>
       {animatedGlyphs.map((
         // @ts-ignore x/y aren't in react-spring's CSSProperties
-        { item, key, props: { x, y, color } },
+        { item, key, props: { x, y, color, opacity } },
       ) => (
         <animated.g
           key={key}
           transform={interpolate([x, y], (xVal, yVal) => `translate(${xVal}, ${yVal})`)}
           color={color}
+          opacity={opacity}
         >
           {renderGlyph({
             key,

--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { animated, useSpring } from 'react-spring';
-// @ts-ignore
+// @ts-ignore no types
 import { interpolatePath } from 'd3-interpolate-path';
 
 export default function AnimatedPath({
@@ -15,11 +15,16 @@ export default function AnimatedPath({
   // d3-interpolate-path is better at interpolating extra/fewer points so we use that
   const interpolator = interpolatePath(previousD.current, d);
   previousD.current = d;
-  const frame = useSpring({ from: { t: 0 }, to: { t: 1 }, reset: true });
+  // @ts-ignore t is not in CSSProperties
+  const { t } = useSpring({
+    from: { t: 0 },
+    to: { t: 1 },
+    reset: true,
+  });
   const tweened = useSpring({ stroke, fill });
   return (
     <animated.path
-      d={frame.t.interpolate(interpolator)}
+      d={t.interpolate(interpolator)}
       stroke={tweened.stroke}
       fill={tweened.fill}
       {...lineProps}

--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { animated, useSpring } from 'react-spring';
+// @ts-ignore
+import { interpolatePath } from 'd3-interpolate-path';
 
 export default function AnimatedPath({
   d,
@@ -7,6 +9,20 @@ export default function AnimatedPath({
   fill,
   ...lineProps
 }: Omit<React.SVGProps<SVGPathElement>, 'ref'>) {
-  const tweened = useSpring({ d, stroke, fill });
-  return <animated.path d={tweened.d} stroke={tweened.stroke} fill={tweened.fill} {...lineProps} />;
+  const previousD = useRef(d);
+  // react-spring cannot interpolate paths which have a differing number of points
+  // flubber is the "best" at interpolating but assumes closed paths
+  // d3-interpolate-path is better at interpolating extra/fewer points so we use that
+  const interpolator = interpolatePath(previousD.current, d);
+  previousD.current = d;
+  const frame = useSpring({ from: { t: 0 }, to: { t: 1 }, reset: true });
+  const tweened = useSpring({ stroke, fill });
+  return (
+    <animated.path
+      d={frame.t.interpolate(interpolator)}
+      stroke={tweened.stroke}
+      fill={tweened.fill}
+      {...lineProps}
+    />
+  );
 }

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -11,15 +11,14 @@ import findNearestDatumX from '../../../utils/findNearestDatumX';
 import TooltipContext from '../../../context/TooltipContext';
 import findNearestDatumY from '../../../utils/findNearestDatumY';
 import getScaleBaseline from '../../../utils/getScaleBaseline';
+import isValidNumber from '../../../typeguards/isValidNumber';
 
 export type BaseAreaSeriesProps<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
 > = SeriesProps<XScale, YScale, Datum> & {
-  /** Whether area should be rendered horizontally instead of vertically. */
-  horizontal?: boolean;
-  /** Whether to render a Line on top of the Area shape (fill only). */
+  /** Whether to render a Line along value of the Area shape (area is fill only). */
   renderLine?: boolean;
   /** Props to be passed to the Line, if rendered. */
   lineProps?: Omit<LinePathProps<Datum>, 'data' | 'x' | 'y' | 'children' | 'defined'>;
@@ -30,7 +29,6 @@ export type BaseAreaSeriesProps<
 function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   data,
   dataKey,
-  horizontal,
   xAccessor,
   xScale,
   yAccessor,
@@ -40,10 +38,14 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   lineProps,
   ...areaProps
 }: BaseAreaSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
-  const { colorScale, theme, width, height } = useContext(DataContext);
+  const { colorScale, theme, width, height, horizontal } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
   const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
+  const isDefined = useCallback(
+    (d: Datum) => isValidNumber(xScale(xAccessor(d))) && isValidNumber(yScale(yAccessor(d))),
+    [xScale, xAccessor, yScale, yAccessor],
+  );
   const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';
 
   const handleMouseMove = useCallback(
@@ -95,7 +97,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
 
   return (
     <>
-      <Area data={data} {...xAccessors} {...yAccessors} {...areaProps}>
+      <Area data={data} {...xAccessors} {...yAccessors} {...areaProps} defined={isDefined}>
         {({ path }) => (
           <PathComponent stroke="transparent" fill={color} {...areaProps} d={path(data) || ''} />
         )}
@@ -107,6 +109,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
           y={getScaledY}
           stroke={color}
           strokeWidth={2}
+          defined={isDefined}
           {...lineProps}
         >
           {({ path }) => (

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -97,14 +97,13 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
 
   return (
     <>
-      <Area data={data} {...xAccessors} {...yAccessors} {...areaProps} defined={isDefined}>
+      <Area {...xAccessors} {...yAccessors} {...areaProps} defined={isDefined}>
         {({ path }) => (
           <PathComponent stroke="transparent" fill={color} {...areaProps} d={path(data) || ''} />
         )}
       </Area>
       {renderLine && (
         <LinePath<Datum>
-          data={data}
           x={getScaledX}
           y={getScaledY}
           stroke={color}

--- a/packages/visx-xychart/src/components/series/private/BaseBarGroup.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarGroup.tsx
@@ -126,8 +126,8 @@ export default function BaseBarGroup<
   const bars = registryEntries.flatMap(({ xAccessor, yAccessor, data, key }) => {
     const getLength = (d: Datum) =>
       horizontal
-        ? (xScale(xAccessor(d)) ?? 0) - xZeroPosition
-        : (yScale(yAccessor(d)) ?? 0) - yZeroPosition;
+        ? (xScale(xAccessor(d)) ?? NaN) - xZeroPosition
+        : (yScale(yAccessor(d)) ?? NaN) - yZeroPosition;
 
     const getGroupPosition = horizontal
       ? (d: Datum) => yScale(yAccessor(d)) ?? 0
@@ -152,13 +152,17 @@ export default function BaseBarGroup<
         if (!isValidNumber(barX)) return null;
         const barY = getY(bar);
         if (!isValidNumber(barY)) return null;
+        const barWidth = getWidth(bar);
+        if (!isValidNumber(barWidth)) return null;
+        const barHeight = getHeight(bar);
+        if (!isValidNumber(barHeight)) return null;
 
         return {
           key: `${key}-${index}`,
           x: barX,
           y: barY,
-          width: getWidth(bar),
-          height: getHeight(bar),
+          width: barWidth,
+          height: barHeight,
           fill: colorScale(key),
         };
       })

--- a/packages/visx-xychart/src/components/series/private/BaseBarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarSeries.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useCallback, useMemo } from 'react';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../../../context/DataContext';
-import { BarsProps, SeriesProps } from '../../../types';
+import { Bar, BarsProps, SeriesProps } from '../../../types';
 import withRegisteredData, { WithRegisteredDataProps } from '../../../enhancers/withRegisteredData';
 import getScaledValueFactory from '../../../utils/getScaledValueFactory';
 import getScaleBandwidth from '../../../utils/getScaleBandwidth';
@@ -83,7 +83,7 @@ function BaseBarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum
           fill: color, // @TODO allow prop overriding
         };
       })
-      .filter(bar => bar);
+      .filter(bar => bar) as Bar[];
   }, [barThickness, color, data, getScaledX, getScaledY, horizontal, xZeroPosition, yZeroPosition]);
 
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};

--- a/packages/visx-xychart/src/components/series/private/BaseBarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarSeries.tsx
@@ -18,8 +18,6 @@ export type BaseBarSeriesProps<
 > = SeriesProps<XScale, YScale, Datum> & {
   /** Rendered component which is passed BarsProps by BaseBarSeries after processing. */
   BarsComponent: React.FC<BarsProps<XScale, YScale>>;
-  /** Whether bars should be rendered horizontally instead of vertically. */
-  horizontal?: boolean;
   /**
    * Specify bar padding when bar thickness does not come from a `band` scale.
    * Accepted values are [0, 1], 0 = no padding, 1 = no bar, defaults to 0.1.
@@ -37,15 +35,20 @@ function BaseBarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum
   BarsComponent,
   data,
   dataKey,
-  horizontal,
   xAccessor,
   xScale,
   yAccessor,
   yScale,
 }: BaseBarSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
-  const { colorScale, theme, width, height, innerWidth = 0, innerHeight = 0 } = useContext(
-    DataContext,
-  );
+  const {
+    colorScale,
+    horizontal,
+    theme,
+    width,
+    height,
+    innerWidth = 0,
+    innerHeight = 0,
+  } = useContext(DataContext);
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
   const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
   const scaleBandwidth = getScaleBandwidth(horizontal ? yScale : xScale);

--- a/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
@@ -180,20 +180,20 @@ function BaseBarStack<
   let getY: (bar: StackBar) => number | undefined;
 
   if (horizontal) {
-    getWidth = bar => (xScale(getSecondItem(bar)) || 0) - (xScale(getFirstItem(bar)) || 0);
+    getWidth = bar => (xScale(getSecondItem(bar)) ?? NaN) - (xScale(getFirstItem(bar)) ?? NaN);
     getHeight = () => barThickness;
     getX = bar => xScale(getFirstItem(bar));
     getY = bar =>
       'bandwidth' in yScale
         ? yScale(getStackValue(bar.data))
-        : Math.max((yScale(getStackValue(bar.data)) || 0) - halfBarThickness);
+        : Math.max((yScale(getStackValue(bar.data)) ?? NaN) - halfBarThickness);
   } else {
     getWidth = () => barThickness;
-    getHeight = bar => (yScale(getFirstItem(bar)) || 0) - (yScale(getSecondItem(bar)) || 0);
+    getHeight = bar => (yScale(getFirstItem(bar)) ?? NaN) - (yScale(getSecondItem(bar)) ?? NaN);
     getX = bar =>
       'bandwidth' in xScale
         ? xScale(getStackValue(bar.data))
-        : Math.max((xScale(getStackValue(bar.data)) || 0) - halfBarThickness);
+        : Math.max((xScale(getStackValue(bar.data)) ?? NaN) - halfBarThickness);
     getY = bar => yScale(getSecondItem(bar));
   }
 
@@ -207,13 +207,17 @@ function BaseBarStack<
         if (!isValidNumber(barX)) return null;
         const barY = getY(bar);
         if (!isValidNumber(barY)) return null;
+        const barWidth = getWidth(bar);
+        if (!isValidNumber(barWidth)) return null;
+        const barHeight = getHeight(bar);
+        if (!isValidNumber(barHeight)) return null;
 
         return {
           key: `${stackIndex}-${barStack.key}-${index}`,
           x: barX,
           y: barY,
-          width: getWidth(bar),
-          height: getHeight(bar),
+          width: barWidth,
+          height: barHeight,
           fill: colorScale(barStack.key),
         };
       });

--- a/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
@@ -23,8 +23,6 @@ export type BaseBarStackProps<
   YScale extends PositionScale,
   Datum extends object
 > = {
-  /** Whether to render the Stack horizontally instead of vertically. */
-  horizontal?: boolean;
   /** `BarSeries` elements */
   children: JSX.Element | JSX.Element[];
   /** Rendered component which is passed BarsProps by BaseBarStack after processing. */
@@ -35,13 +33,7 @@ function BaseBarStack<
   XScale extends PositionScale,
   YScale extends PositionScale,
   Datum extends object
->({
-  children,
-  horizontal,
-  order,
-  offset,
-  BarsComponent,
-}: BaseBarStackProps<XScale, YScale, Datum>) {
+>({ children, order, offset, BarsComponent }: BaseBarStackProps<XScale, YScale, Datum>) {
   type StackBar = SeriesPoint<CombinedStackData<XScale, YScale>>;
   const {
     xScale,
@@ -52,6 +44,7 @@ function BaseBarStack<
     unregisterData,
     width,
     height,
+    horizontal,
   } = (useContext(DataContext) as unknown) as DataContextType<
     XScale,
     YScale,

--- a/packages/visx-xychart/src/components/series/private/BaseGlyphSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseGlyphSeries.tsx
@@ -15,8 +15,6 @@ export type BaseGlyphSeriesProps<
   YScale extends AxisScale,
   Datum extends object
 > = SeriesProps<XScale, YScale, Datum> & {
-  /** Whether line should be rendered horizontally instead of vertically. */
-  horizontal?: boolean;
   /** The size of a `Glyph`, a `number` or a function which takes a `Datum` and returns a `number`. */
   size?: number | ((d: Datum) => number);
   /** Function which handles rendering glyphs. */
@@ -30,11 +28,10 @@ function BaseGlyphSeries<XScale extends AxisScale, YScale extends AxisScale, Dat
   xScale,
   yAccessor,
   yScale,
-  horizontal,
   size = 8,
   renderGlyphs,
 }: BaseGlyphSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
-  const { colorScale, theme, width, height } = useContext(DataContext);
+  const { colorScale, theme, width, height, horizontal } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
   const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -70,7 +70,6 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
 
   return (
     <LinePath
-      data={data}
       x={getScaledX}
       y={getScaledY}
       stroke={color}

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -9,14 +9,13 @@ import useEventEmitter, { HandlerParams } from '../../../hooks/useEventEmitter';
 import findNearestDatumX from '../../../utils/findNearestDatumX';
 import TooltipContext from '../../../context/TooltipContext';
 import findNearestDatumY from '../../../utils/findNearestDatumY';
+import isValidNumber from '../../../typeguards/isValidNumber';
 
 export type BaseLineSeriesProps<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
 > = SeriesProps<XScale, YScale, Datum> & {
-  /** Whether line should be rendered horizontally instead of vertically. */
-  horizontal?: boolean;
   /** Rendered component which is passed path props by BaseLineSeries after processing. */
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
 } & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
@@ -28,14 +27,17 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   xScale,
   yAccessor,
   yScale,
-  horizontal,
   PathComponent = 'path',
   ...lineProps
 }: BaseLineSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
-  const { colorScale, theme, width, height } = useContext(DataContext);
+  const { colorScale, theme, width, height, horizontal } = useContext(DataContext);
   const { showTooltip, hideTooltip } = useContext(TooltipContext) ?? {};
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
   const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
+  const isDefined = useCallback(
+    (d: Datum) => isValidNumber(xScale(xAccessor(d))) && isValidNumber(yScale(yAccessor(d))),
+    [xScale, xAccessor, yScale, yAccessor],
+  );
   const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';
 
   const handleMouseMove = useCallback(
@@ -73,6 +75,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
       y={getScaledY}
       stroke={color}
       strokeWidth={2}
+      defined={isDefined}
       {...lineProps}
     >
       {({ path }) => (

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -3,6 +3,7 @@ import { ScaleConfig, createScale, ScaleInput } from '@visx/scale';
 import { extent as d3Extent } from 'd3-array';
 import { useMemo } from 'react';
 import DataRegistry from '../classes/DataRegistry';
+import isDiscreteScale from '../utils/isDiscreteScale';
 
 /** A hook for creating memoized x- and y-scales. */
 export default function useScales<
@@ -39,8 +40,7 @@ export default function useScales<
       [],
     );
 
-    const xType = xScaleConfig.type;
-    const xDomain = xType === 'band' || xType === 'ordinal' ? xValues : d3Extent(xValues);
+    const xDomain = isDiscreteScale(xScaleConfig) ? xValues : d3Extent(xValues);
 
     xScale.range(xScaleConfig.range || [xMin, xMax]);
     xScale.domain(xScaleConfig.domain || xDomain);
@@ -66,8 +66,7 @@ export default function useScales<
       [],
     );
 
-    const yType = yScaleConfig.type;
-    const yDomain = yType === 'band' || yType === 'ordinal' ? yValues : d3Extent(yValues);
+    const yDomain = isDiscreteScale(yScaleConfig) ? yValues : d3Extent(yValues);
 
     yScale.range(yScaleConfig.range || [yMin, yMax]);
     yScale.domain(yScaleConfig.domain || yDomain);

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -34,18 +34,14 @@ export default function useScales<
 
     let xScale = createScale(xScaleConfig) as XScale;
     type XScaleInput = ScaleInput<XScale>;
-    const xScaleIsDiscrete = isDiscreteScale(xScaleConfig);
-    const valueIsDefined = xScaleIsDiscrete ? (v: XScaleInput) => v != null : isValidNumber;
 
     const xValues = registryEntries.reduce<XScaleInput[]>(
       (combined, entry) =>
-        entry
-          ? combined.concat(entry.data.map((d: Datum) => entry.xAccessor(d)).filter(valueIsDefined))
-          : combined,
+        entry ? combined.concat(entry.data.map((d: Datum) => entry.xAccessor(d))) : combined,
       [],
     );
 
-    const xDomain = xScaleIsDiscrete ? xValues : d3Extent(xValues);
+    const xDomain = isDiscreteScale(xScaleConfig) ? xValues : d3Extent(xValues);
 
     xScale.range(xScaleConfig.range || [xMin, xMax]);
     xScale.domain(xScaleConfig.domain || xDomain);
@@ -65,13 +61,9 @@ export default function useScales<
     let yScale = createScale(yScaleConfig) as YScale;
     type YScaleInput = ScaleInput<YScale>;
 
-    const yScaleIsDiscrete = isDiscreteScale(yScaleConfig);
-    const valueIsDefined = yScaleIsDiscrete ? (v: YScaleInput) => v != null : isValidNumber;
     const yValues = registryEntries.reduce<YScaleInput[]>(
       (combined, entry) =>
-        entry
-          ? combined.concat(entry.data.map((d: Datum) => entry.yAccessor(d)).filter(valueIsDefined))
-          : combined,
+        entry ? combined.concat(entry.data.map((d: Datum) => entry.yAccessor(d))) : combined,
       [],
     );
 

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -3,7 +3,6 @@ import { ScaleConfig, createScale, ScaleInput } from '@visx/scale';
 import { extent as d3Extent } from 'd3-array';
 import { useMemo } from 'react';
 import DataRegistry from '../classes/DataRegistry';
-import isValidNumber from '../typeguards/isValidNumber';
 import isDiscreteScale from '../utils/isDiscreteScale';
 
 /** A hook for creating memoized x- and y-scales. */

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -3,6 +3,7 @@ import { ScaleConfig, createScale, ScaleInput } from '@visx/scale';
 import { extent as d3Extent } from 'd3-array';
 import { useMemo } from 'react';
 import DataRegistry from '../classes/DataRegistry';
+import isValidNumber from '../typeguards/isValidNumber';
 import isDiscreteScale from '../utils/isDiscreteScale';
 
 /** A hook for creating memoized x- and y-scales. */
@@ -33,14 +34,18 @@ export default function useScales<
 
     let xScale = createScale(xScaleConfig) as XScale;
     type XScaleInput = ScaleInput<XScale>;
+    const xScaleIsDiscrete = isDiscreteScale(xScaleConfig);
+    const valueIsDefined = xScaleIsDiscrete ? (v: XScaleInput) => v != null : isValidNumber;
 
     const xValues = registryEntries.reduce<XScaleInput[]>(
       (combined, entry) =>
-        entry ? combined.concat(entry.data.map((d: Datum) => entry.xAccessor(d))) : combined,
+        entry
+          ? combined.concat(entry.data.map((d: Datum) => entry.xAccessor(d)).filter(valueIsDefined))
+          : combined,
       [],
     );
 
-    const xDomain = isDiscreteScale(xScaleConfig) ? xValues : d3Extent(xValues);
+    const xDomain = xScaleIsDiscrete ? xValues : d3Extent(xValues);
 
     xScale.range(xScaleConfig.range || [xMin, xMax]);
     xScale.domain(xScaleConfig.domain || xDomain);
@@ -60,9 +65,13 @@ export default function useScales<
     let yScale = createScale(yScaleConfig) as YScale;
     type YScaleInput = ScaleInput<YScale>;
 
+    const yScaleIsDiscrete = isDiscreteScale(yScaleConfig);
+    const valueIsDefined = yScaleIsDiscrete ? (v: YScaleInput) => v != null : isValidNumber;
     const yValues = registryEntries.reduce<YScaleInput[]>(
       (combined, entry) =>
-        entry ? combined.concat(entry.data.map((d: Datum) => entry.yAccessor(d))) : combined,
+        entry
+          ? combined.concat(entry.data.map((d: Datum) => entry.yAccessor(d)).filter(valueIsDefined))
+          : combined,
       [],
     );
 

--- a/packages/visx-xychart/src/types/data.ts
+++ b/packages/visx-xychart/src/types/data.ts
@@ -51,4 +51,5 @@ export interface DataContextType<
   unregisterData: (keyOrKeys: string | string[]) => void;
   setDimensions: (dims: { width: number; height: number; margin: Margin }) => void;
   theme: XYChartTheme;
+  horizontal: boolean;
 }

--- a/packages/visx-xychart/src/utils/getScaledValueFactory.ts
+++ b/packages/visx-xychart/src/utils/getScaledValueFactory.ts
@@ -16,10 +16,6 @@ export default function getScaledValueFactory<Scale extends AxisScale, Datum>(
         (align === 'start' ? 0 : getScaleBandwidth(scale)) / (align === 'center' ? 2 : 1);
       return scaledValue + bandwidthOffset;
     }
-    // @TODO: NaNs cause react-spring to throw, but the return value of this must be number
-    // this currently causes issues in vertical <> horizontal transitions because
-    // x/yAccessors from context are out of sync with props.horizontal
-    // horizontal should be moved to context
     return NaN;
   };
 }

--- a/packages/visx-xychart/src/utils/isDiscreteScale.ts
+++ b/packages/visx-xychart/src/utils/isDiscreteScale.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AxisScaleOutput } from '@visx/axis';
+import { ScaleConfig } from '@visx/scale';
+
+export default function isDiscreteScale(scaleConfig: ScaleConfig<AxisScaleOutput, any, any>) {
+  return (
+    scaleConfig?.type === 'band' || scaleConfig?.type === 'ordinal' || scaleConfig?.type === 'point'
+  );
+}

--- a/packages/visx-xychart/test/components/BarGroup.test.tsx
+++ b/packages/visx-xychart/test/components/BarGroup.test.tsx
@@ -42,7 +42,7 @@ describe('<BarGroup />', () => {
     const wrapper = mount(
       <DataProvider {...providerProps}>
         <svg>
-          <BarGroup horizontal>
+          <BarGroup>
             <BarSeries dataKey={series1.key} {...series1} />
             <BarSeries dataKey={series2.key} {...series2} />
           </BarGroup>

--- a/packages/visx-xychart/test/components/BarStack.test.tsx
+++ b/packages/visx-xychart/test/components/BarStack.test.tsx
@@ -49,7 +49,7 @@ describe('<BarStack />', () => {
     const wrapper = mount(
       <DataProvider {...providerProps}>
         <svg>
-          <BarStack horizontal>
+          <BarStack>
             <BarSeries dataKey={series1.key} {...series1} />
             <BarSeries dataKey={series2.key} {...series2} />
           </BarStack>

--- a/packages/visx-xychart/test/mocks/getDataContext.ts
+++ b/packages/visx-xychart/test/mocks/getDataContext.ts
@@ -30,6 +30,7 @@ function getDataContext(entries?: Parameters<typeof DataRegistry.prototype.regis
     innerHeight: height,
     theme: lightTheme,
     setDimensions: noOp,
+    horizontal: false,
   };
 
   return mockContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5241,10 +5241,10 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
 
-d3-array@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.6.0.tgz#b8df0c695eab26e2b2fd4ffe2d84bd703f8d0faf"
-  integrity sha512-1TgzIGb6hrHKSCGccdL209Ibk41HCeyv5znFEvJfBsBGhD3qpoHt/2W2ECpyLxpG1k7aNJz0BYrmLpVs9hIGNQ==
+d3-array@^2.6.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
+  integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==
 
 d3-chord@^1.0.4:
   version "1.0.6"
@@ -5281,6 +5281,11 @@ d3-hierarchy@^1.1.4, d3-hierarchy@^1.1.8:
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
   integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
 
+d3-interpolate-path@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate-path/-/d3-interpolate-path-2.2.1.tgz#fd8ff20a90aff3f380bcd1c15305e7b531e55d07"
+  integrity sha512-6qLLh/KJVzls0XtMsMpcxhqMhgVEN7VIbR/6YGZe2qlS8KDgyyVB20XcmGnDyB051HcefQXM/Tppa9vcANEA4Q==
+
 d3-interpolate@1, d3-interpolate@^1.1.5, d3-interpolate@^1.2.0, d3-interpolate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
@@ -5292,6 +5297,11 @@ d3-path@1, d3-path@^1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
   integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
+  integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
 
 d3-random@^1.0.3:
   version "1.1.2"
@@ -5336,6 +5346,13 @@ d3-shape@^1.0.6, d3-shape@^1.2.0:
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
   dependencies:
     d3-path "1"
+
+d3-shape@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.0.0.tgz#2331b62fa784a2a1daac47a7233cfd69301381fd"
+  integrity sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==
+  dependencies:
+    d3-path "1 - 2"
 
 d3-time-format@2, d3-time-format@^2.0.5:
   version "2.2.3"


### PR DESCRIPTION
#### :rocket: Enhancements
#### :bug: Bug Fix
#### :house: Internal

This PR is a mix of improvements + new functionality for `xychart` which are all related by the rabbit hole 🐰 ⚫    I went down trying to fix one problem:

> when transitioning between `horizontal` and `vertical` orientation in the `/xychart` demo, or transitioning between more or fewer data points, `AnimatedPath` would throw due to a cryptic `react-spring` error

The improvements are:
1) does a sweep to handle missing values across all `*Series` and in scale domain calculation
  - tested by updating the `/xychart` demo 
2) (✅  fix for above error) updates `AnimatedPath` to handle missing values and a _**changing number of values**_ by using [`d3-interpolate-path`](https://github.com/pbeshai/d3-interpolate-path) for interpolating `path` `d` attributes
  - caveats: the only animation case this doesn't handle well is `Area` shapes with missing data (see below) but I think it's the best option
  - 💬  reasoning
    - `react-spring` does this beautifully [**except** when the # of points changes](https://www.react-spring.io/docs/props/spring) which is the cause of the above error 😭  
      - I spent a long time trying to test `react-spring@9.0.0-rc.3` to see if it did ... but it does not
    - `d3-interpolate` does not handle path string interpolation well (well documented see e.g., [here](https://bocoup.com/weblog/improving-d3-path-animation))
    - [`flubber`](https://github.com/veltman/flubber) is the best at handling all edge cases, but it assumes _**closed polygon shapes**_ (doesn't apply for lines) and its bundle size is 10x what `d3-interpolate-path`s is.
3) moves `props.horizontal` from all `*Series` types to `DataProvider`s `context.horizontal` (the start of the 🐰 ⚫  )
  - `horizontal` determines orientation for `Bar`-type series, and it controls nearest `datum` logic for mouse events across _all `*Series`_
  - the goal of this was to make it easier for `dev`s, most of the time `horizontal` can be inferred from `scale` types and this could be done once in context vs specified / computed in each `*Series`

<img src="https://user-images.githubusercontent.com/4496521/97388005-685bb880-1894-11eb-85a0-893f755902a4.gif" width="600" />

Note issue with missing area data
<img src="https://user-images.githubusercontent.com/4496521/97388016-6abe1280-1894-11eb-9949-12fbbd2f13f1.gif" width="600" />


@kristw @techniq 