### PR TITLE
new(xychart): expose curve types

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -30,6 +30,7 @@ export default function Example({ height }: Props) {
         accessors,
         animationTrajectory,
         config,
+        curve,
         data,
         numTicks,
         renderAreaSeries,
@@ -122,6 +123,7 @@ export default function Example({ height }: Props) {
                   xAccessor={accessors.x.Austin}
                   yAccessor={accessors.y.Austin}
                   fillOpacity={0.5}
+                  curve={curve}
                 />
                 <AnimatedAreaSeries
                   dataKey="San Francisco"
@@ -129,6 +131,7 @@ export default function Example({ height }: Props) {
                   xAccessor={accessors.x['San Francisco']}
                   yAccessor={accessors.y['San Francisco']}
                   fillOpacity={0.5}
+                  curve={curve}
                 />
               </>
             )}
@@ -139,12 +142,14 @@ export default function Example({ height }: Props) {
                   data={data}
                   xAccessor={accessors.x.Austin}
                   yAccessor={accessors.y.Austin}
+                  curve={curve}
                 />
                 <AnimatedLineSeries
                   dataKey="San Francisco"
                   data={data}
                   xAccessor={accessors.x['San Francisco']}
                   yAccessor={accessors.y['San Francisco']}
+                  curve={curve}
                 />
               </>
             )}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -6,6 +6,7 @@ import { GlyphProps } from '@visx/xychart/lib/types';
 import { AnimationTrajectory } from '@visx/react-spring/lib/types';
 import cityTemperature, { CityTemperature } from '@visx/mock-data/lib/mocks/cityTemperature';
 import { GlyphCross, GlyphDot, GlyphStar } from '@visx/glyph';
+import { curveLinear, curveStep, curveCardinal } from '@visx/curve';
 import customTheme from './customTheme';
 
 const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
@@ -46,6 +47,7 @@ type ProvidedProps = {
     y: SimpleScaleConfig;
   };
   animationTrajectory: AnimationTrajectory;
+  curve: typeof curveLinear | typeof curveCardinal | typeof curveStep;
   data: CityTemperature[];
   numTicks: number;
   renderAreaSeries: boolean;
@@ -98,6 +100,7 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [fewerDatum, setFewerDatum] = useState(false);
   const [missingValues, setMissingValues] = useState(false);
   const [glyphComponent, setGlyphComponent] = useState<'star' | 'cross' | 'circle' | '🍍'>('star');
+  const [curveType, setCurveType] = useState<'linear' | 'cardinal' | 'step'>('linear');
   const themeBackground = theme.backgroundColor;
   const renderGlyph = useCallback(
     ({ size, color }: GlyphProps<CityTemperature>) => {
@@ -160,6 +163,10 @@ export default function ExampleControls({ children }: ControlsProps) {
         accessors,
         animationTrajectory,
         config,
+        curve:
+          (curveType === 'cardinal' && curveCardinal) ||
+          (curveType === 'step' && curveStep) ||
+          curveLinear,
         data: fewerDatum
           ? missingValues
             ? dataSmallMissingValues
@@ -435,6 +442,35 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={renderLineOrAreaSeries === 'none' || !canRenderLineOrArea}
             />
             none
+          </label>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <strong>curve shape</strong>
+          <label>
+            <input
+              type="radio"
+              disabled={!canRenderLineOrArea || renderLineOrAreaSeries === 'none'}
+              onChange={() => setCurveType('linear')}
+              checked={curveType === 'linear'}
+            />
+            linear
+          </label>
+          <label>
+            <input
+              type="radio"
+              disabled={!canRenderLineOrArea || renderLineOrAreaSeries === 'none'}
+              onChange={() => setCurveType('cardinal')}
+              checked={curveType === 'cardinal'}
+            />
+            cardinal (smooth)
+          </label>
+          <label>
+            <input
+              type="radio"
+              disabled={!canRenderLineOrArea || renderLineOrAreaSeries === 'none'}
+              onChange={() => setCurveType('step')}
+              checked={curveType === 'step'}
+            />
+            step
           </label>
         </div>
         {/** glyph */}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/package.json
@@ -7,6 +7,7 @@
     "@babel/runtime": "^7.8.4",
     "@types/react": "^16",
     "@types/react-dom": "^16",
+    "@visx/curve": "1.0.0",
     "@visx/glyph": "latest",
     "@visx/mock-data": "latest",
     "@visx/pattern": "latest",

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useCallback, useMemo } from 'react';
 import { AxisScale } from '@visx/axis';
-import Area from '@visx/shape/lib/shapes/Area';
+import Area, { AreaProps } from '@visx/shape/lib/shapes/Area';
 import LinePath, { LinePathProps } from '@visx/shape/lib/shapes/LinePath';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';
@@ -20,6 +20,8 @@ export type BaseAreaSeriesProps<
 > = SeriesProps<XScale, YScale, Datum> & {
   /** Whether to render a Line along value of the Area shape (area is fill only). */
   renderLine?: boolean;
+  /** Sets the curve factory (from @visx/curve or d3-curve) for the line generator. Defaults to curveLinear. */
+  curve?: AreaProps<Datum>['curve'];
   /** Props to be passed to the Line, if rendered. */
   lineProps?: Omit<LinePathProps<Datum>, 'data' | 'x' | 'y' | 'children' | 'defined'>;
   /** Rendered component which is passed path props by BaseAreaSeries after processing. */
@@ -27,6 +29,7 @@ export type BaseAreaSeriesProps<
 } & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
 
 function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
+  curve,
   data,
   dataKey,
   xAccessor,
@@ -97,7 +100,7 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
 
   return (
     <>
-      <Area {...xAccessors} {...yAccessors} {...areaProps} defined={isDefined}>
+      <Area {...xAccessors} {...yAccessors} {...areaProps} curve={curve} defined={isDefined}>
         {({ path }) => (
           <PathComponent stroke="transparent" fill={color} {...areaProps} d={path(data) || ''} />
         )}
@@ -106,9 +109,8 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
         <LinePath<Datum>
           x={getScaledX}
           y={getScaledY}
-          stroke={color}
-          strokeWidth={2}
           defined={isDefined}
+          curve={curve}
           {...lineProps}
         >
           {({ path }) => (

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback } from 'react';
-import LinePath from '@visx/shape/lib/shapes/LinePath';
+import LinePath, { LinePathProps } from '@visx/shape/lib/shapes/LinePath';
 import { AxisScale } from '@visx/axis';
 import DataContext from '../../../context/DataContext';
 import { SeriesProps } from '../../../types';
@@ -18,9 +18,12 @@ export type BaseLineSeriesProps<
 > = SeriesProps<XScale, YScale, Datum> & {
   /** Rendered component which is passed path props by BaseLineSeries after processing. */
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
+  /** Sets the curve factory (from @visx/curve or d3-curve) for the line generator. Defaults to curveLinear. */
+  curve?: LinePathProps<Datum>['curve'];
 } & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
 
 function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
+  curve,
   data,
   dataKey,
   xAccessor,
@@ -69,14 +72,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   useEventEmitter('mouseout', hideTooltip);
 
   return (
-    <LinePath
-      x={getScaledX}
-      y={getScaledY}
-      stroke={color}
-      strokeWidth={2}
-      defined={isDefined}
-      {...lineProps}
-    >
+    <LinePath x={getScaledX} y={getScaledY} defined={isDefined} curve={curve} {...lineProps}>
       {({ path }) => (
         <PathComponent
           stroke={color}


### PR DESCRIPTION
#### :rocket: Enhancements

This PR 
- exposes the `curve` line interpolation prop in `BaseAreaSeries` + `BaseLineSeries`
- adds `curve` controls to the `/xychart` demo to illustrate + test that interpolation works correctly

This is very addicting to play with
<img src="https://user-images.githubusercontent.com/4496521/97388529-7f4eda80-1895-11eb-97cf-020814944c64.gif" width="600" />

@kristw @techniq 