### PR TITLE
new(drag): add `useDrag` hook

### DIFF
--- a/packages/visx-demo/src/pages/docs/drag.tsx
+++ b/packages/visx-demo/src/pages/docs/drag.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import DragReadme from '!!raw-loader!../../../../visx-drag/Readme.md';
 import Drag from '../../../../visx-drag/src/Drag';
+import useDrag from '../../../../visx-drag/src/useDrag';
 import DocPage from '../../components/DocPage';
 import DragITile from '../../components/Gallery/DragITile';
 import DragIITile from '../../components/Gallery/DragIITile';
 
-const components = [Drag];
+const components = [useDrag, Drag];
 
 const examples = [DragITile, DragIITile];
 

--- a/packages/visx-demo/src/sandboxes/visx-drag-i/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-drag-i/Example.tsx
@@ -64,27 +64,25 @@ export default function DragI({ width, height }: DragIProps) {
               setDraggingItems(raise(draggingItems, i));
             }}
           >
-            {({ dragStart, dragEnd, dragMove, isDragging, dx, dy }) =>
-              (false && isDragging && console.log(d.id, d.x, dx)) || (
-                <circle
-                  key={`dot-${d.id}`}
-                  cx={d.x}
-                  cy={d.y}
-                  r={isDragging ? d.radius + 4 : d.radius}
-                  fill={isDragging ? 'url(#stroke)' : colorScale(d.id)}
-                  transform={`translate(${dx}, ${dy})`}
-                  fillOpacity={0.9}
-                  stroke={isDragging ? 'white' : 'transparent'}
-                  strokeWidth={2}
-                  onMouseMove={dragMove}
-                  onMouseUp={dragEnd}
-                  onMouseDown={dragStart}
-                  onTouchStart={dragStart}
-                  onTouchMove={dragMove}
-                  onTouchEnd={dragEnd}
-                />
-              )
-            }
+            {({ dragStart, dragEnd, dragMove, isDragging, dx, dy }) => (
+              <circle
+                key={`dot-${d.id}`}
+                cx={d.x}
+                cy={d.y}
+                r={isDragging ? d.radius + 4 : d.radius}
+                fill={isDragging ? 'url(#stroke)' : colorScale(d.id)}
+                transform={`translate(${dx}, ${dy})`}
+                fillOpacity={0.9}
+                stroke={isDragging ? 'white' : 'transparent'}
+                strokeWidth={2}
+                onMouseMove={dragMove}
+                onMouseUp={dragEnd}
+                onMouseDown={dragStart}
+                onTouchStart={dragStart}
+                onTouchMove={dragMove}
+                onTouchEnd={dragEnd}
+              />
+            )}
           </Drag>
         ))}
       </svg>

--- a/packages/visx-drag/Readme.md
+++ b/packages/visx-drag/Readme.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/npm/dm/@visx/drag.svg?style=flat-square" />
 </a>
 
-`@visx/drag` provides `react` components for making items within an interface (or chart) draggable.
+`@visx/drag` provides `react` components and hooks for making items within an interface (or chart) draggable.
 
 ## Installation
 

--- a/packages/visx-drag/package.json
+++ b/packages/visx-drag/package.json
@@ -31,7 +31,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.3.0-0"
+    "react": "^16.8.0-0"
   },
   "dependencies": {
     "@types/react": "*",

--- a/packages/visx-drag/src/Drag.tsx
+++ b/packages/visx-drag/src/Drag.tsx
@@ -1,139 +1,42 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
-import { localPoint } from '@visx/event';
+import useDrag, { UseDrag, UseDragOptions } from './useDrag';
 
-type MouseOrTouchEvent = React.MouseEvent | React.TouchEvent;
-
-export type DragProps = {
+export type DragProps = UseDragOptions & {
   /** Children render function which is passed the state of dragging and callbacks for drag start/end/move. */
-  children: (args: ChildrenArgs) => React.ReactNode;
+  children: (args: UseDrag) => React.ReactNode;
   /** Width of the drag container. */
   width: number;
   /** Height of the drag container. */
   height: number;
   /** Whether to render an invisible rect below children to capture the drag area as defined by width and height. */
   captureDragArea?: boolean;
-  /** Whether to reset drag state upon the start of a new drag. */
-  resetOnStart?: boolean;
-  /** Optional callback invoked upon drag end. */
-  onDragEnd?: (args: HandlerArgs) => void;
-  /** Optional callback invoked upon drag movement. */
-  onDragMove?: (args: HandlerArgs) => void;
-  /** Optional callback invoked upon drag start. */
-  onDragStart?: (args: HandlerArgs) => void;
 };
 
-export type DragState = {
-  x: number | undefined;
-  y: number | undefined;
-  dx: number;
-  dy: number;
-  isDragging: boolean;
-};
+export default function Drag({
+  captureDragArea = true,
+  children,
+  height,
+  onDragEnd,
+  onDragMove,
+  onDragStart,
+  resetOnStart,
+  width,
+}: DragProps) {
+  const drag = useDrag({ resetOnStart, onDragEnd, onDragMove, onDragStart });
 
-export type HandlerArgs = DragState & { event: MouseOrTouchEvent };
-
-type ChildrenArgs = DragState & {
-  dragEnd: (event: MouseOrTouchEvent) => void;
-  dragMove: (event: MouseOrTouchEvent) => void;
-  dragStart: (event: MouseOrTouchEvent) => void;
-};
-
-export default class Drag extends React.Component<DragProps, DragState> {
-  static defaultProps = {
-    captureDragArea: true,
-    resetOnStart: false,
-  };
-
-  state = {
-    x: undefined,
-    y: undefined,
-    dx: 0,
-    dy: 0,
-    isDragging: false,
-  };
-
-  handleDragStart = (event: MouseOrTouchEvent) => {
-    const { onDragStart, resetOnStart } = this.props;
-    event.persist();
-
-    this.setState(
-      ({ dx, dy }) => {
-        const point = localPoint(event) || { x: 0, y: 0 };
-        return {
-          isDragging: true,
-          dx: resetOnStart ? 0 : dx,
-          dy: resetOnStart ? 0 : dy,
-          x: resetOnStart ? point.x : point.x - dx,
-          y: resetOnStart ? point.y : point.y - dy,
-        };
-      },
-      onDragStart &&
-        (() => {
-          onDragStart({ ...this.state, event });
-        }),
-    );
-  };
-
-  handleDragMove = (event: MouseOrTouchEvent) => {
-    const { onDragMove } = this.props;
-    event.persist();
-
-    this.setState(
-      ({ x, y, isDragging }) => {
-        const point = localPoint(event) || { x: 0, y: 0 };
-        return isDragging
-          ? {
-              isDragging: true,
-              dx: point.x - (x || 0),
-              dy: point.y - (y || 0),
-            }
-          : null;
-      },
-      onDragMove &&
-        (() => {
-          if (this.state.isDragging) onDragMove({ ...this.state, event });
-        }),
-    );
-  };
-
-  handleDragEnd = (event: MouseOrTouchEvent) => {
-    const { onDragEnd } = this.props;
-    event.persist();
-
-    this.setState(
-      { isDragging: false },
-      onDragEnd &&
-        (() => {
-          onDragEnd({ ...this.state, event });
-        }),
-    );
-  };
-
-  render() {
-    const { x, y, dx, dy, isDragging } = this.state;
-    const { children, width, height, captureDragArea } = this.props;
-    return (
-      <>
-        {isDragging && captureDragArea && (
-          <rect
-            width={width}
-            height={height}
-            onMouseMove={this.handleDragMove}
-            onMouseUp={this.handleDragEnd}
-            fill="transparent"
-          />
-        )}
-        {children({
-          x,
-          y,
-          dx,
-          dy,
-          isDragging,
-          dragEnd: this.handleDragEnd,
-          dragMove: this.handleDragMove,
-          dragStart: this.handleDragStart,
-        })}
-      </>
-    );
-  }
+  return (
+    <>
+      {drag.isDragging && captureDragArea && (
+        <rect
+          width={width}
+          height={height}
+          onMouseMove={drag.dragMove}
+          onMouseUp={drag.dragEnd}
+          fill="transparent"
+        />
+      )}
+      {children(drag)}
+    </>
+  );
 }

--- a/packages/visx-drag/src/Drag.tsx
+++ b/packages/visx-drag/src/Drag.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-handler-names */
 import React from 'react';
-import useDrag, { UseDrag, UseDragOptions } from './useDrag';
+import useDrag, { UseDrag, UseDragOptions, HandlerArgs as HandlerArgsType } from './useDrag';
+
+export type HandlerArgs = HandlerArgsType;
 
 export type DragProps = UseDragOptions & {
   /** Children render function which is passed the state of dragging and callbacks for drag start/end/move. */

--- a/packages/visx-drag/src/index.ts
+++ b/packages/visx-drag/src/index.ts
@@ -1,2 +1,3 @@
 export { default as Drag } from './Drag';
+export { default as useDrag } from './useDrag';
 export { default as raise } from './util/raise';

--- a/packages/visx-drag/src/useDrag.tsx
+++ b/packages/visx-drag/src/useDrag.tsx
@@ -4,52 +4,45 @@ import useStateWithCallback from './util/useStateWithCallback';
 
 type MouseOrTouchEvent = React.MouseEvent | React.TouchEvent;
 
+export type HandlerArgs = DragState & {
+  /** Drag event. */
+  event: MouseOrTouchEvent;
+};
+
 export type UseDragOptions = {
   /** Whether to reset drag state upon the start of a new drag. */
   resetOnStart?: boolean;
   /** Optional callback invoked upon drag end. */
-  onDragEnd?: (args: {
-    x: number | undefined; // these are defined multiple times for improved docs
-    y: number | undefined;
-    dx: number;
-    dy: number;
-    isDragging: boolean;
-    event: MouseOrTouchEvent;
-  }) => void;
+  onDragEnd?: (args: HandlerArgs) => void;
   /** Optional callback invoked upon drag movement. */
-  onDragMove?: (args: {
-    x: number | undefined;
-    y: number | undefined;
-    dx: number;
-    dy: number;
-    isDragging: boolean;
-    event: MouseOrTouchEvent;
-  }) => void;
+  onDragMove?: (args: HandlerArgs) => void;
   /** Optional callback invoked upon drag start. */
-  onDragStart?: (args: {
-    x: number | undefined;
-    y: number | undefined;
-    dx: number;
-    dy: number;
-    isDragging: boolean;
-    event: MouseOrTouchEvent;
-  }) => void;
+  onDragStart?: (args: HandlerArgs) => void;
 };
 
 export type DragState = {
+  /** x position of drag at drag start time, reset to 0 if `resetOnStart=true`. */
   x: number | undefined;
+  /** y position of drag at drag start time, reset to 0 if `resetOnStart=true`. */
   y: number | undefined;
+  /** Change in x position since drag start, reset to 0 on drag start if `resetOnStart=true`. */
   dx: number;
+  /** Change in y position since drag start, reset to 0 on drag start if `resetOnStart=true`. */
   dy: number;
+  /** Whether a drag is currently in progress. */
   isDragging: boolean;
 };
 
 export type UseDrag = DragState & {
+  /** Callback to be be invoked on drag end. */
   dragEnd: (event: MouseOrTouchEvent) => void;
+  /** Callback to be be invoked on drag move. */
   dragMove: (event: MouseOrTouchEvent) => void;
+  /** Callback to be be invoked on drag start. */
   dragStart: (event: MouseOrTouchEvent) => void;
 };
 
+/** Hook for dragging, returns a `UseDrag` object. */
 export default function useDrag({
   resetOnStart = false,
   onDragEnd,

--- a/packages/visx-drag/src/useDrag.tsx
+++ b/packages/visx-drag/src/useDrag.tsx
@@ -79,11 +79,10 @@ export default function useDrag({
           const point = localPoint(event) || { x: 0, y: 0 };
           return isDragging
             ? {
+                ...currState,
                 isDragging: true,
                 dx: point.x - (x || 0),
                 dy: point.y - (y || 0),
-                x,
-                y,
               }
             : currState;
         },

--- a/packages/visx-drag/src/useDrag.tsx
+++ b/packages/visx-drag/src/useDrag.tsx
@@ -4,17 +4,36 @@ import useStateWithCallback from './util/useStateWithCallback';
 
 type MouseOrTouchEvent = React.MouseEvent | React.TouchEvent;
 
-export type HandlerArgs = DragState & { event: MouseOrTouchEvent };
-
 export type UseDragOptions = {
   /** Whether to reset drag state upon the start of a new drag. */
   resetOnStart?: boolean;
   /** Optional callback invoked upon drag end. */
-  onDragEnd?: (args: HandlerArgs) => void;
+  onDragEnd?: (args: {
+    x: number | undefined; // these are defined multiple times for improved docs
+    y: number | undefined;
+    dx: number;
+    dy: number;
+    isDragging: boolean;
+    event: MouseOrTouchEvent;
+  }) => void;
   /** Optional callback invoked upon drag movement. */
-  onDragMove?: (args: HandlerArgs) => void;
+  onDragMove?: (args: {
+    x: number | undefined;
+    y: number | undefined;
+    dx: number;
+    dy: number;
+    isDragging: boolean;
+    event: MouseOrTouchEvent;
+  }) => void;
   /** Optional callback invoked upon drag start. */
-  onDragStart?: (args: HandlerArgs) => void;
+  onDragStart?: (args: {
+    x: number | undefined;
+    y: number | undefined;
+    dx: number;
+    dy: number;
+    isDragging: boolean;
+    event: MouseOrTouchEvent;
+  }) => void;
 };
 
 export type DragState = {
@@ -32,7 +51,7 @@ export type UseDrag = DragState & {
 };
 
 export default function useDrag({
-  resetOnStart,
+  resetOnStart = false,
   onDragEnd,
   onDragMove,
   onDragStart,

--- a/packages/visx-drag/src/useDrag.tsx
+++ b/packages/visx-drag/src/useDrag.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback } from 'react';
+import { localPoint } from '@visx/event';
+import useStateWithCallback from './util/useStateWithCallback';
+
+type MouseOrTouchEvent = React.MouseEvent | React.TouchEvent;
+
+export type HandlerArgs = DragState & { event: MouseOrTouchEvent };
+
+export type UseDragOptions = {
+  /** Whether to reset drag state upon the start of a new drag. */
+  resetOnStart?: boolean;
+  /** Optional callback invoked upon drag end. */
+  onDragEnd?: (args: HandlerArgs) => void;
+  /** Optional callback invoked upon drag movement. */
+  onDragMove?: (args: HandlerArgs) => void;
+  /** Optional callback invoked upon drag start. */
+  onDragStart?: (args: HandlerArgs) => void;
+};
+
+export type DragState = {
+  x: number | undefined;
+  y: number | undefined;
+  dx: number;
+  dy: number;
+  isDragging: boolean;
+};
+
+export type UseDrag = DragState & {
+  dragEnd: (event: MouseOrTouchEvent) => void;
+  dragMove: (event: MouseOrTouchEvent) => void;
+  dragStart: (event: MouseOrTouchEvent) => void;
+};
+
+export default function useDrag({
+  resetOnStart,
+  onDragEnd,
+  onDragMove,
+  onDragStart,
+}: UseDragOptions): UseDrag {
+  const [dragState, setDragStateWithCallback] = useStateWithCallback<DragState>({
+    x: undefined,
+    y: undefined,
+    dx: 0,
+    dy: 0,
+    isDragging: false,
+  });
+
+  const handleDragStart = useCallback(
+    (event: MouseOrTouchEvent) => {
+      event.persist();
+
+      setDragStateWithCallback(
+        ({ dx, dy }) => {
+          const point = localPoint(event) || { x: 0, y: 0 };
+          return {
+            isDragging: true,
+            dx: resetOnStart ? 0 : dx,
+            dy: resetOnStart ? 0 : dy,
+            x: resetOnStart ? point.x : point.x - dx,
+            y: resetOnStart ? point.y : point.y - dy,
+          };
+        },
+        onDragStart &&
+          (currState => {
+            onDragStart({ ...currState, event });
+          }),
+      );
+    },
+    [onDragStart, resetOnStart, setDragStateWithCallback],
+  );
+
+  const handleDragMove = useCallback(
+    (event: MouseOrTouchEvent) => {
+      event.persist();
+
+      setDragStateWithCallback(
+        currState => {
+          const { x, y, isDragging } = currState;
+          const point = localPoint(event) || { x: 0, y: 0 };
+          return isDragging
+            ? {
+                isDragging: true,
+                dx: point.x - (x || 0),
+                dy: point.y - (y || 0),
+                x,
+                y,
+              }
+            : currState;
+        },
+        onDragMove &&
+          (currState => {
+            if (currState.isDragging) onDragMove({ ...currState, event });
+          }),
+      );
+    },
+    [onDragMove, setDragStateWithCallback],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: MouseOrTouchEvent) => {
+      event.persist();
+
+      setDragStateWithCallback(
+        currState => ({ ...currState, isDragging: false }),
+        onDragEnd &&
+          (currState => {
+            onDragEnd({ ...currState, event });
+          }),
+      );
+    },
+    [onDragEnd, setDragStateWithCallback],
+  );
+
+  return {
+    ...dragState,
+    dragEnd: handleDragEnd,
+    dragMove: handleDragMove,
+    dragStart: handleDragStart,
+  };
+}

--- a/packages/visx-drag/src/useDrag.tsx
+++ b/packages/visx-drag/src/useDrag.tsx
@@ -48,7 +48,7 @@ export default function useDrag({
   onDragEnd,
   onDragMove,
   onDragStart,
-}: UseDragOptions): UseDrag {
+}: UseDragOptions | undefined = {}): UseDrag {
   const [dragState, setDragStateWithCallback] = useStateWithCallback<DragState>({
     x: undefined,
     y: undefined,

--- a/packages/visx-drag/src/useDrag.tsx
+++ b/packages/visx-drag/src/useDrag.tsx
@@ -2,11 +2,11 @@ import React, { useCallback } from 'react';
 import { localPoint } from '@visx/event';
 import useStateWithCallback from './util/useStateWithCallback';
 
-type MouseOrTouchEvent = React.MouseEvent | React.TouchEvent;
+type MouseTouchOrPointerEvent = React.MouseEvent | React.TouchEvent | React.PointerEvent;
 
 export type HandlerArgs = DragState & {
   /** Drag event. */
-  event: MouseOrTouchEvent;
+  event: MouseTouchOrPointerEvent;
 };
 
 export type UseDragOptions = {
@@ -35,11 +35,11 @@ export type DragState = {
 
 export type UseDrag = DragState & {
   /** Callback to be be invoked on drag end. */
-  dragEnd: (event: MouseOrTouchEvent) => void;
+  dragEnd: (event: MouseTouchOrPointerEvent) => void;
   /** Callback to be be invoked on drag move. */
-  dragMove: (event: MouseOrTouchEvent) => void;
+  dragMove: (event: MouseTouchOrPointerEvent) => void;
   /** Callback to be be invoked on drag start. */
-  dragStart: (event: MouseOrTouchEvent) => void;
+  dragStart: (event: MouseTouchOrPointerEvent) => void;
 };
 
 /** Hook for dragging, returns a `UseDrag` object. */
@@ -58,7 +58,7 @@ export default function useDrag({
   });
 
   const handleDragStart = useCallback(
-    (event: MouseOrTouchEvent) => {
+    (event: MouseTouchOrPointerEvent) => {
       event.persist();
 
       setDragStateWithCallback(
@@ -82,7 +82,7 @@ export default function useDrag({
   );
 
   const handleDragMove = useCallback(
-    (event: MouseOrTouchEvent) => {
+    (event: MouseTouchOrPointerEvent) => {
       event.persist();
 
       setDragStateWithCallback(
@@ -108,7 +108,7 @@ export default function useDrag({
   );
 
   const handleDragEnd = useCallback(
-    (event: MouseOrTouchEvent) => {
+    (event: MouseTouchOrPointerEvent) => {
       event.persist();
 
       setDragStateWithCallback(

--- a/packages/visx-drag/src/util/useStateWithCallback.ts
+++ b/packages/visx-drag/src/util/useStateWithCallback.ts
@@ -5,6 +5,7 @@ type SetStateWithCallback<State> = (
   callback?: (currState: State) => void,
 ) => void;
 
+/** A hook that exposes a setState(state, callback) API similar to a component class. */
 export default function useStateWithCallback<State>(
   initialState: State,
 ): [State, SetStateWithCallback<State>] {

--- a/packages/visx-drag/src/util/useStateWithCallback.ts
+++ b/packages/visx-drag/src/util/useStateWithCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 type SetStateWithCallback<State> = (
   nextState: State | ((currState: State) => State),
@@ -19,7 +19,8 @@ export default function useStateWithCallback<State>(
     [setState],
   );
 
-  useEffect(() => {
+  // if we use useEffect, some callback invocations are skipped
+  useLayoutEffect(() => {
     // `null` on initial render, so we only execute callback on state *updates*
     if (callbackRef.current) {
       callbackRef.current(state);

--- a/packages/visx-drag/src/util/useStateWithCallback.ts
+++ b/packages/visx-drag/src/util/useStateWithCallback.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type SetStateWithCallback<State> = (
+  nextState: State | ((currState: State) => State),
+  callback?: (currState: State) => void,
+) => void;
+
+export default function useStateWithCallback<State>(
+  initialState: State,
+): [State, SetStateWithCallback<State>] {
+  const [state, setState] = useState(initialState);
+  const callbackRef = useRef<null | ((state: State) => void)>(null);
+
+  const setStateCallback = useCallback<SetStateWithCallback<State>>(
+    (nextState, callback) => {
+      callbackRef.current = callback || null;
+      setState(nextState);
+    },
+    [setState],
+  );
+
+  useEffect(() => {
+    // `null` on initial render, so we only execute callback on state *updates*
+    if (callbackRef.current) {
+      callbackRef.current(state);
+      callbackRef.current = null; // reset callback after execution
+    }
+  }, [state]);
+
+  return [state, setStateCallback];
+}

--- a/packages/visx-drag/test/raise.test.ts
+++ b/packages/visx-drag/test/raise.test.ts
@@ -1,0 +1,7 @@
+import { raise } from '../src';
+
+describe('raise', () => {
+  test('it should be defined', () => {
+    expect(raise).toBeDefined();
+  });
+});

--- a/packages/visx-drag/test/useDrag.test.ts
+++ b/packages/visx-drag/test/useDrag.test.ts
@@ -1,0 +1,7 @@
+import { useDrag } from '../src';
+
+describe('useDrag', () => {
+  test('it should be defined', () => {
+    expect(useDrag).toBeDefined();
+  });
+});

--- a/packages/visx-drag/test/useStateWithCallback.test.ts
+++ b/packages/visx-drag/test/useStateWithCallback.test.ts
@@ -1,0 +1,7 @@
+import useStateWithCallback from '../src/util/useStateWithCallback';
+
+describe('useStateWithCallback', () => {
+  test('it should be defined', () => {
+    expect(useStateWithCallback).toBeDefined();
+  });
+});


### PR DESCRIPTION
#### :rocket: Enhancements

This PR 
- adds a `useDrag` hook to `@visx/drag` to complement the render props `<Drag />` component 
  - **(I need this for some `@visx/annotation` work)**
- refactors `<Drag />` to use `useDrag`
- bumps `react` `peerDependency` to `^16.8.0-0` to support hooks
- adds support for `PointerEvents` (in addition to `Mouse` and `Touch` events) in drag callbacks
- updates `@visx/demo` `/drag-ii` to use `useDrag` so we have examples of both usages
- updates `/docs/drag` to include `useDrag`
- adds minimal tests for all `@visx/drag` apis

Tested via
- verified `/drag-ii` is still functional
- Updated docs
<img width="600" src="https://user-images.githubusercontent.com/4496521/97628920-9a7f2e80-19ea-11eb-9d89-1bd6439ff062.png" />

@hshoff @kristw 