### PR TITLE
new(demo): add Annotation demo

### DIFF
--- a/packages/visx-annotation/Readme.md
+++ b/packages/visx-annotation/Readme.md
@@ -6,7 +6,15 @@
   </a>
 </p>
 
-Annotations enable you to label points, thresholds, or regions of a visualization to provide additional context for your chart consumer.
+Annotations enable you to label points, thresholds, or regions of a visualization to provide additional context to for your chart consumer.
+
+Each annotation consists of three (optional) parts:
+
+1) `Subject` – what is being annotated (point, line, region)
+
+2) `Label` – the text annotation for the annotation
+
+3) `Connector` – line connecting a subject and label
 
 ## Installation
 

--- a/packages/visx-annotation/Readme.md
+++ b/packages/visx-annotation/Readme.md
@@ -6,15 +6,59 @@
   </a>
 </p>
 
-Annotations enable you to label points, thresholds, or regions of a visualization to provide additional context to for your chart consumer.
+SVG `Annotation`s enable you to label points, thresholds, or regions of a visualization to provide additional context to for your chart consumer. This package is heavily inspired by [Susie Lu](https://github.com/susielu/)'s [`react-annotation`](https://github.com/susielu/react-annotation) library.
 
 Each annotation consists of three (optional) parts:
 
-1) `Subject` – what is being annotated (point, line, region)
+1) `Subject` – what part of a chart is being annotated (point, line, region)
+   - `CircleSubject`
+   - `LineSubject`
+   - (More 🔜)
 
-2) `Label` – the text annotation for the annotation
+2) `Label` – the text component for the annotation. Handles SVG text wrapping using `@visx/text`, and supports `title` and `subtitle` customization as well as vertical & horizontal anchors / alignment
 
 3) `Connector` – line connecting a subject and label
+
+The `Annotation` or `EditableAnnotation` component wrappers allow you to compose these components and simplify their individual positioning:
+
+```tsx
+<EditableAnnotation
+  x={subjectX}
+  y={subjectY}
+  dx={labelDx} // x offset of label from subject
+  dy={labelDy} // y offset of label from subject
+  onDragEnd={({ x, y, dx, dy }) => ...}
+>
+  <Connector />
+  <CircleSubject />
+  <Label title="Context about this point" subtitle="More deets">
+</EditableAnnotation>
+```
+
+Components can also be used in isolation, in which case you must specify exact positions for each item:
+
+```tsx
+() => (
+  <g>
+    <Connector x={subjectX} y={subjectY} dx={labelDx} dy={labelDy} />
+    <CircleSubject x={subjectX} y={subjectY} />
+    <Label x={subjectX + labelDx} y={subjectY + labelDy} title="...">
+  </g>
+)
+```
+
+##### ⚠️ `ResizeObserver` dependency
+
+The `Label` component relies on `ResizeObserver`s for auto-sizing. If you need a polyfill, you can either polute the `window` object or inject it cleanly through props:
+
+
+```tsx
+import { ResizeObserver } from 'your-favorite-polyfill';
+
+function App() {
+  return <Label resizeObserverPolyfill={ResizeObserver} {...} />
+```
+
 
 ## Installation
 

--- a/packages/visx-annotation/Readme.md
+++ b/packages/visx-annotation/Readme.md
@@ -10,14 +10,12 @@ SVG `Annotation`s enable you to label points, thresholds, or regions of a visual
 
 Each annotation consists of three (optional) parts:
 
-1) `Subject` – what part of a chart is being annotated (point, line, region)
-   - `CircleSubject`
-   - `LineSubject`
-   - (More 🔜)
+1) `Subject` (`CircleSubject`, `LineSubject`, more 🔜) – what part of a chart is being annotated (point, line, region)
 
 2) `Label` – the text component for the annotation. Handles SVG text wrapping using `@visx/text`, and supports `title` and `subtitle` customization as well as vertical & horizontal anchors / alignment
 
 3) `Connector` – line connecting a subject and label
+
 
 The `Annotation` or `EditableAnnotation` component wrappers allow you to compose these components and simplify their individual positioning:
 

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -73,7 +73,7 @@ export default function AnnotationLabel({
   fontColor = '#222',
   horizontalAnchor: propsHorizontalAnchor,
   resizeObserverPolyfill,
-  showAnchorLine,
+  showAnchorLine = true,
   showBackground = true,
   subtitle,
   subtitleDy = 4,

--- a/packages/visx-demo/src/components/Gallery/AnnotationTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/AnnotationTile.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Annotation, { AnnotationProps, greens } from '../../sandboxes/visx-annotation/Example';
+import GalleryTile from '../GalleryTile';
+
+export { default as packageJson } from '../../sandboxes/visx-area/package.json';
+
+const tileStyles = { background: greens[0] };
+const detailsStyles: React.CSSProperties = {
+  color: greens[0],
+  background: greens[1],
+  borderBottomRightRadius: 16,
+  borderBottomLeftRadius: 16,
+};
+const exampleProps = { compact: true };
+const exampleRenderer: React.FC<AnnotationProps> = props =>
+  props.width > 0 && props.height > 0 ? <Annotation {...props} /> : null;
+
+export default function AnnotationTile() {
+  return (
+    <GalleryTile<AnnotationProps>
+      title="Annotation"
+      description="<Annotation />"
+      exampleRenderer={exampleRenderer}
+      exampleUrl="/annotation"
+      detailsStyles={detailsStyles}
+      tileStyles={tileStyles}
+      exampleProps={exampleProps}
+    />
+  );
+}

--- a/packages/visx-demo/src/components/Gallery/AnnotationTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/AnnotationTile.tsx
@@ -6,8 +6,7 @@ export { default as packageJson } from '../../sandboxes/visx-area/package.json';
 
 const tileStyles = { background: greens[0] };
 const detailsStyles: React.CSSProperties = {
-  color: greens[0],
-  background: greens[1],
+  color: greens[2],
   borderBottomRightRadius: 16,
   borderBottomLeftRadius: 16,
 };

--- a/packages/visx-demo/src/components/Gallery/index.tsx
+++ b/packages/visx-demo/src/components/Gallery/index.tsx
@@ -4,6 +4,7 @@ import Tilt from 'react-tilt';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
+import * as AnnotationTile from './AnnotationTile';
 import * as AreaTile from './AreaTile';
 import * as AxisTile from './AxisTile';
 import * as BarGroupHorizontalTile from './BarGroupHorizontalTile';
@@ -63,6 +64,7 @@ const tiles = [
   StreamGraphTile,
   LegendsTile,
   ThresholdTile,
+  AnnotationTile,
   TreemapTile,
   ZoomITile,
   LineRadialTile,
@@ -117,6 +119,7 @@ export default function Gallery() {
                 query: routePackage === visxPackage ? undefined : { pkg: visxPackage },
               }}
             >
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
               <a
                 className={cx('filter-button', {
                   emphasize: routePackage === visxPackage,

--- a/packages/visx-demo/src/pages/annotation.tsx
+++ b/packages/visx-demo/src/pages/annotation.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Show from '../components/Show';
+import Annotation from '../sandboxes/visx-annotation/Example';
+import AnnotationSource from '!!raw-loader!../sandboxes/visx-annotation/Example';
+import packageJson from '../sandboxes/visx-annotation/package.json';
+
+export default () => (
+  <Show
+    component={Annotation}
+    title="Annotation"
+    codeSandboxDirectoryName="visx-annotation"
+    packageJson={packageJson}
+  >
+    {AnnotationSource}
+  </Show>
+);

--- a/packages/visx-demo/src/pages/docs/annotation.tsx
+++ b/packages/visx-demo/src/pages/docs/annotation.tsx
@@ -1,11 +1,34 @@
 import React from 'react';
 import AnnotationReadme from '!!raw-loader!../../../../visx-annotation/Readme.md';
-import LinePathAnnotation from '../../../../visx-annotation/src/deprecated/LinePathAnnotation';
+import Annotation from '../../../../visx-annotation/src/components/Annotation';
+import EditableAnnotation from '../../../../visx-annotation/src/components/EditableAnnotation';
+import CircleSubject from '../../../../visx-annotation/src/components/CircleSubject';
+import LineSubject from '../../../../visx-annotation/src/components/LineSubject';
+import Connector from '../../../../visx-annotation/src/components/Connector';
+import Label from '../../../../visx-annotation/src/components/Label';
+import LinePathAnnotationDeprecated from '../../../../visx-annotation/src/deprecated/LinePathAnnotation';
 import DocPage from '../../components/DocPage';
+import AnnotationTile from '../../components/Gallery/AnnotationTile';
 
-const components = [LinePathAnnotation];
+const components = [
+  Annotation,
+  EditableAnnotation,
+  CircleSubject,
+  LineSubject,
+  Connector,
+  Label,
+  LinePathAnnotationDeprecated,
+];
+
+const examples = [AnnotationTile];
 
 const AnnotationDocs = () => (
-  <DocPage components={components} readme={AnnotationReadme} visxPackage="annotation" />
+  <DocPage
+    examples={examples}
+    components={components}
+    readme={AnnotationReadme}
+    visxPackage="annotation"
+  />
 );
+
 export default AnnotationDocs;

--- a/packages/visx-demo/src/sandboxes/exampleToVisxDependencyLookup.ts
+++ b/packages/visx-demo/src/sandboxes/exampleToVisxDependencyLookup.ts
@@ -1,3 +1,4 @@
+import annotationPackageJson from './visx-annotation/package.json';
 import areaPackageJson from './visx-area/package.json';
 import axisPackageJson from './visx-axis/package.json';
 import bargroupPackageJson from './visx-bargroup/package.json';
@@ -42,6 +43,7 @@ import extractVisxDepsFromPackageJson from '../components/util/extractVisxDepsFr
 import { VisxPackage } from '../types';
 
 const examples = [
+  annotationPackageJson,
   areaPackageJson,
   axisPackageJson,
   bargroupHorizontalPackageJson,

--- a/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
@@ -1,17 +1,9 @@
 /* eslint @typescript-eslint/no-use-before-define: 'off', jsx-a11y/label-has-associated-control: 'off' */
-import React, { useMemo, useState } from 'react';
-import {
-  Annotation,
-  EditableAnnotation,
-  Label,
-  Connector,
-  CircleSubject,
-  LineSubject,
-} from '@visx/annotation';
-import appleStock, { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
+import React from 'react';
+import { Label, Connector, CircleSubject, LineSubject } from '@visx/annotation';
 import { LinePath } from '@visx/shape';
-import { scaleTime, scaleLinear } from '@visx/scale';
-import { extent, bisector } from 'd3-array';
+import ExampleControls from './ExampleControls';
+import findNearestDatum from './findNearestDatum';
 
 export type AnnotationProps = {
   width: number;
@@ -19,198 +11,98 @@ export type AnnotationProps = {
   compact?: boolean;
 };
 
-const data = appleStock.slice(-100);
-const getDate = (d: AppleStock) => new Date(d.date).valueOf();
-const getStockValue = (d: AppleStock) => d.close;
-const annotateDatum = data[Math.floor(data.length / 2) + 4];
-
-const approxTooltipHeight = 60;
 export const orange = '#ff7e67';
 export const greens = ['#ecf4f3', '#68b0ab', '#006a71'];
 
-export default function Example({ width, height, compact }: AnnotationProps) {
-  const xScale = useMemo(
-    () =>
-      scaleTime({
-        domain: extent(data, d => getDate(d)) as number[],
-        range: [0, width],
-      }),
-    [width],
-  );
-  const yScale = useMemo(
-    () =>
-      scaleLinear({
-        domain: extent(data, d => getStockValue(d)) as number[],
-        range: [height - 100, 100],
-      }),
-    [height],
-  );
-
-  const [editAnnotation, setEditAnnotation] = useState(false);
-  const [connectorType, setConnectorType] = useState<'line' | 'elbow'>('elbow');
-  const [subjectType, setSubjectType] = useState<'circle' | 'horizontal-line' | 'vertical-line'>(
-    'circle',
-  );
-  const [labelWidth] = useState(compact ? 100 : 175);
-  const [annotationPosition, setAnnotationPosition] = useState({
-    x: xScale(getDate(annotateDatum)) ?? 0,
-    y: yScale(getStockValue(annotateDatum)) ?? 0,
-    dx: compact ? -50 : -100,
-    dy: compact ? -30 : -50,
-  });
-
-  const AnnotationComponent = editAnnotation ? EditableAnnotation : Annotation;
-
+export default function Example({ width, height, compact = false }: AnnotationProps) {
   return (
-    <>
-      <svg width={width} height={height}>
-        <rect width={width} height={height} fill={greens[0]} />
-        <LinePath
-          stroke={greens[2]}
-          strokeWidth={2}
-          data={data}
-          x={d => xScale(getDate(d)) ?? 0}
-          y={d => yScale(getStockValue(d)) ?? 0}
-        />
-        <AnnotationComponent
-          width={width}
-          height={height}
-          x={annotationPosition.x}
-          y={annotationPosition.y}
-          dx={annotationPosition.dx}
-          dy={annotationPosition.dy}
-          onDragEnd={({ event, ...nextPosition }) => {
-            // snap Annotation to the nearest data point
-            const nearestDatum = findNearestDatum({
-              value: subjectType === 'horizontal-line' ? nextPosition.y : nextPosition.x,
-              scale: subjectType === 'horizontal-line' ? yScale : xScale,
-              accessor: subjectType === 'horizontal-line' ? getStockValue : getDate,
-            });
-            const x = xScale(getDate(nearestDatum)) ?? 0;
-            const y = yScale(getStockValue(nearestDatum)) ?? 0;
-
-            // flip label to keep in view
-            const shouldFlipDx =
-              (nextPosition.dx > 0 && x + nextPosition.dx + labelWidth > width) ||
-              (nextPosition.dx < 0 && x + nextPosition.dx - labelWidth <= 0);
-            const shouldFlipDy = // 100 is est. tooltip height
-              (nextPosition.dy > 0 && height - (y + nextPosition.dy) < approxTooltipHeight) ||
-              (nextPosition.dy < 0 && y + nextPosition.dy - approxTooltipHeight <= 0);
-            setAnnotationPosition({
-              x,
-              y,
-              dx: (shouldFlipDx ? -1 : 1) * nextPosition.dx,
-              dy: (shouldFlipDy ? -1 : 1) * nextPosition.dy,
-            });
-          }}
-        >
-          <Connector stroke={orange} type={connectorType} />
-          <Label
-            title="Annotation"
-            subtitle={compact ? 'Subtitle' : 'Subtitle with deets and deets and deets and deets'}
-            fontColor={greens[2]}
-            backgroundFill={greens[0]}
-            backgroundProps={{ stroke: orange }}
-            width={labelWidth}
+    <ExampleControls width={width} height={height} compact={compact}>
+      {({
+        AnnotationComponent,
+        annotationPosition,
+        approxTooltipHeight,
+        anchorOutlinePosition,
+        connectorType,
+        data,
+        getDate,
+        getStockValue,
+        horizontalAnchor,
+        labelWidth,
+        setAnnotationPosition,
+        subjectType,
+        subtitle,
+        title,
+        verticalAnchor,
+        xScale,
+        yScale,
+      }) => (
+        <svg width={width} height={height}>
+          <rect width={width} height={height} fill={greens[0]} />
+          <LinePath
+            stroke={greens[2]}
+            strokeWidth={2}
+            data={data}
+            x={d => xScale(getDate(d)) ?? 0}
+            y={d => yScale(getStockValue(d)) ?? 0}
           />
-          {subjectType === 'circle' && <CircleSubject stroke={orange} />}
-          {subjectType !== 'circle' && (
-            <LineSubject
-              orientation={subjectType === 'vertical-line' ? 'vertical' : 'horizontal'}
-              stroke={orange}
-              min={0}
-              max={subjectType === 'vertical-line' ? height : width}
-            />
-          )}
-        </AnnotationComponent>
-      </svg>
-      {!compact && (
-        <div className="controls">
-          <div>
-            <label>
-              <input
-                type="checkbox"
-                onChange={() => setEditAnnotation(!editAnnotation)}
-                checked={editAnnotation}
-              />
-              Edit annotation
-            </label>
-          </div>
-          <div>
-            <strong>Connector type</strong>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setConnectorType('elbow')}
-                checked={connectorType === 'elbow'}
-              />
-              Elbow
-            </label>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setConnectorType('line')}
-                checked={connectorType === 'line'}
-              />
-              Straight line
-            </label>
-          </div>
-          <div>
-            <strong>Subject type</strong>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setSubjectType('circle')}
-                checked={subjectType === 'circle'}
-              />
-              Circle
-            </label>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setSubjectType('vertical-line')}
-                checked={subjectType === 'vertical-line'}
-              />
-              Vertical line
-            </label>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setSubjectType('horizontal-line')}
-                checked={subjectType === 'horizontal-line'}
-              />
-              Horizontal line
-            </label>
-          </div>
-        </div>
-      )}
-      <style jsx>{`
-        .controls {
-          font-size: 13px;
-          line-height: 1.5em;
-        }
-      `}</style>
-    </>
-  );
-}
+          <AnnotationComponent
+            width={width}
+            height={height}
+            x={annotationPosition.x}
+            y={annotationPosition.y}
+            dx={annotationPosition.dx}
+            dy={annotationPosition.dy}
+            onDragEnd={({ event, ...nextPosition }) => {
+              // snap Annotation to the nearest data point
+              const nearestDatum = findNearestDatum({
+                accessor: subjectType === 'horizontal-line' ? getStockValue : getDate,
+                data,
+                scale: subjectType === 'horizontal-line' ? yScale : xScale,
+                value: subjectType === 'horizontal-line' ? nextPosition.y : nextPosition.x,
+              });
+              const x = xScale(getDate(nearestDatum)) ?? 0;
+              const y = yScale(getStockValue(nearestDatum)) ?? 0;
 
-function findNearestDatum({
-  value,
-  scale,
-  accessor,
-}: {
-  value: number;
-  scale: ReturnType<typeof scaleLinear | typeof scaleTime>;
-  accessor: (d: AppleStock) => number;
-}): AppleStock {
-  const bisect = bisector(accessor).left;
-  const nearestValue = scale.invert(value) as number;
-  const nearestValueIndex = bisect(data, nearestValue, 1);
-  const d0 = data[nearestValueIndex - 1];
-  const d1 = data[nearestValueIndex];
-  let nearestDatum = d0;
-  if (d1 && getDate(d1)) {
-    nearestDatum = nearestValue - accessor(d0) > accessor(d1) - nearestValue ? d1 : d0;
-  }
-  return nearestDatum;
+              // flip label to keep in view
+              const shouldFlipDx =
+                (nextPosition.dx > 0 && x + nextPosition.dx + labelWidth > width) ||
+                (nextPosition.dx < 0 && x + nextPosition.dx - labelWidth <= 0);
+              const shouldFlipDy = // 100 is est. tooltip height
+                (nextPosition.dy > 0 && height - (y + nextPosition.dy) < approxTooltipHeight) ||
+                (nextPosition.dy < 0 && y + nextPosition.dy - approxTooltipHeight <= 0);
+              setAnnotationPosition({
+                x,
+                y,
+                dx: (shouldFlipDx ? -1 : 1) * nextPosition.dx,
+                dy: (shouldFlipDy ? -1 : 1) * nextPosition.dy,
+              });
+            }}
+          >
+            <Connector stroke={orange} type={connectorType} />
+            <Label
+              backgroundFill="white"
+              anchorOutlinePosition={anchorOutlinePosition}
+              anchorOutlineStroke={greens[2]}
+              backgroundProps={{ stroke: greens[1] }}
+              fontColor={greens[2]}
+              horizontalAnchor={horizontalAnchor}
+              subtitle={subtitle}
+              title={title}
+              verticalAnchor={verticalAnchor}
+              width={labelWidth}
+            />
+            {subjectType === 'circle' && <CircleSubject stroke={orange} />}
+            {subjectType !== 'circle' && (
+              <LineSubject
+                orientation={subjectType === 'vertical-line' ? 'vertical' : 'horizontal'}
+                stroke={orange}
+                min={0}
+                max={subjectType === 'vertical-line' ? height : width}
+              />
+            )}
+          </AnnotationComponent>
+        </svg>
+      )}
+    </ExampleControls>
+  );
 }

--- a/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
@@ -1,0 +1,210 @@
+/* eslint @typescript-eslint/no-use-before-define: 'off', jsx-a11y/label-has-associated-control: 'off' */
+import React, { useMemo, useState } from 'react';
+import {
+  Annotation,
+  EditableAnnotation,
+  Label,
+  Connector,
+  CircleSubject,
+  LineSubject,
+} from '@visx/annotation';
+import appleStock, { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
+import { LinePath } from '@visx/shape';
+import { scaleTime, scaleLinear } from '@visx/scale';
+import { extent, bisector } from 'd3-array';
+
+type Props = {
+  width: number;
+  height: number;
+};
+
+const data = appleStock.slice(-100);
+const getDate = (d: AppleStock) => new Date(d.date).valueOf();
+const getStockValue = (d: AppleStock) => d.close;
+const annotateDatum = data[Math.floor(data.length / 2) + 4];
+
+const APPROX_TOOLTIP_HEIGHT = 60;
+const ORANGE = '#ff7e67';
+const GREENS = ['#ecf4f3', '#68b0ab', '#006a71'];
+
+export default function Example({ width, height }: Props) {
+  const xScale = useMemo(
+    () =>
+      scaleTime({
+        domain: extent(data, d => getDate(d)) as number[],
+        range: [0, width],
+      }),
+    [width],
+  );
+  const yScale = useMemo(
+    () =>
+      scaleLinear({
+        domain: extent(data, d => getStockValue(d)) as number[],
+        range: [height - 100, 100],
+      }),
+    [height],
+  );
+
+  const [editAnnotation, setEditAnnotation] = useState(false);
+  const [connectorType, setConnectorType] = useState<'line' | 'elbow'>('elbow');
+  const [subjectType, setSubjectType] = useState<'circle' | 'horizontal-line' | 'vertical-line'>(
+    'circle',
+  );
+  const [labelWidth] = useState(175);
+  const [annotationPosition, setAnnotationPosition] = useState({
+    x: xScale(getDate(annotateDatum)) ?? 0,
+    y: yScale(getStockValue(annotateDatum)) ?? 0,
+    dx: -100,
+    dy: -50,
+  });
+
+  const AnnotationComponent = editAnnotation ? EditableAnnotation : Annotation;
+
+  return (
+    <>
+      <svg width={width} height={height}>
+        <rect width={width} height={height} fill={GREENS[0]} />
+        <LinePath
+          stroke={GREENS[2]}
+          strokeWidth={2}
+          data={data}
+          x={d => xScale(getDate(d)) ?? 0}
+          y={d => yScale(getStockValue(d)) ?? 0}
+        />
+        <AnnotationComponent
+          width={width}
+          height={height}
+          x={annotationPosition.x}
+          y={annotationPosition.y}
+          dx={annotationPosition.dx}
+          dy={annotationPosition.dy}
+          onDragEnd={({ event, ...nextPosition }) => {
+            const nearestDatum = findNearestDatum({
+              value: subjectType === 'horizontal-line' ? nextPosition.y : nextPosition.x,
+              scale: subjectType === 'horizontal-line' ? yScale : xScale,
+              accessor: subjectType === 'horizontal-line' ? getStockValue : getDate,
+            });
+            const x = xScale(getDate(nearestDatum)) ?? 0;
+            const y = yScale(getStockValue(nearestDatum)) ?? 0;
+            const shouldFlipDx =
+              (nextPosition.dx > 0 && x + nextPosition.dx + labelWidth > width) ||
+              (nextPosition.dx < 0 && x + nextPosition.dx - labelWidth <= 0);
+            const shouldFlipDy = // 100 is est. tooltip height
+              (nextPosition.dy > 0 && height - (y + nextPosition.dy) < APPROX_TOOLTIP_HEIGHT) ||
+              (nextPosition.dy < 0 && y + nextPosition.dy - APPROX_TOOLTIP_HEIGHT <= 0);
+            setAnnotationPosition({
+              x,
+              y,
+              dx: (shouldFlipDx ? -1 : 1) * nextPosition.dx,
+              dy: (shouldFlipDy ? -1 : 1) * nextPosition.dy,
+            });
+          }}
+        >
+          <Connector stroke={ORANGE} type={connectorType} />
+          <Label
+            title="Annotation title"
+            subtitle="Subtitle with deets and deets and deets and deets"
+            fontColor="#fff"
+            titleProps={{ fill: GREENS[2], fontSize: 16 }}
+            backgroundFill={GREENS[1]}
+            width={labelWidth}
+          />
+          {subjectType === 'circle' && <CircleSubject stroke={ORANGE} />}
+          {subjectType !== 'circle' && (
+            <LineSubject
+              orientation={subjectType === 'vertical-line' ? 'vertical' : 'horizontal'}
+              stroke={ORANGE}
+              min={0}
+              max={subjectType === 'vertical-line' ? height : width}
+            />
+          )}
+        </AnnotationComponent>
+      </svg>
+      <div className="controls">
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setEditAnnotation(!editAnnotation)}
+              checked={editAnnotation}
+            />
+            Edit annotation
+          </label>
+        </div>
+        <div>
+          <strong>Connector type</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setConnectorType('elbow')}
+              checked={connectorType === 'elbow'}
+            />
+            Elbow
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setConnectorType('line')}
+              checked={connectorType === 'line'}
+            />
+            Straight line
+          </label>
+        </div>
+        <div>
+          <strong>Subject type</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setSubjectType('circle')}
+              checked={subjectType === 'circle'}
+            />
+            Circle
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setSubjectType('vertical-line')}
+              checked={subjectType === 'vertical-line'}
+            />
+            Vertical line
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setSubjectType('horizontal-line')}
+              checked={subjectType === 'horizontal-line'}
+            />
+            Horizontal line
+          </label>
+        </div>
+      </div>
+      <style jsx>{`
+        .controls {
+          font-size: 13px;
+          line-height: 1.5em;
+        }
+      `}</style>
+    </>
+  );
+}
+
+function findNearestDatum({
+  value,
+  scale,
+  accessor,
+}: {
+  value: number;
+  scale: ReturnType<typeof scaleLinear | typeof scaleTime>;
+  accessor: (d: AppleStock) => number;
+}): AppleStock {
+  const bisect = bisector(accessor).left;
+  const nearestValue = scale.invert(value) as number;
+  const nearestValueIndex = bisect(data, nearestValue, 1);
+  const d0 = data[nearestValueIndex - 1];
+  const d1 = data[nearestValueIndex];
+  let nearestDatum = d0;
+  if (d1 && getDate(d1)) {
+    nearestDatum = nearestValue - accessor(d0) > accessor(d1) - nearestValue ? d1 : d0;
+  }
+  return nearestDatum;
+}

--- a/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/no-use-before-define: 'off', jsx-a11y/label-has-associated-control: 'off' */
 import React from 'react';
 import { Label, Connector, CircleSubject, LineSubject } from '@visx/annotation';
 import { LinePath } from '@visx/shape';
@@ -21,7 +20,6 @@ export default function Example({ width, height, compact = false }: AnnotationPr
         AnnotationComponent,
         annotationPosition,
         approxTooltipHeight,
-        anchorOutlinePosition,
         connectorType,
         data,
         getDate,
@@ -29,6 +27,7 @@ export default function Example({ width, height, compact = false }: AnnotationPr
         horizontalAnchor,
         labelWidth,
         setAnnotationPosition,
+        showAnchorLine,
         subjectType,
         subtitle,
         title,
@@ -81,8 +80,8 @@ export default function Example({ width, height, compact = false }: AnnotationPr
             <Connector stroke={orange} type={connectorType} />
             <Label
               backgroundFill="white"
-              anchorOutlinePosition={anchorOutlinePosition}
-              anchorOutlineStroke={greens[2]}
+              showAnchorLine={showAnchorLine}
+              anchorLineStroke={greens[2]}
               backgroundProps={{ stroke: greens[1] }}
               fontColor={greens[2]}
               horizontalAnchor={horizontalAnchor}

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -13,7 +13,7 @@ type ExampleControlsProps = AnnotationProps & {
 type AnnotationPosition = { x: number; y: number; dx: number; dy: number };
 
 type ProvidedProps = {
-  AnnotationComponent: React.FC<any>;
+  AnnotationComponent: typeof Annotation | typeof EditableAnnotation;
   anchorLinePosition?: 'auto' | 'all' | 'none';
   annotationPosition: AnnotationPosition;
   approxTooltipHeight: number;
@@ -29,8 +29,8 @@ type ProvidedProps = {
   subtitle: string;
   title: string;
   verticalAnchor?: 'top' | 'middle' | 'bottom';
-  xScale: PickD3Scale<'time'>;
-  yScale: PickD3Scale<'linear'>;
+  xScale: PickD3Scale<'time', number>;
+  yScale: PickD3Scale<'linear', number>;
 };
 
 const data = appleStock.slice(-100);

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -14,7 +14,7 @@ type AnnotationPosition = { x: number; y: number; dx: number; dy: number };
 
 type ProvidedProps = {
   AnnotationComponent: React.FC<any>;
-  anchorOutlinePosition?: 'auto' | 'all' | 'none';
+  anchorLinePosition?: 'auto' | 'all' | 'none';
   annotationPosition: AnnotationPosition;
   approxTooltipHeight: number;
   connectorType: 'line' | 'elbow';
@@ -24,6 +24,7 @@ type ProvidedProps = {
   horizontalAnchor?: 'left' | 'middle' | 'right';
   labelWidth: number;
   setAnnotationPosition: (position: AnnotationPosition) => void;
+  showAnchorLine: boolean;
   subjectType: 'circle' | 'horizontal-line' | 'vertical-line';
   subtitle: string;
   title: string;
@@ -68,9 +69,7 @@ export default function ExampleControls({
   );
   const [connectorType, setConnectorType] = useState<ProvidedProps['connectorType']>('elbow');
   const [subjectType, setSubjectType] = useState<ProvidedProps['subjectType']>('circle');
-  const [anchorOutlinePosition, setBackgroundOutlinePosition] = useState<
-    ProvidedProps['anchorOutlinePosition']
-  >('auto');
+  const [showAnchorLine, setShowAnchorLine] = useState(true);
   const [verticalAnchor, setVerticalAnchor] = useState<ProvidedProps['verticalAnchor'] | 'auto'>(
     'auto',
   );
@@ -91,7 +90,6 @@ export default function ExampleControls({
         AnnotationComponent: editAnnotation ? EditableAnnotation : Annotation,
         annotationPosition,
         approxTooltipHeight,
-        anchorOutlinePosition,
         connectorType,
         data,
         getDate,
@@ -99,6 +97,7 @@ export default function ExampleControls({
         horizontalAnchor: horizontalAnchor === 'auto' ? undefined : horizontalAnchor,
         labelWidth,
         setAnnotationPosition,
+        showAnchorLine,
         subjectType,
         subtitle,
         title,
@@ -175,33 +174,6 @@ export default function ExampleControls({
             </label>
           </div>
           <div>
-            <strong>Background outline</strong>&nbsp;&nbsp;
-            <label>
-              <input
-                type="radio"
-                onChange={() => setBackgroundOutlinePosition('auto')}
-                checked={anchorOutlinePosition === 'auto'}
-              />
-              auto
-            </label>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setBackgroundOutlinePosition('none')}
-                checked={anchorOutlinePosition === 'none'}
-              />
-              none
-            </label>
-            <label>
-              <input
-                type="radio"
-                onChange={() => setBackgroundOutlinePosition('all')}
-                checked={anchorOutlinePosition === 'all'}
-              />
-              all
-            </label>
-          </div>
-          <div>
             <strong>Horizontal label anchor</strong>
             <label>
               <input
@@ -270,6 +242,16 @@ export default function ExampleControls({
               />
               bottom
             </label>
+            <div>
+              <label>
+                <input
+                  type="checkbox"
+                  onChange={() => setShowAnchorLine(!showAnchorLine)}
+                  checked={showAnchorLine}
+                />
+                Show anchor line
+              </label>
+            </div>
           </div>
         </div>
       )}

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -1,0 +1,287 @@
+/* eslint jsx-a11y/label-has-associated-control: 'off', @typescript-eslint/no-explicit-any: 'off' */
+import React, { useMemo, useState } from 'react';
+import appleStock, { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
+import { PickD3Scale, scaleTime, scaleLinear } from '@visx/scale';
+import { extent } from 'd3-array';
+import { Annotation, EditableAnnotation } from '@visx/annotation';
+import { AnnotationProps } from './Example';
+
+type ExampleControlsProps = AnnotationProps & {
+  children: (props: ProvidedProps) => React.ReactNode;
+};
+
+type AnnotationPosition = { x: number; y: number; dx: number; dy: number };
+
+type ProvidedProps = {
+  AnnotationComponent: React.FC<any>;
+  anchorOutlinePosition?: 'auto' | 'all' | 'none';
+  annotationPosition: AnnotationPosition;
+  approxTooltipHeight: number;
+  connectorType: 'line' | 'elbow';
+  data: AppleStock[];
+  getDate: (d: AppleStock) => number;
+  getStockValue: (d: AppleStock) => number;
+  horizontalAnchor?: 'left' | 'middle' | 'right';
+  labelWidth: number;
+  setAnnotationPosition: (position: AnnotationPosition) => void;
+  subjectType: 'circle' | 'horizontal-line' | 'vertical-line';
+  subtitle: string;
+  title: string;
+  verticalAnchor?: 'top' | 'middle' | 'bottom';
+  xScale: PickD3Scale<'time'>;
+  yScale: PickD3Scale<'linear'>;
+};
+
+const data = appleStock.slice(-100);
+const getDate = (d: AppleStock) => new Date(d.date).valueOf();
+const getStockValue = (d: AppleStock) => d.close;
+const annotateDatum = data[Math.floor(data.length / 2) + 4];
+const approxTooltipHeight = 70;
+
+export default function ExampleControls({
+  width,
+  height,
+  compact = false,
+  children,
+}: ExampleControlsProps) {
+  const xScale = useMemo(
+    () =>
+      scaleTime({
+        domain: extent(data, d => getDate(d)) as number[],
+        range: [0, width],
+      }),
+    [width],
+  );
+  const yScale = useMemo(
+    () =>
+      scaleLinear({
+        domain: extent(data, d => getStockValue(d)) as number[],
+        range: [height - 100, 100],
+      }),
+    [height],
+  );
+
+  const [editAnnotation, setEditAnnotation] = useState(false);
+  const [title, setTitle] = useState('Title');
+  const [subtitle, setSubtitle] = useState(
+    compact ? 'Subtitle' : 'Subtitle with deets and deets and deets and deets',
+  );
+  const [connectorType, setConnectorType] = useState<ProvidedProps['connectorType']>('elbow');
+  const [subjectType, setSubjectType] = useState<ProvidedProps['subjectType']>('circle');
+  const [anchorOutlinePosition, setBackgroundOutlinePosition] = useState<
+    ProvidedProps['anchorOutlinePosition']
+  >('auto');
+  const [verticalAnchor, setVerticalAnchor] = useState<ProvidedProps['verticalAnchor'] | 'auto'>(
+    'auto',
+  );
+  const [horizontalAnchor, setHorizontalAnchor] = useState<
+    ProvidedProps['horizontalAnchor'] | 'auto'
+  >('auto');
+  const [labelWidth] = useState(compact ? 100 : 175);
+  const [annotationPosition, setAnnotationPosition] = useState({
+    x: xScale(getDate(annotateDatum)) ?? 0,
+    y: yScale(getStockValue(annotateDatum)) ?? 0,
+    dx: compact ? -50 : -100,
+    dy: compact ? -30 : -50,
+  });
+
+  return (
+    <>
+      {children({
+        AnnotationComponent: editAnnotation ? EditableAnnotation : Annotation,
+        annotationPosition,
+        approxTooltipHeight,
+        anchorOutlinePosition,
+        connectorType,
+        data,
+        getDate,
+        getStockValue,
+        horizontalAnchor: horizontalAnchor === 'auto' ? undefined : horizontalAnchor,
+        labelWidth,
+        setAnnotationPosition,
+        subjectType,
+        subtitle,
+        title,
+        verticalAnchor: verticalAnchor === 'auto' ? undefined : verticalAnchor,
+        xScale,
+        yScale,
+      })}
+      {!compact && (
+        <div className="controls">
+          <div>
+            <label>
+              <strong>Title</strong>&nbsp;&nbsp;
+              <input type="text" onChange={e => setTitle(e.target.value)} value={title} />
+            </label>
+            &nbsp;&nbsp;&nbsp;
+            <label>
+              <strong>Subtitle</strong>&nbsp;&nbsp;
+              <input type="text" onChange={e => setSubtitle(e.target.value)} value={subtitle} />
+            </label>
+            &nbsp;&nbsp;&nbsp;
+            <label>
+              <input
+                type="checkbox"
+                onChange={() => setEditAnnotation(!editAnnotation)}
+                checked={editAnnotation}
+              />
+              Edit annotation
+            </label>
+          </div>
+          <div>
+            <strong>Connector type</strong>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setConnectorType('elbow')}
+                checked={connectorType === 'elbow'}
+              />
+              Elbow
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setConnectorType('line')}
+                checked={connectorType === 'line'}
+              />
+              Straight line
+            </label>
+          </div>
+          <div>
+            <strong>Subject type</strong>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setSubjectType('circle')}
+                checked={subjectType === 'circle'}
+              />
+              Circle
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setSubjectType('vertical-line')}
+                checked={subjectType === 'vertical-line'}
+              />
+              Vertical line
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setSubjectType('horizontal-line')}
+                checked={subjectType === 'horizontal-line'}
+              />
+              Horizontal line
+            </label>
+          </div>
+          <div>
+            <strong>Background outline</strong>&nbsp;&nbsp;
+            <label>
+              <input
+                type="radio"
+                onChange={() => setBackgroundOutlinePosition('auto')}
+                checked={anchorOutlinePosition === 'auto'}
+              />
+              auto
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setBackgroundOutlinePosition('none')}
+                checked={anchorOutlinePosition === 'none'}
+              />
+              none
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setBackgroundOutlinePosition('all')}
+                checked={anchorOutlinePosition === 'all'}
+              />
+              all
+            </label>
+          </div>
+          <div>
+            <strong>Horizontal label anchor</strong>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setHorizontalAnchor('auto')}
+                checked={horizontalAnchor === 'auto'}
+              />
+              auto
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setHorizontalAnchor('left')}
+                checked={horizontalAnchor === 'left'}
+              />
+              left
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setHorizontalAnchor('middle')}
+                checked={horizontalAnchor === 'middle'}
+              />
+              middle
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setHorizontalAnchor('right')}
+                checked={horizontalAnchor === 'right'}
+              />
+              right
+            </label>
+          </div>
+          <div>
+            <strong>Vertical label anchor</strong>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setVerticalAnchor('auto')}
+                checked={verticalAnchor === 'auto'}
+              />
+              auto
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setVerticalAnchor('top')}
+                checked={verticalAnchor === 'top'}
+              />
+              top
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setVerticalAnchor('middle')}
+                checked={verticalAnchor === 'middle'}
+              />
+              middle
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setVerticalAnchor('bottom')}
+                checked={verticalAnchor === 'bottom'}
+              />
+              bottom
+            </label>
+          </div>
+        </div>
+      )}
+      <style jsx>{`
+        .controls {
+          font-size: 13px;
+          line-height: 1.5em;
+        }
+        .controls > div {
+          margin-bottom: 4px;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/packages/visx-demo/src/sandboxes/visx-annotation/findNearestDatum.ts
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/findNearestDatum.ts
@@ -1,0 +1,26 @@
+import { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
+import { bisector } from 'd3-array';
+import { scaleLinear, scaleTime } from '@visx/scale';
+
+export default function findNearestDatum({
+  value,
+  scale,
+  accessor,
+  data,
+}: {
+  value: number;
+  scale: ReturnType<typeof scaleLinear | typeof scaleTime>;
+  accessor: (d: AppleStock) => number;
+  data: AppleStock[];
+}): AppleStock {
+  const bisect = bisector(accessor).left;
+  const nearestValue = scale.invert(value) as number;
+  const nearestValueIndex = bisect(data, nearestValue, 1);
+  const d0 = data[nearestValueIndex - 1];
+  const d1 = data[nearestValueIndex];
+  let nearestDatum = d0;
+  if (d1 && accessor(d1)) {
+    nearestDatum = nearestValue - accessor(d0) > accessor(d1) - nearestValue ? d1 : d0;
+  }
+  return nearestDatum;
+}

--- a/packages/visx-demo/src/sandboxes/visx-annotation/index.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@visx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/visx-demo/src/sandboxes/visx-annotation/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@visx/annotation-example",
+  "description": "Standalone visx annotation demo.",
+  "main": "index.tsx",
+  "private": true,
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@visx/annotation": "latest",
+    "@visx/mock-data": "latest",
+    "@visx/responsive": "latest",
+    "@visx/scale": "latest",
+    "@visx/shape": "latest",
+    "d3-array": "^2.8.0",
+    "react": "^16",
+    "react-dom": "^16",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "visx",
+    "annotation"
+  ]
+}

--- a/packages/visx-demo/src/sandboxes/visx-annotation/sandbox-styles.css
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}


### PR DESCRIPTION
#### :memo: Documentation

This builds on #907 and 
- adds a new `/annotation` demo
- adds an `Annotation` tile to the Gallery + as an example to `/docs/annotation`
- adds the new components to `/docs/annotation`


**TODO**
- [x] add `ResizeObserver` polyfill info to `Readme`

**Demo**
<img src="https://user-images.githubusercontent.com/4496521/97954273-e8cc5e80-1d57-11eb-8610-252345ff2d69.gif" width="600" />

**Tile**
<img src="https://user-images.githubusercontent.com/4496521/97954137-883d2180-1d57-11eb-932d-102dc9efc993.png" width="600" />