### PR TITLE
new(xychart): make DataProvider optional

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -9,7 +9,6 @@ import {
   AnimatedGlyphSeries,
   AnimatedGrid,
   AnimatedLineSeries,
-  DataProvider,
   Tooltip,
   XYChart,
 } from '@visx/xychart';
@@ -53,173 +52,171 @@ export default function Example({ height }: Props) {
         xAxisOrientation,
         yAxisOrientation,
       }) => (
-        <DataProvider theme={theme} xScale={config.x} yScale={config.y}>
-          <XYChart height={Math.min(400, height)}>
-            <CustomChartBackground />
-            <AnimatedGrid
-              key={`grid-${animationTrajectory}`} // force animate on update
-              rows={showGridRows}
-              columns={showGridColumns}
-              animationTrajectory={animationTrajectory}
-              numTicks={numTicks}
-            />
-            {renderBarStack && (
-              <AnimatedBarStack>
-                <AnimatedBarSeries
-                  dataKey="New York"
-                  data={data}
-                  xAccessor={accessors.x['New York']}
-                  yAccessor={accessors.y['New York']}
-                />
-                <AnimatedBarSeries
-                  dataKey="San Francisco"
-                  data={data}
-                  xAccessor={accessors.x['San Francisco']}
-                  yAccessor={accessors.y['San Francisco']}
-                />
-                <AnimatedBarSeries
-                  dataKey="Austin"
-                  data={data}
-                  xAccessor={accessors.x.Austin}
-                  yAccessor={accessors.y.Austin}
-                />
-              </AnimatedBarStack>
-            )}
-            {renderBarGroup && (
-              <AnimatedBarGroup>
-                <AnimatedBarSeries
-                  dataKey="New York"
-                  data={data}
-                  xAccessor={accessors.x['New York']}
-                  yAccessor={accessors.y['New York']}
-                />
-                <AnimatedBarSeries
-                  dataKey="San Francisco"
-                  data={data}
-                  xAccessor={accessors.x['San Francisco']}
-                  yAccessor={accessors.y['San Francisco']}
-                />
-                <AnimatedBarSeries
-                  dataKey="Austin"
-                  data={data}
-                  xAccessor={accessors.x.Austin}
-                  yAccessor={accessors.y.Austin}
-                />
-              </AnimatedBarGroup>
-            )}
-            {renderBarSeries && (
+        <XYChart theme={theme} xScale={config.x} yScale={config.y} height={Math.min(400, height)}>
+          <CustomChartBackground />
+          <AnimatedGrid
+            key={`grid-${animationTrajectory}`} // force animate on update
+            rows={showGridRows}
+            columns={showGridColumns}
+            animationTrajectory={animationTrajectory}
+            numTicks={numTicks}
+          />
+          {renderBarStack && (
+            <AnimatedBarStack>
               <AnimatedBarSeries
                 dataKey="New York"
                 data={data}
                 xAccessor={accessors.x['New York']}
                 yAccessor={accessors.y['New York']}
               />
-            )}
-            {renderAreaSeries && (
-              <>
-                <AnimatedAreaSeries
-                  dataKey="Austin"
-                  data={data}
-                  xAccessor={accessors.x.Austin}
-                  yAccessor={accessors.y.Austin}
-                  fillOpacity={0.5}
-                  curve={curve}
-                />
-                <AnimatedAreaSeries
-                  dataKey="San Francisco"
-                  data={data}
-                  xAccessor={accessors.x['San Francisco']}
-                  yAccessor={accessors.y['San Francisco']}
-                  fillOpacity={0.5}
-                  curve={curve}
-                />
-              </>
-            )}
-            {renderLineSeries && (
-              <>
-                <AnimatedLineSeries
-                  dataKey="Austin"
-                  data={data}
-                  xAccessor={accessors.x.Austin}
-                  yAccessor={accessors.y.Austin}
-                  curve={curve}
-                />
-                <AnimatedLineSeries
-                  dataKey="San Francisco"
-                  data={data}
-                  xAccessor={accessors.x['San Francisco']}
-                  yAccessor={accessors.y['San Francisco']}
-                  curve={curve}
-                />
-              </>
-            )}
-            {renderGlyphSeries && (
-              <AnimatedGlyphSeries
+              <AnimatedBarSeries
                 dataKey="San Francisco"
                 data={data}
                 xAccessor={accessors.x['San Francisco']}
                 yAccessor={accessors.y['San Francisco']}
-                renderGlyph={renderGlyph}
               />
-            )}
-            <AnimatedAxis
-              key={`time-axis-${animationTrajectory}-${renderHorizontally}`}
-              orientation={renderHorizontally ? yAxisOrientation : xAxisOrientation}
-              numTicks={numTicks}
-              animationTrajectory={animationTrajectory}
-            />
-            <AnimatedAxis
-              key={`temp-axis-${animationTrajectory}-${renderHorizontally}`}
-              label="Temperature (°F)"
-              orientation={renderHorizontally ? xAxisOrientation : yAxisOrientation}
-              numTicks={numTicks}
-              animationTrajectory={animationTrajectory}
-            />
-            {showTooltip && (
-              <Tooltip<CityTemperature>
-                showHorizontalCrosshair={showHorizontalCrosshair}
-                showVerticalCrosshair={showVerticalCrosshair}
-                snapTooltipToDatumX={snapTooltipToDatumX}
-                snapTooltipToDatumY={snapTooltipToDatumY}
-                showDatumGlyph={(snapTooltipToDatumX || snapTooltipToDatumY) && !renderBarGroup}
-                showSeriesGlyphs={sharedTooltip && !renderBarGroup}
-                renderTooltip={({ tooltipData, colorScale }) => (
-                  <>
-                    {/** date */}
-                    {(tooltipData?.nearestDatum?.datum &&
-                      accessors.date(tooltipData?.nearestDatum?.datum)) ||
-                      'No date'}
-                    <br />
-                    <br />
-                    {/** temperatures */}
-                    {((sharedTooltip
-                      ? Object.keys(tooltipData?.datumByKey ?? {})
-                      : [tooltipData?.nearestDatum?.key]
-                    ).filter(city => city) as City[]).map(city => (
-                      <div key={city}>
-                        <em
-                          style={{
-                            color: colorScale?.(city),
-                            textDecoration:
-                              tooltipData?.nearestDatum?.key === city ? 'underline' : undefined,
-                          }}
-                        >
-                          {city}
-                        </em>{' '}
-                        {tooltipData?.nearestDatum?.datum
-                          ? accessors[renderHorizontally ? 'x' : 'y'][city](
-                              tooltipData?.nearestDatum?.datum,
-                            )
-                          : '–'}
-                        ° F
-                      </div>
-                    ))}
-                  </>
-                )}
+              <AnimatedBarSeries
+                dataKey="Austin"
+                data={data}
+                xAccessor={accessors.x.Austin}
+                yAccessor={accessors.y.Austin}
               />
-            )}
-          </XYChart>
-        </DataProvider>
+            </AnimatedBarStack>
+          )}
+          {renderBarGroup && (
+            <AnimatedBarGroup>
+              <AnimatedBarSeries
+                dataKey="New York"
+                data={data}
+                xAccessor={accessors.x['New York']}
+                yAccessor={accessors.y['New York']}
+              />
+              <AnimatedBarSeries
+                dataKey="San Francisco"
+                data={data}
+                xAccessor={accessors.x['San Francisco']}
+                yAccessor={accessors.y['San Francisco']}
+              />
+              <AnimatedBarSeries
+                dataKey="Austin"
+                data={data}
+                xAccessor={accessors.x.Austin}
+                yAccessor={accessors.y.Austin}
+              />
+            </AnimatedBarGroup>
+          )}
+          {renderBarSeries && (
+            <AnimatedBarSeries
+              dataKey="New York"
+              data={data}
+              xAccessor={accessors.x['New York']}
+              yAccessor={accessors.y['New York']}
+            />
+          )}
+          {renderAreaSeries && (
+            <>
+              <AnimatedAreaSeries
+                dataKey="Austin"
+                data={data}
+                xAccessor={accessors.x.Austin}
+                yAccessor={accessors.y.Austin}
+                fillOpacity={0.5}
+                curve={curve}
+              />
+              <AnimatedAreaSeries
+                dataKey="San Francisco"
+                data={data}
+                xAccessor={accessors.x['San Francisco']}
+                yAccessor={accessors.y['San Francisco']}
+                fillOpacity={0.5}
+                curve={curve}
+              />
+            </>
+          )}
+          {renderLineSeries && (
+            <>
+              <AnimatedLineSeries
+                dataKey="Austin"
+                data={data}
+                xAccessor={accessors.x.Austin}
+                yAccessor={accessors.y.Austin}
+                curve={curve}
+              />
+              <AnimatedLineSeries
+                dataKey="San Francisco"
+                data={data}
+                xAccessor={accessors.x['San Francisco']}
+                yAccessor={accessors.y['San Francisco']}
+                curve={curve}
+              />
+            </>
+          )}
+          {renderGlyphSeries && (
+            <AnimatedGlyphSeries
+              dataKey="San Francisco"
+              data={data}
+              xAccessor={accessors.x['San Francisco']}
+              yAccessor={accessors.y['San Francisco']}
+              renderGlyph={renderGlyph}
+            />
+          )}
+          <AnimatedAxis
+            key={`time-axis-${animationTrajectory}-${renderHorizontally}`}
+            orientation={renderHorizontally ? yAxisOrientation : xAxisOrientation}
+            numTicks={numTicks}
+            animationTrajectory={animationTrajectory}
+          />
+          <AnimatedAxis
+            key={`temp-axis-${animationTrajectory}-${renderHorizontally}`}
+            label="Temperature (°F)"
+            orientation={renderHorizontally ? xAxisOrientation : yAxisOrientation}
+            numTicks={numTicks}
+            animationTrajectory={animationTrajectory}
+          />
+          {showTooltip && (
+            <Tooltip<CityTemperature>
+              showHorizontalCrosshair={showHorizontalCrosshair}
+              showVerticalCrosshair={showVerticalCrosshair}
+              snapTooltipToDatumX={snapTooltipToDatumX}
+              snapTooltipToDatumY={snapTooltipToDatumY}
+              showDatumGlyph={(snapTooltipToDatumX || snapTooltipToDatumY) && !renderBarGroup}
+              showSeriesGlyphs={sharedTooltip && !renderBarGroup}
+              renderTooltip={({ tooltipData, colorScale }) => (
+                <>
+                  {/** date */}
+                  {(tooltipData?.nearestDatum?.datum &&
+                    accessors.date(tooltipData?.nearestDatum?.datum)) ||
+                    'No date'}
+                  <br />
+                  <br />
+                  {/** temperatures */}
+                  {((sharedTooltip
+                    ? Object.keys(tooltipData?.datumByKey ?? {})
+                    : [tooltipData?.nearestDatum?.key]
+                  ).filter(city => city) as City[]).map(city => (
+                    <div key={city}>
+                      <em
+                        style={{
+                          color: colorScale?.(city),
+                          textDecoration:
+                            tooltipData?.nearestDatum?.key === city ? 'underline' : undefined,
+                        }}
+                      >
+                        {city}
+                      </em>{' '}
+                      {tooltipData?.nearestDatum?.datum
+                        ? accessors[renderHorizontally ? 'x' : 'y'][city](
+                            tooltipData?.nearestDatum?.datum,
+                          )
+                        : '–'}
+                      ° F
+                    </div>
+                  ))}
+                </>
+              )}
+            />
+          )}
+        </XYChart>
       )}
     </ExampleControls>
   );

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -1,6 +1,8 @@
-/* eslint-disable jsx-a11y/mouse-events-have-key-events */
+/* eslint jsx-a11y/mouse-events-have-key-events: 'off', @typescript-eslint/no-explicit-any: 'off' */
 import React, { useCallback, useContext, useEffect } from 'react';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
+import { AxisScaleOutput } from '@visx/axis';
+import { ScaleConfig } from '@visx/scale';
 
 import DataContext from '../context/DataContext';
 import { Margin } from '../types';
@@ -8,25 +10,45 @@ import useEventEmitter from '../hooks/useEventEmitter';
 import EventEmitterProvider from '../providers/EventEmitterProvider';
 import TooltipContext from '../context/TooltipContext';
 import TooltipProvider from '../providers/TooltipProvider';
+import DataProvider, { DataProviderProps } from '../providers/DataProvider';
 
 const DEFAULT_MARGIN = { top: 50, right: 50, bottom: 50, left: 50 };
 
-type Props = {
+export type XYChartProps<
+  XScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>,
+  YScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>
+> = {
+  /** aria-label for the chart svg element. */
   accessibilityLabel?: string;
-  events?: boolean;
+  /** Total width of the desired chart svg, including margin. */
   width?: number;
+  /** Total height of the desired chart svg, including margin. */
   height?: number;
+  /** Margin to apply around the outside the. */
   margin?: Margin;
+  /** XYChart children (Series, Tooltip, etc.). */
   children: React.ReactNode;
+  /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the theme. */
+  theme?: DataProviderProps<XScaleConfig, YScaleConfig>['theme'];
+  /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the xScale config. */
+  xScale?: DataProviderProps<XScaleConfig, YScaleConfig>['xScale'];
+  /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the yScale config. */
+  yScale?: DataProviderProps<XScaleConfig, YScaleConfig>['yScale'];
 };
 
-export default function XYChart(props: Props) {
+export default function XYChart<
+  XScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>,
+  YScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>
+>(props: XYChartProps<XScaleConfig, YScaleConfig>) {
   const {
     accessibilityLabel = 'XYChart',
     children,
-    width,
     height,
     margin = DEFAULT_MARGIN,
+    theme,
+    width,
+    xScale,
+    yScale,
   } = props;
   const { setDimensions } = useContext(DataContext);
   const tooltipContext = useContext(TooltipContext);
@@ -49,6 +71,24 @@ export default function XYChart(props: Props) {
   );
 
   // if Context or dimensions are not available, wrap self in the needed providers
+  if (!setDimensions) {
+    if (!xScale || !yScale) {
+      console.warn(
+        '[@visx/xychart] XYChart: When no DataProvider is available in context, you must pass xScale & yScale config to XYChart.',
+      );
+      return null;
+    }
+    return (
+      <DataProvider
+        xScale={xScale}
+        yScale={yScale}
+        theme={theme}
+        initialDimensions={{ width, height, margin }}
+      >
+        <XYChart {...props} />
+      </DataProvider>
+    );
+  }
   if (width == null || height == null) {
     return <ParentSize>{dims => <XYChart {...dims} {...props} />}</ParentSize>;
   }

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -90,7 +90,17 @@ export default function XYChart<
     );
   }
   if (width == null || height == null) {
-    return <ParentSize>{dims => <XYChart {...dims} {...props} />}</ParentSize>;
+    return (
+      <ParentSize>
+        {dims => (
+          <XYChart
+            {...props}
+            width={props.width == null ? dims.width : props.width}
+            height={props.height == null ? dims.height : props.height}
+          />
+        )}
+      </ParentSize>
+    );
   }
   if (emit == null) {
     return (

--- a/packages/visx-xychart/test/components/XYChart.test.tsx
+++ b/packages/visx-xychart/test/components/XYChart.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
 import {
   XYChart,
@@ -9,40 +9,66 @@ import {
   TooltipProvider,
 } from '../../src';
 
+const chartProps = {
+  xScale: { type: 'linear' },
+  yScale: { type: 'linear' },
+  width: 100,
+  height: 100,
+} as const;
+
 describe('<XYChart />', () => {
   it('should be defined', () => {
     expect(XYChart).toBeDefined();
   });
 
+  it('should render a ParentSize if width or height is not provided', () => {
+    const wrapper = mount(
+      <XYChart {...chartProps} width={undefined}>
+        <rect />
+      </XYChart>,
+    );
+    expect(wrapper.find(ParentSize)).toHaveLength(1);
+  });
+
+  it('should render DataProvider, EventEmitterProvider, and TooltipProvider if not available in context', () => {
+    const wrapper = mount(
+      <XYChart {...chartProps}>
+        <rect />
+      </XYChart>,
+    );
+    expect(wrapper.find(DataProvider)).toHaveLength(1);
+    expect(wrapper.find(EventEmitterProvider)).toHaveLength(1);
+    expect(wrapper.find(TooltipProvider)).toHaveLength(1);
+  });
+
+  it('should warn if DataProvider is not available and no x- or yScale config is passed', () => {
+    expect(
+      () =>
+        mount(
+          <XYChart>
+            <rect />
+          </XYChart>,
+        ),
+      // eslint-disable-next-line jest/require-to-throw-message
+    ).toThrow();
+  });
+
   it('should render an svg', () => {
     const wrapper = mount(
-      <EventEmitterProvider>
-        <TooltipProvider>
-          <XYChart width={300} height={300}>
-            <rect />
-          </XYChart>
-        </TooltipProvider>
-      </EventEmitterProvider>,
+      <XYChart {...chartProps}>
+        <rect />
+      </XYChart>,
     );
     expect(wrapper.find('svg')).toHaveLength(1);
   });
 
   it('should render children', () => {
-    const wrapper = shallow(
-      <XYChart width={300} height={300}>
+    const wrapper = mount(
+      <XYChart {...chartProps}>
         <rect id="xychart-child" />
       </XYChart>,
     );
     expect(wrapper.find('#xychart-child')).toHaveLength(1);
-  });
-
-  it('should render a ParentSize if width or height is not provided', () => {
-    const wrapper = shallow(
-      <XYChart height={300}>
-        <rect />
-      </XYChart>,
-    );
-    expect(wrapper.find(ParentSize)).toHaveLength(1);
   });
 
   it('should update the registry dimensions', () => {


### PR DESCRIPTION
#### :rocket: Enhancements

This PR adds a usability improvement to `@visx/xychart`, making it optional for package consumers to render `DataProvider` which is arguably an internal implementation detail (note that it is already optional for consumers to render `TooltipProvider` and `EventEmitterProvider`). 

Users can still render `DataProvider` up the parent chain for advanced use cases like linked charts, where it's desirable to share a single `DataContext`.

```tsx
// before (still valid)
() => (
  <DataProvider xScale={..} yScale={..} theme={..}>
    <XYChart width={..} height={..}>
      {...}
    </XYChart>
  </DataProvider>
)

// after
() => (
  <XYChart 
    xScale={..} 
    yScale={..} 
    theme={..}
    width={..} 
    height={..}
  >
    {...}
  </XYChart>
)
```

**Testing**
- [x] new jest tests
- [x] verified that `/xychart` demo is still functional