### PR TITLE
fix(demo): bump next dep to 9.5.4

### DIFF
--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -78,7 +78,7 @@
     "d3-shape": "^1.0.6",
     "d3-time-format": "^2.0.5",
     "markdown-loader": "^5.1.0",
-    "next": "9.5.3",
+    "next": "9.5.4",
     "nprogress": "^0.2.0",
     "prismjs": "^1.19.0",
     "raw-loader": "^4.0.0",


### PR DESCRIPTION
#### :house: Internal

- fix(demo): bump next dep to [9.5.4](https://github.com/vercel/next.js/releases/tag/v9.5.4)