### PR TITLE
fix(demo): fix view demo hover pointer

### DIFF
--- a/packages/visx-demo/src/pages/home.tsx
+++ b/packages/visx-demo/src/pages/home.tsx
@@ -126,7 +126,7 @@ const Home = () => (
             </Link>
           </div>
           <div className="buttons">
-            <Link href="/gallery">
+            <Link href="/gallery" passHref>
               <Button>View Gallery</Button>
             </Link>
           </div>


### PR DESCRIPTION
#### :boom: Breaking Changes

- none

#### :memo: Documentation

- Small improvement to the `View Gallery` button located on the Home page. Mouse over cursor should switch to the pointer cursor when the mouse is hovering the button. Please refer to the Next.js documentation about the implemented solution: [If the child is a custom component that wraps an <a> tag
](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag).
