### PR TITLE
new(xychart): add annotations

### DIFF
--- a/packages/visx-annotation/src/components/CircleSubject.tsx
+++ b/packages/visx-annotation/src/components/CircleSubject.tsx
@@ -17,7 +17,7 @@ export default function CircleSubject({
   x: propsX,
   y: propsY,
   stroke = '#222',
-  radius = 24,
+  radius = 16,
   ...restProps
 }: CircleSubjectProps & Omit<React.SVGProps<SVGCircleElement>, keyof CircleSubjectProps>) {
   // if props are provided, they take precedence over context

--- a/packages/visx-annotation/src/components/Connector.tsx
+++ b/packages/visx-annotation/src/components/Connector.tsx
@@ -6,7 +6,7 @@ import AnnotationContext from '../context/AnnotationContext';
 // @TODO
 // add end marker support
 
-export type AnnotationConnectorProps = Pick<AnnotationContextType, 'x' | 'y' | 'dx' | 'dy'> & {
+export type ConnectorProps = Pick<AnnotationContextType, 'x' | 'y' | 'dx' | 'dy'> & {
   /** Optional className to apply to container in addition to 'visx-annotation-connector'. */
   className?: string;
   /** Connector type. */
@@ -17,7 +17,7 @@ export type AnnotationConnectorProps = Pick<AnnotationContextType, 'x' | 'y' | '
   pathProps?: React.SVGProps<SVGPathElement>;
 };
 
-export default function AnnotationConnector({
+export default function Connector({
   className,
   x: propsX,
   y: propsY,
@@ -26,7 +26,7 @@ export default function AnnotationConnector({
   type = 'elbow',
   stroke = '#222',
   pathProps,
-}: AnnotationConnectorProps) {
+}: ConnectorProps) {
   // if props are provided, they take precedence over context
   const annotationContext = useContext(AnnotationContext);
   const x0 = propsX == null ? annotationContext.x ?? 0 : propsX;

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -29,9 +29,9 @@ export type LabelProps = {
   /** Optional subtitle. */
   subtitle?: string;
   /** Optional title font size. */
-  subtitleFontSize?: number;
+  subtitleFontSize?: TextProps['fontSize'];
   /** Optional title font weight. */
-  subtitleFontWeight?: number;
+  subtitleFontWeight?: TextProps['fontWeight'];
   /** The vertical offset of the subtitle from the title. */
   subtitleDy?: number;
   /** Optional subtitle Text props (to override color, etc.). */
@@ -39,9 +39,9 @@ export type LabelProps = {
   /** Optional title. */
   title?: string;
   /** Optional title font size. */
-  titleFontSize?: number;
+  titleFontSize?: TextProps['fontSize'];
   /** Optional title font weight. */
-  titleFontWeight?: number;
+  titleFontWeight?: TextProps['fontWeight'];
   /** Optional title Text props (to override color, etc.). */
   titleProps?: Partial<TextProps>;
   /** Whether the label is vertically anchored to the top, middle, or bottom of its x position. */
@@ -126,7 +126,7 @@ export default function AnnotationLabel({
       fontWeight: titleFontWeight,
     }),
     [titleFontSize, titleFontWeight],
-  );
+  ) as React.CSSProperties;
 
   const subtitleStyle = useMemo(
     () => ({
@@ -134,7 +134,7 @@ export default function AnnotationLabel({
       fontWeight: subtitleFontWeight,
     }),
     [subtitleFontSize, subtitleFontWeight],
-  );
+  ) as React.CSSProperties;
 
   const anchorLineOrientation = Math.abs(dx) > Math.abs(dy) ? 'vertical' : 'horizontal';
 
@@ -181,7 +181,7 @@ export default function AnnotationLabel({
           innerRef={titleRef}
           fill={fontColor}
           verticalAnchor="start"
-          x={padding.left}
+          x={padding.left + (titleProps?.textAnchor === 'middle' ? innerWidth / 2 : 0)}
           y={padding.top}
           width={innerWidth}
           capHeight={titleFontSize} // capHeight should match fontSize, used for first line line height
@@ -197,7 +197,7 @@ export default function AnnotationLabel({
           innerRef={subtitleRef}
           fill={fontColor}
           verticalAnchor="start"
-          x={padding.left}
+          x={padding.left + (subtitleProps?.textAnchor === 'middle' ? innerWidth / 2 : 0)}
           y={padding.top + (titleBounds.height ?? 0)}
           dy={title ? subtitleDy : 0}
           width={innerWidth}

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -161,16 +161,16 @@ export default function AnnotationLabel({
       )}
       {showAnchorLine && (
         <>
-          {anchorLineOrientation === 'horizontal' && verticalAnchor === 'top' && (
+          {anchorLineOrientation === 'horizontal' && verticalAnchor === 'start' && (
             <line {...backgroundOutline} x1={0} x2={width} y1={0} y2={0} />
           )}
-          {anchorLineOrientation === 'horizontal' && verticalAnchor === 'bottom' && (
+          {anchorLineOrientation === 'horizontal' && verticalAnchor === 'end' && (
             <line {...backgroundOutline} x1={0} x2={width} y1={height} y2={height} />
           )}
-          {anchorLineOrientation === 'vertical' && horizontalAnchor === 'left' && (
+          {anchorLineOrientation === 'vertical' && horizontalAnchor === 'start' && (
             <line {...backgroundOutline} x1={0} x2={0} y1={0} y2={height} />
           )}
-          {anchorLineOrientation === 'vertical' && horizontalAnchor === 'right' && (
+          {anchorLineOrientation === 'vertical' && horizontalAnchor === 'end' && (
             <line {...backgroundOutline} x1={width} x2={width} y1={0} y2={height} />
           )}
         </>

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -18,8 +18,8 @@ export type LabelProps = {
   className?: string;
   /** Color of title and subtitle text. */
   fontColor?: string;
-  /** Whether the label is horizontally anchored to the left, middle, or right of its x position. */
-  horizontalAnchor?: 'left' | 'middle' | 'right';
+  /** Whether the label is horizontally anchored to the start, middle, or end of its x position. */
+  horizontalAnchor?: TextProps['textAnchor'];
   /** Optionally inject a ResizeObserver polyfill, else this *must* be globally available. */
   resizeObserverPolyfill?: UseMeasureOptions['polyfill'];
   /** Whether to render a line indicating label text anchor. */
@@ -44,8 +44,8 @@ export type LabelProps = {
   titleFontWeight?: TextProps['fontWeight'];
   /** Optional title Text props (to override color, etc.). */
   titleProps?: Partial<TextProps>;
-  /** Whether the label is vertically anchored to the top, middle, or bottom of its x position. */
-  verticalAnchor?: 'top' | 'middle' | 'bottom';
+  /** Whether the label is vertically anchored to the start, middle, or end of its y position. */
+  verticalAnchor?: TextProps['verticalAnchor'];
   /** Width of annotation, including background, for text wrapping. */
   width?: number;
   /** Left offset of entire AnnotationLabel, if not specified uses x + dx from Annotation. */
@@ -104,18 +104,18 @@ export default function AnnotationLabel({
 
   // offset container position based on horizontal + vertical anchor
   const horizontalAnchor =
-    propsHorizontalAnchor || (Math.abs(dx) < Math.abs(dy) ? 'middle' : dx > 0 ? 'left' : 'right');
+    propsHorizontalAnchor || (Math.abs(dx) < Math.abs(dy) ? 'middle' : dx > 0 ? 'start' : 'end');
   const verticalAnchor =
-    propsVerticalAnchor || (Math.abs(dx) > Math.abs(dy) ? 'middle' : dy > 0 ? 'top' : 'bottom');
+    propsVerticalAnchor || (Math.abs(dx) > Math.abs(dy) ? 'middle' : dy > 0 ? 'start' : 'end');
 
   const containerCoords = useMemo(() => {
     let adjustedX: number = propsX == null ? x + dx : propsX;
     let adjustedY: number = propsY == null ? y + dy : propsY;
 
     if (horizontalAnchor === 'middle') adjustedX -= width / 2;
-    if (horizontalAnchor === 'right') adjustedX -= width;
+    if (horizontalAnchor === 'end') adjustedX -= width;
     if (verticalAnchor === 'middle') adjustedY -= height / 2;
-    if (verticalAnchor === 'bottom') adjustedY -= height;
+    if (verticalAnchor === 'end') adjustedY -= height;
 
     return { x: adjustedX, y: adjustedY };
   }, [propsX, x, dx, propsY, y, dy, horizontalAnchor, verticalAnchor, width, height]);

--- a/packages/visx-annotation/src/index.ts
+++ b/packages/visx-annotation/src/index.ts
@@ -4,6 +4,7 @@ export { default as CircleSubject } from './components/CircleSubject';
 export { default as LineSubject } from './components/LineSubject';
 export { default as Annotation } from './components/Annotation';
 export { default as EditableAnnotation } from './components/EditableAnnotation';
+export { default as AnnotationContext } from './context/AnnotationContext';
 
 // @TODO deprecated, remove in 2.0
 export { default as LinePathAnnotation } from './deprecated/LinePathAnnotation';

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -23,14 +23,14 @@ type ProvidedProps = {
   editSubjectPosition: boolean;
   getDate: (d: AppleStock) => number;
   getStockValue: (d: AppleStock) => number;
-  horizontalAnchor?: 'left' | 'middle' | 'right';
+  horizontalAnchor?: 'start' | 'middle' | 'end';
   labelWidth: number;
   setAnnotationPosition: (position: AnnotationPosition) => void;
   showAnchorLine: boolean;
   subjectType: 'circle' | 'horizontal-line' | 'vertical-line';
   subtitle: string;
   title: string;
-  verticalAnchor?: 'top' | 'middle' | 'bottom';
+  verticalAnchor?: 'start' | 'middle' | 'end';
   xScale: PickD3Scale<'time', number>;
   yScale: PickD3Scale<'linear', number>;
 };
@@ -201,8 +201,8 @@ export default function ExampleControls({
             <label>
               <input
                 type="radio"
-                onChange={() => setHorizontalAnchor('left')}
-                checked={horizontalAnchor === 'left'}
+                onChange={() => setHorizontalAnchor('start')}
+                checked={horizontalAnchor === 'start'}
               />
               left
             </label>
@@ -217,8 +217,8 @@ export default function ExampleControls({
             <label>
               <input
                 type="radio"
-                onChange={() => setHorizontalAnchor('right')}
-                checked={horizontalAnchor === 'right'}
+                onChange={() => setHorizontalAnchor('end')}
+                checked={horizontalAnchor === 'end'}
               />
               right
             </label>
@@ -236,8 +236,8 @@ export default function ExampleControls({
             <label>
               <input
                 type="radio"
-                onChange={() => setVerticalAnchor('top')}
-                checked={verticalAnchor === 'top'}
+                onChange={() => setVerticalAnchor('start')}
+                checked={verticalAnchor === 'start'}
               />
               top
             </label>
@@ -252,8 +252,8 @@ export default function ExampleControls({
             <label>
               <input
                 type="radio"
-                onChange={() => setVerticalAnchor('bottom')}
-                checked={verticalAnchor === 'bottom'}
+                onChange={() => setVerticalAnchor('end')}
+                checked={verticalAnchor === 'end'}
               />
               bottom
             </label>

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CityTemperature } from '@visx/mock-data/lib/mocks/cityTemperature';
 import {
+  AnimatedAnnotation,
   AnimatedAreaSeries,
   AnimatedAxis,
   AnimatedBarGroup,
@@ -9,6 +10,10 @@ import {
   AnimatedGlyphSeries,
   AnimatedGrid,
   AnimatedLineSeries,
+  AnnotationCircleSubject,
+  AnnotationConnector,
+  AnnotationLabel,
+  AnnotationLineSubject,
   Tooltip,
   XYChart,
 } from '@visx/xychart';
@@ -28,6 +33,9 @@ export default function Example({ height }: Props) {
       {({
         accessors,
         animationTrajectory,
+        annotationDataKey,
+        annotationDatum,
+        annotationType,
         config,
         curve,
         data,
@@ -159,6 +167,26 @@ export default function Example({ height }: Props) {
               yAccessor={accessors.y['San Francisco']}
               renderGlyph={renderGlyph}
             />
+          )}
+          {annotationDataKey && annotationDatum && (
+            <AnimatedAnnotation
+              dataKey={annotationDataKey}
+              datum={annotationDatum}
+              dx={-45}
+              dy={-50}
+            >
+              <AnnotationConnector />
+              {annotationType === 'circle' ? (
+                <AnnotationCircleSubject />
+              ) : (
+                <AnnotationLineSubject />
+              )}
+              <AnnotationLabel
+                title={annotationDataKey}
+                subtitle={`${annotationDatum.date}, ${annotationDatum[annotationDataKey]}°F`}
+                backgroundProps={{ stroke: theme.gridStyles.stroke, strokeOpacity: 0.5 }}
+              />
+            </AnimatedAnnotation>
           )}
           <AnimatedAxis
             key={`time-axis-${animationTrajectory}-${renderHorizontally}`}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -35,10 +35,12 @@ export default function Example({ height }: Props) {
         animationTrajectory,
         annotationDataKey,
         annotationDatum,
+        annotationLabelPosition,
         annotationType,
         config,
         curve,
         data,
+        editAnnotationLabelPosition,
         numTicks,
         renderAreaSeries,
         renderBarGroup,
@@ -48,6 +50,7 @@ export default function Example({ height }: Props) {
         renderGlyphSeries,
         renderHorizontally,
         renderLineSeries,
+        setAnnotationLabelPosition,
         sharedTooltip,
         showGridColumns,
         showGridRows,
@@ -60,7 +63,13 @@ export default function Example({ height }: Props) {
         xAxisOrientation,
         yAxisOrientation,
       }) => (
-        <XYChart theme={theme} xScale={config.x} yScale={config.y} height={Math.min(400, height)}>
+        <XYChart
+          theme={theme}
+          xScale={config.x}
+          yScale={config.y}
+          height={Math.min(400, height)}
+          captureEvents={!editAnnotationLabelPosition}
+        >
           <CustomChartBackground />
           <AnimatedGrid
             key={`grid-${animationTrajectory}`} // force animate on update
@@ -128,15 +137,25 @@ export default function Example({ height }: Props) {
                 data={data}
                 xAccessor={accessors.x.Austin}
                 yAccessor={accessors.y.Austin}
-                fillOpacity={0.5}
+                fillOpacity={0.4}
                 curve={curve}
               />
+              {!renderBarSeries && (
+                <AnimatedAreaSeries
+                  dataKey="New York"
+                  data={data}
+                  xAccessor={accessors.x['New York']}
+                  yAccessor={accessors.y['New York']}
+                  fillOpacity={0.4}
+                  curve={curve}
+                />
+              )}
               <AnimatedAreaSeries
                 dataKey="San Francisco"
                 data={data}
                 xAccessor={accessors.x['San Francisco']}
                 yAccessor={accessors.y['San Francisco']}
-                fillOpacity={0.5}
+                fillOpacity={0.4}
                 curve={curve}
               />
             </>
@@ -150,6 +169,15 @@ export default function Example({ height }: Props) {
                 yAccessor={accessors.y.Austin}
                 curve={curve}
               />
+              {!renderBarSeries && (
+                <AnimatedLineSeries
+                  dataKey="New York"
+                  data={data}
+                  xAccessor={accessors.x['New York']}
+                  yAccessor={accessors.y['New York']}
+                  curve={curve}
+                />
+              )}
               <AnimatedLineSeries
                 dataKey="San Francisco"
                 data={data}
@@ -168,26 +196,6 @@ export default function Example({ height }: Props) {
               renderGlyph={renderGlyph}
             />
           )}
-          {annotationDataKey && annotationDatum && (
-            <AnimatedAnnotation
-              dataKey={annotationDataKey}
-              datum={annotationDatum}
-              dx={-45}
-              dy={-50}
-            >
-              <AnnotationConnector />
-              {annotationType === 'circle' ? (
-                <AnnotationCircleSubject />
-              ) : (
-                <AnnotationLineSubject />
-              )}
-              <AnnotationLabel
-                title={annotationDataKey}
-                subtitle={`${annotationDatum.date}, ${annotationDatum[annotationDataKey]}°F`}
-                backgroundProps={{ stroke: theme.gridStyles.stroke, strokeOpacity: 0.5 }}
-              />
-            </AnimatedAnnotation>
-          )}
           <AnimatedAxis
             key={`time-axis-${animationTrajectory}-${renderHorizontally}`}
             orientation={renderHorizontally ? yAxisOrientation : xAxisOrientation}
@@ -201,6 +209,34 @@ export default function Example({ height }: Props) {
             numTicks={numTicks}
             animationTrajectory={animationTrajectory}
           />
+          {annotationDataKey && annotationDatum && (
+            <AnimatedAnnotation
+              dataKey={annotationDataKey}
+              datum={annotationDatum}
+              dx={annotationLabelPosition.dx}
+              dy={annotationLabelPosition.dy}
+              editable={editAnnotationLabelPosition}
+              canEditSubject={false}
+              onDragEnd={({ dx, dy }) => setAnnotationLabelPosition({ dx, dy })}
+            >
+              <AnnotationConnector />
+              {annotationType === 'circle' ? (
+                <AnnotationCircleSubject />
+              ) : (
+                <AnnotationLineSubject />
+              )}
+              <AnnotationLabel
+                title={annotationDataKey}
+                subtitle={`${annotationDatum.date}, ${annotationDatum[annotationDataKey]}°F`}
+                width={135}
+                backgroundProps={{
+                  stroke: theme.gridStyles.stroke,
+                  strokeOpacity: 0.5,
+                  fillOpacity: 0.8,
+                }}
+              />
+            </AnimatedAnnotation>
+          )}
           {showTooltip && (
             <Tooltip<CityTemperature>
               showHorizontalCrosshair={showHorizontalCrosshair}

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -25,6 +25,7 @@ const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNegativeSfTemperature = (d: CityTemperature) => -getSfTemperature(d);
 const getNyTemperature = (d: CityTemperature) => Number(d['New York']);
 const getAustinTemperature = (d: CityTemperature) => Number(d.Austin);
+const defaultAnnotationDataIndex = 10;
 
 type Accessor = (d: CityTemperature) => number | string;
 
@@ -42,11 +43,14 @@ type ProvidedProps = {
     y: Accessors;
     date: Accessor;
   };
+  animationTrajectory: AnimationTrajectory;
+  annotationDataKey: keyof Accessors | null;
+  annotationDatum?: CityTemperature;
+  annotationType?: 'line' | 'circle';
   config: {
     x: SimpleScaleConfig;
     y: SimpleScaleConfig;
   };
-  animationTrajectory: AnimationTrajectory;
   curve: typeof curveLinear | typeof curveCardinal | typeof curveStep;
   data: CityTemperature[];
   numTicks: number;
@@ -84,6 +88,10 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [yAxisOrientation, setYAxisOrientation] = useState<'left' | 'right'>('right');
   const [renderHorizontally, setRenderHorizontally] = useState(false);
   const [showTooltip, setShowTooltip] = useState(true);
+  const [annotationDataKey, setAnnotationDataKey] = useState<ProvidedProps['annotationDataKey']>(
+    'Austin',
+  );
+  const [annotationType, setAnnotationType] = useState<ProvidedProps['annotationType']>('circle');
   const [showVerticalCrosshair, setShowVerticalCrosshair] = useState(true);
   const [showHorizontalCrosshair, setShowHorizontalCrosshair] = useState(false);
   const [snapTooltipToDatumX, setSnapTooltipToDatumX] = useState(true);
@@ -162,6 +170,9 @@ export default function ExampleControls({ children }: ControlsProps) {
       {children({
         accessors,
         animationTrajectory,
+        annotationDataKey,
+        annotationDatum: data[defaultAnnotationDataIndex],
+        annotationType,
         config,
         curve:
           (curveType === 'cardinal' && curveCardinal) ||
@@ -583,6 +594,60 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={fewerDatum}
             />
             fewer datum
+          </label>
+        </div>
+        {/** annotation */}
+        <div>
+          <strong>annotate</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey(null)}
+              checked={annotationDataKey == null}
+            />
+            none
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('San Francisco')}
+              checked={annotationDataKey === 'San Francisco'}
+            />
+            SF
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('New York')}
+              checked={annotationDataKey === 'New York'}
+            />
+            NY
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('Austin')}
+              checked={annotationDataKey === 'Austin'}
+            />
+            Austin
+          </label>
+          &nbsp;&nbsp;&nbsp;
+          <strong>type</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationType('circle')}
+              checked={annotationType === 'circle'}
+            />
+            circle
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationType('line')}
+              checked={annotationType === 'line'}
+            />
+            line
           </label>
         </div>
       </div>

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -25,7 +25,7 @@ const getSfTemperature = (d: CityTemperature) => Number(d['San Francisco']);
 const getNegativeSfTemperature = (d: CityTemperature) => -getSfTemperature(d);
 const getNyTemperature = (d: CityTemperature) => Number(d['New York']);
 const getAustinTemperature = (d: CityTemperature) => Number(d.Austin);
-const defaultAnnotationDataIndex = 10;
+const defaultAnnotationDataIndex = 13;
 
 type Accessor = (d: CityTemperature) => number | string;
 
@@ -46,6 +46,7 @@ type ProvidedProps = {
   animationTrajectory: AnimationTrajectory;
   annotationDataKey: keyof Accessors | null;
   annotationDatum?: CityTemperature;
+  annotationLabelPosition: { dx: number; dy: number };
   annotationType?: 'line' | 'circle';
   config: {
     x: SimpleScaleConfig;
@@ -53,7 +54,9 @@ type ProvidedProps = {
   };
   curve: typeof curveLinear | typeof curveCardinal | typeof curveStep;
   data: CityTemperature[];
+  editAnnotationLabelPosition: boolean;
   numTicks: number;
+  setAnnotationLabelPosition: (position: { dx: number; dy: number }) => void;
   renderAreaSeries: boolean;
   renderBarGroup: boolean;
   renderBarSeries: boolean;
@@ -89,7 +92,7 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [renderHorizontally, setRenderHorizontally] = useState(false);
   const [showTooltip, setShowTooltip] = useState(true);
   const [annotationDataKey, setAnnotationDataKey] = useState<ProvidedProps['annotationDataKey']>(
-    'Austin',
+    'New York',
   );
   const [annotationType, setAnnotationType] = useState<ProvidedProps['annotationType']>('circle');
   const [showVerticalCrosshair, setShowVerticalCrosshair] = useState(true);
@@ -104,6 +107,8 @@ export default function ExampleControls({ children }: ControlsProps) {
     'line',
   );
   const [renderGlyphSeries, setRenderGlyphSeries] = useState(false);
+  const [editAnnotationLabelPosition, setEditAnnotationLabelPosition] = useState(false);
+  const [annotationLabelPosition, setAnnotationLabelPosition] = useState({ dx: -40, dy: -20 });
   const [negativeValues, setNegativeValues] = useState(false);
   const [fewerDatum, setFewerDatum] = useState(false);
   const [missingValues, setMissingValues] = useState(false);
@@ -172,6 +177,7 @@ export default function ExampleControls({ children }: ControlsProps) {
         animationTrajectory,
         annotationDataKey,
         annotationDatum: data[defaultAnnotationDataIndex],
+        annotationLabelPosition,
         annotationType,
         config,
         curve:
@@ -185,6 +191,7 @@ export default function ExampleControls({ children }: ControlsProps) {
           : missingValues
           ? dataMissingValues
           : data,
+        editAnnotationLabelPosition,
         numTicks,
         renderBarGroup: renderBarStackOrGroup === 'group',
         renderBarSeries: renderBarStackOrGroup === 'bar',
@@ -194,6 +201,7 @@ export default function ExampleControls({ children }: ControlsProps) {
         renderHorizontally,
         renderAreaSeries: canRenderLineOrArea && renderLineOrAreaSeries === 'area',
         renderLineSeries: canRenderLineOrArea && renderLineOrAreaSeries === 'line',
+        setAnnotationLabelPosition,
         sharedTooltip,
         showGridColumns,
         showGridRows,
@@ -233,27 +241,6 @@ export default function ExampleControls({ children }: ControlsProps) {
               checked={theme === customTheme}
             />
             custom
-          </label>
-        </div>
-
-        {/** series orientation */}
-        <div>
-          <strong>series orientation</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setRenderHorizontally(false)}
-              checked={!renderHorizontally}
-            />
-            vertical
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setRenderHorizontally(true)}
-              checked={renderHorizontally}
-            />
-            horizontal
           </label>
         </div>
 
@@ -367,6 +354,7 @@ export default function ExampleControls({ children }: ControlsProps) {
             from max
           </label>
         </div>
+        <br />
         {/** tooltip */}
         <div>
           <strong>tooltip</strong>
@@ -424,6 +412,72 @@ export default function ExampleControls({ children }: ControlsProps) {
             shared tooltip
           </label>
         </div>
+        {/** annotation */}
+        <div>
+          <strong>annotate</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey(null)}
+              checked={annotationDataKey == null}
+            />
+            none
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('San Francisco')}
+              checked={annotationDataKey === 'San Francisco'}
+            />
+            SF
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('New York')}
+              checked={annotationDataKey === 'New York'}
+            />
+            NY
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('Austin')}
+              checked={annotationDataKey === 'Austin'}
+            />
+            Austin
+          </label>
+          &nbsp;&nbsp;&nbsp;
+          <strong>type</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationType('circle')}
+              checked={annotationType === 'circle'}
+            />
+            circle
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationType('line')}
+              checked={annotationType === 'line'}
+            />
+            line
+          </label>
+          &nbsp;&nbsp;&nbsp;
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setEditAnnotationLabelPosition(!editAnnotationLabelPosition)}
+              checked={editAnnotationLabelPosition}
+            />
+            edit label position
+          </label>
+        </div>
+
+        <br />
+
         {/** series */}
         <div>
           <strong>line series</strong>
@@ -568,6 +622,29 @@ export default function ExampleControls({ children }: ControlsProps) {
             none
           </label>
         </div>
+        {/** orientation */}
+        <div>
+          <strong>series orientation</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderHorizontally(false)}
+              checked={!renderHorizontally}
+            />
+            vertical
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderHorizontally(true)}
+              checked={renderHorizontally}
+            />
+            horizontal
+          </label>
+        </div>
+
+        <br />
+
         {/** data */}
         <div>
           <strong>data</strong>
@@ -596,60 +673,6 @@ export default function ExampleControls({ children }: ControlsProps) {
             fewer datum
           </label>
         </div>
-        {/** annotation */}
-        <div>
-          <strong>annotate</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey(null)}
-              checked={annotationDataKey == null}
-            />
-            none
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey('San Francisco')}
-              checked={annotationDataKey === 'San Francisco'}
-            />
-            SF
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey('New York')}
-              checked={annotationDataKey === 'New York'}
-            />
-            NY
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey('Austin')}
-              checked={annotationDataKey === 'Austin'}
-            />
-            Austin
-          </label>
-          &nbsp;&nbsp;&nbsp;
-          <strong>type</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationType('circle')}
-              checked={annotationType === 'circle'}
-            />
-            circle
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationType('line')}
-              checked={annotationType === 'line'}
-            />
-            line
-          </label>
-        </div>
       </div>
       <style jsx>{`
         .controls {
@@ -657,7 +680,7 @@ export default function ExampleControls({ children }: ControlsProps) {
           line-height: 1.5em;
         }
         .controls > div {
-          margin-bottom: 8px;
+          margin-bottom: 4px;
         }
         label {
           font-size: 12px;

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -92,7 +92,7 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [renderHorizontally, setRenderHorizontally] = useState(false);
   const [showTooltip, setShowTooltip] = useState(true);
   const [annotationDataKey, setAnnotationDataKey] = useState<ProvidedProps['annotationDataKey']>(
-    'New York',
+    null,
   );
   const [annotationType, setAnnotationType] = useState<ProvidedProps['annotationType']>('circle');
   const [showVerticalCrosshair, setShowVerticalCrosshair] = useState(true);
@@ -102,9 +102,9 @@ export default function ExampleControls({ children }: ControlsProps) {
   const [sharedTooltip, setSharedTooltip] = useState(true);
   const [renderBarStackOrGroup, setRenderBarStackOrGroup] = useState<
     'bar' | 'stack' | 'group' | 'none'
-  >('bar');
+  >('none');
   const [renderLineOrAreaSeries, setRenderLineOrAreaSeries] = useState<'line' | 'area' | 'none'>(
-    'line',
+    'area',
   );
   const [renderGlyphSeries, setRenderGlyphSeries] = useState(false);
   const [editAnnotationLabelPosition, setEditAnnotationLabelPosition] = useState(false);
@@ -215,6 +215,35 @@ export default function ExampleControls({ children }: ControlsProps) {
         yAxisOrientation,
       })}
       <div className="controls">
+        {/** data */}
+        <div>
+          <strong>data</strong>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setNegativeValues(!negativeValues)}
+              checked={negativeValues}
+            />
+            negative values (SF)
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setMissingValues(!missingValues)}
+              checked={missingValues}
+            />
+            missing values
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setFewerDatum(!fewerDatum)}
+              checked={fewerDatum}
+            />
+            fewer datum
+          </label>
+        </div>
+
         {/** theme */}
         <div>
           <strong>theme</strong>
@@ -244,241 +273,29 @@ export default function ExampleControls({ children }: ControlsProps) {
           </label>
         </div>
 
-        {/** axes */}
-        <div>
-          <strong>axes</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setXAxisOrientation('bottom')}
-              checked={xAxisOrientation === 'bottom'}
-            />
-            bottom
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setXAxisOrientation('top')}
-              checked={xAxisOrientation === 'top'}
-            />
-            top
-          </label>
-          &nbsp;&nbsp;&nbsp;&nbsp;
-          <label>
-            <input
-              type="radio"
-              onChange={() => setYAxisOrientation('left')}
-              checked={yAxisOrientation === 'left'}
-            />
-            left
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setYAxisOrientation('right')}
-              checked={yAxisOrientation === 'right'}
-            />
-            right
-          </label>
-        </div>
-
-        {/** grid */}
-        <div>
-          <strong>grid</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setGridProps([true, false])}
-              checked={showGridRows && !showGridColumns}
-            />
-            rows
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setGridProps([false, true])}
-              checked={!showGridRows && showGridColumns}
-            />
-            columns
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setGridProps([true, true])}
-              checked={showGridRows && showGridColumns}
-            />
-            both
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setGridProps([false, false])}
-              checked={!showGridRows && !showGridColumns}
-            />
-            none
-          </label>
-        </div>
-        {/** animation trajectory */}
-        <div>
-          <strong>axis + grid animation</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnimationTrajectory('center')}
-              checked={animationTrajectory === 'center'}
-            />
-            from center
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnimationTrajectory('outside')}
-              checked={animationTrajectory === 'outside'}
-            />
-            from outside
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnimationTrajectory('min')}
-              checked={animationTrajectory === 'min'}
-            />
-            from min
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnimationTrajectory('max')}
-              checked={animationTrajectory === 'max'}
-            />
-            from max
-          </label>
-        </div>
-        <br />
-        {/** tooltip */}
-        <div>
-          <strong>tooltip</strong>
-          <label>
-            <input
-              type="checkbox"
-              onChange={() => setShowTooltip(!showTooltip)}
-              checked={showTooltip}
-            />
-            show tooltip
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              disabled={!showTooltip || renderBarStackOrGroup === 'stack'}
-              onChange={() => setSnapTooltipToDatumX(!snapTooltipToDatumX)}
-              checked={showTooltip && snapTooltipToDatumX}
-            />
-            snap tooltip to datum x
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              disabled={!showTooltip || renderBarStackOrGroup === 'stack'}
-              onChange={() => setSnapTooltipToDatumY(!snapTooltipToDatumY)}
-              checked={showTooltip && snapTooltipToDatumY}
-            />
-            snap tooltip to datum y
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              disabled={!showTooltip}
-              onChange={() => setShowVerticalCrosshair(!showVerticalCrosshair)}
-              checked={showTooltip && showVerticalCrosshair}
-            />
-            vertical crosshair
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              disabled={!showTooltip}
-              onChange={() => setShowHorizontalCrosshair(!showHorizontalCrosshair)}
-              checked={showTooltip && showHorizontalCrosshair}
-            />
-            horizontal crosshair
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              disabled={!showTooltip}
-              onChange={() => setSharedTooltip(!sharedTooltip)}
-              checked={showTooltip && sharedTooltip}
-            />
-            shared tooltip
-          </label>
-        </div>
-        {/** annotation */}
-        <div>
-          <strong>annotate</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey(null)}
-              checked={annotationDataKey == null}
-            />
-            none
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey('San Francisco')}
-              checked={annotationDataKey === 'San Francisco'}
-            />
-            SF
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey('New York')}
-              checked={annotationDataKey === 'New York'}
-            />
-            NY
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationDataKey('Austin')}
-              checked={annotationDataKey === 'Austin'}
-            />
-            Austin
-          </label>
-          &nbsp;&nbsp;&nbsp;
-          <strong>type</strong>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationType('circle')}
-              checked={annotationType === 'circle'}
-            />
-            circle
-          </label>
-          <label>
-            <input
-              type="radio"
-              onChange={() => setAnnotationType('line')}
-              checked={annotationType === 'line'}
-            />
-            line
-          </label>
-          &nbsp;&nbsp;&nbsp;
-          <label>
-            <input
-              type="checkbox"
-              onChange={() => setEditAnnotationLabelPosition(!editAnnotationLabelPosition)}
-              checked={editAnnotationLabelPosition}
-            />
-            edit label position
-          </label>
-        </div>
-
         <br />
 
         {/** series */}
+        {/** orientation */}
+        <div>
+          <strong>series orientation</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderHorizontally(false)}
+              checked={!renderHorizontally}
+            />
+            vertical
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setRenderHorizontally(true)}
+              checked={renderHorizontally}
+            />
+            horizontal
+          </label>
+        </div>
         <div>
           <strong>line series</strong>
           <label>
@@ -622,55 +439,239 @@ export default function ExampleControls({ children }: ControlsProps) {
             none
           </label>
         </div>
-        {/** orientation */}
+
+        <br />
+        {/** tooltip */}
         <div>
-          <strong>series orientation</strong>
+          <strong>tooltip</strong>
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setShowTooltip(!showTooltip)}
+              checked={showTooltip}
+            />
+            show tooltip
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip || renderBarStackOrGroup === 'stack'}
+              onChange={() => setSnapTooltipToDatumX(!snapTooltipToDatumX)}
+              checked={showTooltip && snapTooltipToDatumX}
+            />
+            snap tooltip to datum x
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip || renderBarStackOrGroup === 'stack'}
+              onChange={() => setSnapTooltipToDatumY(!snapTooltipToDatumY)}
+              checked={showTooltip && snapTooltipToDatumY}
+            />
+            snap tooltip to datum y
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setShowVerticalCrosshair(!showVerticalCrosshair)}
+              checked={showTooltip && showVerticalCrosshair}
+            />
+            vertical crosshair
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setShowHorizontalCrosshair(!showHorizontalCrosshair)}
+              checked={showTooltip && showHorizontalCrosshair}
+            />
+            horizontal crosshair
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={!showTooltip}
+              onChange={() => setSharedTooltip(!sharedTooltip)}
+              checked={showTooltip && sharedTooltip}
+            />
+            shared tooltip
+          </label>
+        </div>
+        {/** annotation */}
+        <div>
+          <strong>annotation</strong>
           <label>
             <input
               type="radio"
-              onChange={() => setRenderHorizontally(false)}
-              checked={!renderHorizontally}
+              onChange={() => setAnnotationDataKey(null)}
+              checked={annotationDataKey == null}
             />
-            vertical
+            none
           </label>
           <label>
             <input
               type="radio"
-              onChange={() => setRenderHorizontally(true)}
-              checked={renderHorizontally}
+              onChange={() => setAnnotationDataKey('San Francisco')}
+              checked={annotationDataKey === 'San Francisco'}
             />
-            horizontal
+            SF
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('New York')}
+              checked={annotationDataKey === 'New York'}
+            />
+            NY
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationDataKey('Austin')}
+              checked={annotationDataKey === 'Austin'}
+            />
+            Austin
+          </label>
+          &nbsp;&nbsp;&nbsp;
+          <strong>type</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationType('circle')}
+              checked={annotationType === 'circle'}
+            />
+            circle
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnnotationType('line')}
+              checked={annotationType === 'line'}
+            />
+            line
+          </label>
+          &nbsp;&nbsp;&nbsp;
+          <label>
+            <input
+              type="checkbox"
+              onChange={() => setEditAnnotationLabelPosition(!editAnnotationLabelPosition)}
+              checked={editAnnotationLabelPosition}
+            />
+            edit label position
           </label>
         </div>
 
         <br />
 
-        {/** data */}
+        {/** axes */}
         <div>
-          <strong>data</strong>
+          <strong>axes</strong>
           <label>
             <input
-              type="checkbox"
-              onChange={() => setNegativeValues(!negativeValues)}
-              checked={negativeValues}
+              type="radio"
+              onChange={() => setXAxisOrientation('bottom')}
+              checked={xAxisOrientation === 'bottom'}
             />
-            negative values (SF)
+            bottom
           </label>
           <label>
             <input
-              type="checkbox"
-              onChange={() => setMissingValues(!missingValues)}
-              checked={missingValues}
+              type="radio"
+              onChange={() => setXAxisOrientation('top')}
+              checked={xAxisOrientation === 'top'}
             />
-            missing values
+            top
+          </label>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <label>
+            <input
+              type="radio"
+              onChange={() => setYAxisOrientation('left')}
+              checked={yAxisOrientation === 'left'}
+            />
+            left
           </label>
           <label>
             <input
-              type="checkbox"
-              onChange={() => setFewerDatum(!fewerDatum)}
-              checked={fewerDatum}
+              type="radio"
+              onChange={() => setYAxisOrientation('right')}
+              checked={yAxisOrientation === 'right'}
             />
-            fewer datum
+            right
+          </label>
+        </div>
+
+        {/** grid */}
+        <div>
+          <strong>grid</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setGridProps([true, false])}
+              checked={showGridRows && !showGridColumns}
+            />
+            rows
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setGridProps([false, true])}
+              checked={!showGridRows && showGridColumns}
+            />
+            columns
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setGridProps([true, true])}
+              checked={showGridRows && showGridColumns}
+            />
+            both
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setGridProps([false, false])}
+              checked={!showGridRows && !showGridColumns}
+            />
+            none
+          </label>
+        </div>
+        {/** animation trajectory */}
+        <div>
+          <strong>axis + grid animation</strong>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnimationTrajectory('center')}
+              checked={animationTrajectory === 'center'}
+            />
+            from center
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnimationTrajectory('outside')}
+              checked={animationTrajectory === 'outside'}
+            />
+            from outside
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnimationTrajectory('min')}
+              checked={animationTrajectory === 'min'}
+            />
+            from min
+          </label>
+          <label>
+            <input
+              type="radio"
+              onChange={() => setAnimationTrajectory('max')}
+              checked={animationTrajectory === 'max'}
+            />
+            from max
           </label>
         </div>
       </div>

--- a/packages/visx-demo/src/sandboxes/visx-xychart/customTheme.ts
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/customTheme.ts
@@ -5,6 +5,6 @@ export default buildChartTheme({
   colors: ['rgba(255,231,143,0.8)', '#6a097d', '#d6e0f0'],
   gridColor: '#336d88',
   gridColorDark: '#1d1b38',
-  labelStyles: { fill: '#1d1b38' },
+  svgLabelBig: { fill: '#1d1b38' },
   tickLength: 8,
 });

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -44,6 +44,7 @@
     "@types/classnames": "^2.2.9",
     "@types/lodash": "^4.14.146",
     "@types/react": "*",
+    "@visx/annotation": "1.2.0",
     "@visx/axis": "1.2.0",
     "@visx/event": "1.0.0",
     "@visx/glyph": "1.0.0",

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -158,7 +158,7 @@ export default function Tooltip<Datum extends object>({
 
     if (showSeriesGlyphs) {
       Object.values(tooltipContext?.tooltipData?.datumByKey ?? {}).forEach(({ key, datum }) => {
-        const color = colorScale?.(key) ?? theme?.htmlLabelStyles?.color ?? '#222';
+        const color = colorScale?.(key) ?? theme?.htmlLabel?.color ?? '#222';
         const { left, top } = getDatumLeftTop(key, datum);
         glyphProps.push({
           left: left == null ? left : left - radius - strokeWidth,
@@ -178,7 +178,7 @@ export default function Tooltip<Datum extends object>({
           (nearestDatumKey && colorScale?.(nearestDatumKey)) ??
           null ??
           theme?.gridStyles?.stroke ??
-          theme?.htmlLabelStyles?.color ??
+          theme?.htmlLabel?.color ??
           '#222',
         radius,
         strokeWidth,
@@ -211,7 +211,7 @@ export default function Tooltip<Datum extends object>({
                   y1={0}
                   y2={innerHeight}
                   strokeWidth={1.5}
-                  stroke={theme?.gridStyles?.stroke ?? theme?.htmlLabelStyles?.color ?? '#222'}
+                  stroke={theme?.gridStyles?.stroke ?? theme?.htmlLabel?.color ?? '#222'}
                   {...verticalCrosshairStyle}
                 />
               </svg>
@@ -234,7 +234,7 @@ export default function Tooltip<Datum extends object>({
                   y1={0}
                   y2={0}
                   strokeWidth={1.5}
-                  stroke={theme?.gridStyles?.stroke ?? theme?.htmlLabelStyles?.color ?? '#222'}
+                  stroke={theme?.gridStyles?.stroke ?? theme?.htmlLabel?.color ?? '#222'}
                   {...horizontalCrosshairStyle}
                 />
               </svg>
@@ -275,10 +275,10 @@ export default function Tooltip<Datum extends object>({
               ...defaultStyles,
               background: theme?.backgroundColor ?? 'white',
               boxShadow: `0 1px 2px ${
-                theme?.htmlLabelStyles?.color ? `${theme?.htmlLabelStyles?.color}55` : '#22222255'
+                theme?.htmlLabel?.color ? `${theme?.htmlLabel?.color}55` : '#22222255'
               }`,
 
-              ...theme?.htmlLabelStyles,
+              ...theme?.htmlLabel,
             }}
             {...tooltipProps}
           >

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -20,6 +20,8 @@ export type XYChartProps<
 > = {
   /** aria-label for the chart svg element. */
   accessibilityLabel?: string;
+  /** Whether to capture and dispatch pointer events. */
+  captureEvents?: boolean;
   /** Total width of the desired chart svg, including margin. */
   width?: number;
   /** Total height of the desired chart svg, including margin. */
@@ -42,6 +44,7 @@ export default function XYChart<
 >(props: XYChartProps<XScaleConfig, YScaleConfig>) {
   const {
     accessibilityLabel = 'XYChart',
+    captureEvents = true,
     children,
     height,
     margin = DEFAULT_MARGIN,
@@ -61,14 +64,12 @@ export default function XYChart<
     }
   }, [setDimensions, width, height, margin]);
 
-  const handleMouseTouchMove = useCallback(
-    (event: React.MouseEvent | React.TouchEvent) => emit?.('mousemove', event),
-    [emit],
-  );
-  const handleMouseOutTouchEnd = useCallback(
-    (event: React.MouseEvent | React.TouchEvent) => emit?.('mouseout', event),
-    [emit],
-  );
+  const handlePointerMove = useCallback((event: React.PointerEvent) => emit?.('mousemove', event), [
+    emit,
+  ]);
+  const handlePointerEnd = useCallback((event: React.PointerEvent) => emit?.('mouseout', event), [
+    emit,
+  ]);
 
   // if Context or dimensions are not available, wrap self in the needed providers
   if (!setDimensions) {
@@ -120,18 +121,18 @@ export default function XYChart<
   return width > 0 && height > 0 ? (
     <svg width={width} height={height} aria-label={accessibilityLabel}>
       {children}
-      {/** capture all mouse/touch events and emit them. */}
-      <rect
-        x={margin.left}
-        y={margin.top}
-        width={width - margin.left - margin.right}
-        height={height - margin.top - margin.bottom}
-        fill="transparent"
-        onMouseMove={handleMouseTouchMove}
-        onTouchMove={handleMouseTouchMove}
-        onMouseOut={handleMouseOutTouchEnd}
-        onTouchEnd={handleMouseOutTouchEnd}
-      />
+      {/** capture all pointer events and emit them. */}
+      {captureEvents && (
+        <rect
+          x={margin.left}
+          y={margin.top}
+          width={width - margin.left - margin.right}
+          height={height - margin.top - margin.bottom}
+          fill="transparent"
+          onPointerMove={handlePointerMove}
+          onPointerOut={handlePointerEnd}
+        />
+      )}
     </svg>
   ) : null;
 }

--- a/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSpring, animated, interpolate } from 'react-spring';
+import {
+  Annotation as VisxAnnotation,
+  EditableAnnotation as VisxEditableAnnotation,
+} from '@visx/annotation';
+import { AnnotationProps as VisxAnnotationProps } from '@visx/annotation/lib/components/Annotation';
+import {
+  EditableAnnotationProps,
+  EditableAnnotationProps as VisxEditableAnnotationProps,
+} from '@visx/annotation/lib/components/EditableAnnotation';
+import { AxisScale } from '@visx/axis';
+import BaseAnnotation, { BaseAnnotationProps } from './private/BaseAnnotation';
+
+export type AnnotationProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> = { editable?: boolean } & Omit<
+  BaseAnnotationProps<XScale, YScale, Datum>,
+  'AnnotationComponent'
+>;
+
+export default function AnimatedAnnotation<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>({ editable, ...props }: AnnotationProps<XScale, YScale, Datum>) {
+  const AnnotationComponent: BaseAnnotationProps<
+    XScale,
+    YScale,
+    Datum
+  >['AnnotationComponent'] = useCallback(
+    (annotationProps: VisxAnnotationProps & VisxEditableAnnotationProps) => (
+      <BaseAnimatedAnnotation
+        AnnotationComponent={editable ? VisxEditableAnnotation : VisxAnnotation}
+        {...annotationProps}
+      />
+    ),
+    [editable],
+  );
+  return <BaseAnnotation AnnotationComponent={AnnotationComponent} {...props} />;
+}
+
+function BaseAnimatedAnnotation<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>({
+  x = 0,
+  y = 0,
+  AnnotationComponent,
+  ...props
+}: {
+  AnnotationComponent: React.FC<VisxAnnotationProps> | React.FC<VisxEditableAnnotationProps>;
+} & VisxAnnotationProps &
+  EditableAnnotationProps) {
+  const lastXY = useRef({ x, y });
+
+  // in order to keep x/y/dx/dy accurate in AnnotationComponent, animate the delta
+  // between positions, to an x + y transform of zero from the previous value
+  const animatedXY = useSpring({
+    from: { x: lastXY.current.x - x, y: lastXY.current.y - y },
+    to: { x: 0, y: 0 },
+    reset: true,
+    onRest: () => {
+      lastXY.current = { x, y };
+    },
+  });
+
+  return (
+    <animated.g // for perf animate a group element not the Annotation itself
+      transform={interpolate(
+        // @ts-expect-error from/to mess up the useSpring types
+        [animatedXY.x, animatedXY.y],
+        (xVal, yVal) => `translate(${xVal}, ${yVal})`,
+      )}
+    >
+      <AnnotationComponent x={x} y={y} {...props} />
+    </animated.g>
+  );
+}

--- a/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
@@ -63,10 +63,11 @@ function BaseAnimatedAnnotation<
     from: { x: lastXY.current.x - x, y: lastXY.current.y - y },
     to: { x: 0, y: 0 },
     reset: true,
-    onRest: () => {
-      lastXY.current = { x, y };
-    },
   });
+
+  useEffect(() => {
+    lastXY.current = { x, y };
+  }, [x, y]);
 
   return (
     <animated.g // for perf animate a group element not the Annotation itself

--- a/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useSpring, animated, interpolate } from 'react-spring';
 import {
   Annotation as VisxAnnotation,

--- a/packages/visx-xychart/src/components/annotation/Annotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/Annotation.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  Annotation as VisxAnnotation,
+  EditableAnnotation as VisxEditableAnnotation,
+} from '@visx/annotation';
+import { AxisScale } from '@visx/axis';
+import BaseAnnotation, { BaseAnnotationProps } from './private/BaseAnnotation';
+
+export type AnnotationProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> = { editable?: boolean } & Omit<
+  BaseAnnotationProps<XScale, YScale, Datum>,
+  'AnnotationComponent'
+>;
+
+export default function Annotation<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>({ editable, ...props }: AnnotationProps<XScale, YScale, Datum>) {
+  return (
+    <BaseAnnotation
+      AnnotationComponent={editable ? VisxEditableAnnotation : VisxAnnotation}
+      {...props}
+    />
+  );
+}

--- a/packages/visx-xychart/src/components/annotation/AnnotationCircleSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationCircleSubject.tsx
@@ -1,0 +1,12 @@
+import React, { useContext } from 'react';
+import { CircleSubject as BaseCircleSubject } from '@visx/annotation';
+import { CircleSubjectProps } from '@visx/annotation/lib/components/CircleSubject';
+import DataContext from '../../context/DataContext';
+
+export type AnnotationSubjectCircleProps = CircleSubjectProps;
+
+/** AnnotationSubjectCircle which provides color from theme. */
+export default function AnnotationCircleSubject(props: AnnotationSubjectCircleProps) {
+  const { theme } = useContext(DataContext);
+  return <BaseCircleSubject stroke={theme?.gridStyles.stroke} {...props} />;
+}

--- a/packages/visx-xychart/src/components/annotation/AnnotationCircleSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationCircleSubject.tsx
@@ -8,5 +8,5 @@ export type AnnotationSubjectCircleProps = CircleSubjectProps;
 /** AnnotationSubjectCircle which provides color from theme. */
 export default function AnnotationCircleSubject(props: AnnotationSubjectCircleProps) {
   const { theme } = useContext(DataContext);
-  return <BaseCircleSubject stroke={theme?.gridStyles.stroke} {...props} />;
+  return <BaseCircleSubject stroke={theme?.axisStyles.x.bottom.axisLine.stroke} {...props} />;
 }

--- a/packages/visx-xychart/src/components/annotation/AnnotationConnector.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationConnector.tsx
@@ -1,0 +1,12 @@
+import React, { useContext } from 'react';
+import { Connector as BaseConnector } from '@visx/annotation';
+import { ConnectorProps as BaseConnectorProps } from '@visx/annotation/lib/components/Connector';
+import DataContext from '../../context/DataContext';
+
+export type AnnotationConnectorProps = BaseConnectorProps;
+
+/** AnnotationConnector which provides color from theme. */
+export default function AnnotationConnector(props: AnnotationConnectorProps) {
+  const { theme } = useContext(DataContext);
+  return <BaseConnector stroke={theme?.gridStyles.stroke} {...props} />;
+}

--- a/packages/visx-xychart/src/components/annotation/AnnotationConnector.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationConnector.tsx
@@ -8,5 +8,5 @@ export type AnnotationConnectorProps = BaseConnectorProps;
 /** AnnotationConnector which provides color from theme. */
 export default function AnnotationConnector(props: AnnotationConnectorProps) {
   const { theme } = useContext(DataContext);
-  return <BaseConnector stroke={theme?.gridStyles.stroke} {...props} />;
+  return <BaseConnector stroke={theme?.axisStyles.x.bottom.axisLine.stroke} {...props} />;
 }

--- a/packages/visx-xychart/src/components/annotation/AnnotationLabel.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLabel.tsx
@@ -1,0 +1,29 @@
+import React, { useContext } from 'react';
+import { Label as BaseLabel } from '@visx/annotation';
+import { LabelProps as BaseLabelProps } from '@visx/annotation/lib/components/Label';
+import DataContext from '../../context/DataContext';
+
+export type AnnotationLabelProps = BaseLabelProps;
+
+const defaultBackgroundProps = { fillOpacity: 0.7 };
+
+export default function AnnotationLabel(props: AnnotationLabelProps) {
+  const { theme } = useContext(DataContext);
+  const titleProps = theme?.svgLabelBig;
+  const subtitleProps = theme?.svgLabelSmall;
+  return (
+    <BaseLabel
+      anchorLineStroke={theme?.gridStyles.stroke}
+      backgroundFill={theme?.backgroundColor}
+      backgroundProps={defaultBackgroundProps}
+      showAnchorLine
+      subtitleFontSize={subtitleProps?.fontSize}
+      subtitleFontWeight={subtitleProps?.fontWeight}
+      subtitleProps={subtitleProps}
+      titleFontSize={titleProps?.fontSize}
+      titleFontWeight={titleProps?.fontWeight}
+      titleProps={titleProps}
+      {...props}
+    />
+  );
+}

--- a/packages/visx-xychart/src/components/annotation/AnnotationLabel.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLabel.tsx
@@ -13,7 +13,7 @@ export default function AnnotationLabel(props: AnnotationLabelProps) {
   const subtitleProps = theme?.svgLabelSmall;
   return (
     <BaseLabel
-      anchorLineStroke={theme?.gridStyles.stroke}
+      anchorLineStroke={theme?.axisStyles.x.bottom.axisLine.stroke}
       backgroundFill={theme?.backgroundColor}
       backgroundProps={defaultBackgroundProps}
       showAnchorLine

--- a/packages/visx-xychart/src/components/annotation/AnnotationLabel.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLabel.tsx
@@ -7,6 +7,7 @@ export type AnnotationLabelProps = BaseLabelProps;
 
 const defaultBackgroundProps = { fillOpacity: 0.7 };
 
+/** AnnotationLabel which provides text styles from theme. */
 export default function AnnotationLabel(props: AnnotationLabelProps) {
   const { theme } = useContext(DataContext);
   const titleProps = theme?.svgLabelBig;

--- a/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
@@ -3,14 +3,14 @@ import { LineSubject as BaseLineSubject } from '@visx/annotation';
 import { LineSubjectProps } from '@visx/annotation/lib/components/LineSubject';
 import DataContext from '../../context/DataContext';
 
-export type AnnotationLineSubjectProps = LineSubjectProps;
+export type AnnotationLineSubjectProps = LineSubjectProps & { min?: number; max?: number };
 
 /** AnnotationLineSubject which provides color and dimensions from context. */
 export default function AnnotationLineSubject({ min, max, ...props }: AnnotationLineSubjectProps) {
   const { theme, margin, innerHeight = 0, innerWidth = 0 } = useContext(DataContext);
   return (
     <BaseLineSubject
-      stroke={theme?.gridStyles.stroke}
+      stroke={theme?.axisStyles.x.bottom.axisLine.stroke}
       min={min ?? (props.orientation === 'horizontal' ? margin?.left : margin?.top)}
       max={
         max ??

--- a/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import { LineSubject as BaseLineSubject } from '@visx/annotation';
+import { LineSubjectProps } from '@visx/annotation/lib/components/LineSubject';
+import DataContext from '../../context/DataContext';
+
+export type AnnotationLineSubjectProps = LineSubjectProps;
+
+/** AnnotationLineSubject which provides color and dimensions from context. */
+export default function AnnotationLineSubject({ min, max, ...props }: AnnotationLineSubjectProps) {
+  const { theme, margin, innerHeight = 0, innerWidth = 0 } = useContext(DataContext);
+  return (
+    <BaseLineSubject
+      stroke={theme?.gridStyles.stroke}
+      min={min ?? (props.orientation === 'horizontal' ? margin?.left : margin?.top)}
+      max={
+        max ??
+        (props.orientation === 'horizontal'
+          ? (margin?.left ?? 0) + innerWidth
+          : (margin?.top ?? 0) + innerHeight)
+      }
+      {...props}
+    />
+  );
+}

--- a/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
@@ -3,7 +3,10 @@ import { LineSubject as BaseLineSubject } from '@visx/annotation';
 import { LineSubjectProps } from '@visx/annotation/lib/components/LineSubject';
 import DataContext from '../../context/DataContext';
 
-export type AnnotationLineSubjectProps = LineSubjectProps & { min?: number; max?: number };
+export type AnnotationLineSubjectProps = Omit<LineSubjectProps, 'min' | 'max'> & {
+  min?: number;
+  max?: number;
+};
 
 /** AnnotationLineSubject which provides color and dimensions from context. */
 export default function AnnotationLineSubject({ min, max, ...props }: AnnotationLineSubjectProps) {

--- a/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
@@ -14,7 +14,7 @@ export default function AnnotationLineSubject({ min, max, ...props }: Annotation
   return (
     <BaseLineSubject
       stroke={theme?.axisStyles.x.bottom.axisLine.stroke}
-      min={min ?? (props.orientation === 'horizontal' ? margin?.left : margin?.top)}
+      min={min ?? (props.orientation === 'horizontal' ? margin?.left : margin?.top) ?? 0}
       max={
         max ??
         (props.orientation === 'horizontal'

--- a/packages/visx-xychart/src/components/annotation/private/BaseAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/private/BaseAnnotation.tsx
@@ -11,29 +11,23 @@ export type BaseAnnotationProps<
   XScale extends AxisScale,
   YScale extends AxisScale,
   Datum extends object
-> = {
+> = Pick<
+  EditableAnnotationProps,
+  | 'canEditLabel'
+  | 'canEditSubject'
+  | 'children'
+  | 'dx'
+  | 'dy'
+  | 'onDragEnd'
+  | 'onDragMove'
+  | 'onDragStart'
+> & {
   /** Annotation component to render. */
   AnnotationComponent: React.FC<AnnotationProps> | React.FC<EditableAnnotationProps>;
-  /** If editable, whether label position can be edited. */
-  canEditLabel: EditableAnnotationProps['canEditLabel'];
-  /** If editable, whether subject position can be edited. */
-  canEditSubject: EditableAnnotationProps['canEditSubject'];
-  /** Annotation children. */
-  children: AnnotationProps['children'];
   /** Key for series to which datum belongs (used for x/yAccessors). Alternatively xAccessor + yAccessor may be specified. */
   dataKey: string;
   /** Datum to annotate, used for Annotation positioning. */
   datum: Datum;
-  /** x offset of annotation label from the datum to be annotated. */
-  dx?: number;
-  /** y offset of annotation label from the datum to be annotated. */
-  dy?: number;
-  /** Callback invoked for editable annotations on drag end. */
-  onDragEnd?: EditableAnnotationProps['onDragEnd'];
-  /** Callback invoked for editable annotations on drag move. */
-  onDragMove?: EditableAnnotationProps['onDragMove'];
-  /** Callback invoked for editable annotations on drag start. */
-  onDragStart?: EditableAnnotationProps['onDragStart'];
   /** If dataKey is not specified, you must specify an xAccessor for datum. */
   xAccessor?: (d: Datum) => ScaleInput<XScale>;
   /** If dataKey is not specified, you must specify an yAccessor for datum. */

--- a/packages/visx-xychart/src/components/annotation/private/BaseAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/private/BaseAnnotation.tsx
@@ -14,6 +14,10 @@ export type BaseAnnotationProps<
 > = {
   /** Annotation component to render. */
   AnnotationComponent: React.FC<AnnotationProps> | React.FC<EditableAnnotationProps>;
+  /** If editable, whether label position can be edited. */
+  canEditLabel: EditableAnnotationProps['canEditLabel'];
+  /** If editable, whether subject position can be edited. */
+  canEditSubject: EditableAnnotationProps['canEditSubject'];
   /** Annotation children. */
   children: AnnotationProps['children'];
   /** Key for series to which datum belongs (used for x/yAccessors). Alternatively xAccessor + yAccessor may be specified. */

--- a/packages/visx-xychart/src/components/annotation/private/BaseAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/private/BaseAnnotation.tsx
@@ -1,0 +1,94 @@
+import React, { useContext, useMemo } from 'react';
+import { AnnotationProps } from '@visx/annotation/lib/components/Annotation';
+import { EditableAnnotationProps } from '@visx/annotation/lib/components/EditableAnnotation';
+import { coerceNumber, ScaleInput } from '@visx/scale';
+import { AxisScale } from '@visx/axis';
+import DataContext from '../../../context/DataContext';
+import getScaleBandwidth from '../../../utils/getScaleBandwidth';
+import isValidNumber from '../../../typeguards/isValidNumber';
+
+export type BaseAnnotationProps<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+> = {
+  /** Annotation component to render. */
+  AnnotationComponent: React.FC<AnnotationProps> | React.FC<EditableAnnotationProps>;
+  /** Annotation children. */
+  children: AnnotationProps['children'];
+  /** Key for series to which datum belongs (used for x/yAccessors). Alternatively xAccessor + yAccessor may be specified. */
+  dataKey: string;
+  /** Datum to annotate, used for Annotation positioning. */
+  datum: Datum;
+  /** x offset of annotation label from the datum to be annotated. */
+  dx?: number;
+  /** y offset of annotation label from the datum to be annotated. */
+  dy?: number;
+  /** Callback invoked for editable annotations on drag end. */
+  onDragEnd?: EditableAnnotationProps['onDragEnd'];
+  /** Callback invoked for editable annotations on drag move. */
+  onDragMove?: EditableAnnotationProps['onDragMove'];
+  /** Callback invoked for editable annotations on drag start. */
+  onDragStart?: EditableAnnotationProps['onDragStart'];
+  /** If dataKey is not specified, you must specify an xAccessor for datum. */
+  xAccessor?: (d: Datum) => ScaleInput<XScale>;
+  /** If dataKey is not specified, you must specify an yAccessor for datum. */
+  yAccessor?: (d: Datum) => ScaleInput<YScale>;
+};
+
+// used for auto-positioning
+const minimumLabelDimension = 16;
+
+export default function BaseAnnotation<
+  XScale extends AxisScale,
+  YScale extends AxisScale,
+  Datum extends object
+>({
+  AnnotationComponent,
+  children,
+  datum,
+  dataKey,
+  xAccessor: propsXAccessor,
+  yAccessor: propsYAccessor,
+  dx: propsDx = 0,
+  dy: propsDy = 0,
+  ...annotationProps
+}: BaseAnnotationProps<XScale, YScale, Datum>) {
+  const { innerHeight, innerWidth, margin, xScale, yScale, dataRegistry } =
+    useContext(DataContext) || {};
+
+  const xBandWidth = useMemo(() => (xScale ? getScaleBandwidth(xScale) : 0), [xScale]);
+  const yBandWidth = useMemo(() => (yScale ? getScaleBandwidth(yScale) : 0), [yScale]);
+
+  if ((!propsXAccessor || !propsYAccessor) && !dataKey) {
+    console.warn('[@visx/xychart/BaseAnnotation]: dataKey or x/yAccessors must be specified.');
+    return null;
+  }
+
+  const registryEntry = propsXAccessor && propsYAccessor ? null : dataRegistry?.get(dataKey);
+  const xAccessor = propsXAccessor || registryEntry?.xAccessor;
+  const yAccessor = propsYAccessor || registryEntry?.yAccessor;
+
+  if (!xScale || !yScale || !innerWidth || !innerHeight || !xAccessor || !yAccessor || !margin) {
+    return null;
+  }
+
+  const x = (coerceNumber(xScale(xAccessor(datum))) ?? NaN) + xBandWidth / 2;
+  const y = (coerceNumber(yScale(yAccessor(datum))) ?? NaN) + yBandWidth / 2;
+  const dx = x + propsDx + minimumLabelDimension > margin.left + innerWidth ? -propsDx : propsDx;
+  const dy = y + propsDy + minimumLabelDimension > margin.top + innerHeight ? -propsDy : propsDy;
+
+  return isValidNumber(x) && isValidNumber(y) ? (
+    <AnnotationComponent
+      width={innerWidth}
+      height={innerHeight}
+      {...annotationProps}
+      x={x}
+      y={y}
+      dx={dx}
+      dy={dy}
+    >
+      {children}
+    </AnnotationComponent>
+  ) : null;
+}

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -1,4 +1,10 @@
 // components
+export { default as Annotation } from './components/annotation/Annotation';
+export { default as AnimatedAnnotation } from './components/annotation/AnimatedAnnotation';
+export { default as AnnotationLabel } from './components/annotation/AnnotationLabel';
+export { default as AnnotationConnector } from './components/annotation/AnnotationConnector';
+export { default as AnnotationCircleSubject } from './components/annotation/AnnotationCircleSubject';
+export { default as AnnotationLineSubject } from './components/annotation/AnnotationLineSubject';
 export { default as AnimatedAxis } from './components/axis/AnimatedAxis';
 export { default as AnimatedGrid } from './components/grid/AnimatedGrid';
 export { default as Axis } from './components/axis/Axis';

--- a/packages/visx-xychart/src/theme/buildChartTheme.ts
+++ b/packages/visx-xychart/src/theme/buildChartTheme.ts
@@ -9,9 +9,9 @@ export type ThemeConfig = {
   colors: string[];
 
   // labels
-  labelStyles?: SVGTextProps;
-  tickLabelStyles?: SVGTextProps;
-  htmlLabelStyles?: HTMLTextStyles;
+  svgLabelBig?: SVGTextProps;
+  svgLabelSmall?: SVGTextProps;
+  htmlLabel?: HTMLTextStyles;
 
   // lines
   xAxisLineStyles?: LineStyles;
@@ -41,7 +41,7 @@ export default function buildChartTheme(config: ThemeConfig): XYChartTheme {
     ...defaultLabelStyles,
     fill: textColor,
     stroke: 'none',
-    ...config.labelStyles,
+    ...config.svgLabelBig,
   } as const;
 
   const baseTickLabel: SVGTextProps = {
@@ -50,20 +50,30 @@ export default function buildChartTheme(config: ThemeConfig): XYChartTheme {
     fontSize: 11,
     fill: textColor,
     stroke: 'none',
-    ...config.tickLabelStyles,
+    ...config.svgLabelSmall,
   } as const;
 
   const baseHtmlLabel: HTMLTextStyles = {
-    color: config.labelStyles?.fill ?? textColor,
+    color:
+      config.htmlLabel?.color ??
+      config.svgLabelBig?.fill ??
+      config.svgLabelSmall?.fill ??
+      textColor,
     ...defaultLabelStyles,
-    ...config.htmlLabelStyles,
+    ...config.htmlLabel,
   };
 
   return {
     backgroundColor: config.backgroundColor,
     colors: [...config.colors],
-    htmlLabelStyles: {
+    htmlLabel: {
       ...baseHtmlLabel,
+    },
+    svgLabelSmall: {
+      ...baseTickLabel,
+    },
+    svgLabelBig: {
+      ...baseSvgLabel,
     },
     gridStyles: {
       stroke: config.gridColor,

--- a/packages/visx-xychart/src/theme/themes/dark.ts
+++ b/packages/visx-xychart/src/theme/themes/dark.ts
@@ -13,10 +13,10 @@ export default buildChartTheme({
     allColors.pink[3],
   ],
   tickLength: 4,
-  tickLabelStyles: {
+  svgLabelSmall: {
     fill: grayColors[2],
   },
-  labelStyles: {
+  svgLabelBig: {
     fill: grayColors[0],
   },
   gridColor: grayColors[4],

--- a/packages/visx-xychart/src/theme/themes/light.ts
+++ b/packages/visx-xychart/src/theme/themes/light.ts
@@ -5,10 +5,10 @@ export default buildChartTheme({
   backgroundColor: '#fff',
   colors: defaultColors,
   tickLength: 4,
-  tickLabelStyles: {
+  svgLabelSmall: {
     fill: grayColors[7],
   },
-  labelStyles: {
+  svgLabelBig: {
     fill: grayColors[9],
   },
   gridColor: grayColors[5],

--- a/packages/visx-xychart/src/types/theme.ts
+++ b/packages/visx-xychart/src/types/theme.ts
@@ -29,7 +29,11 @@ export interface XYChartTheme {
   /** Ordinal colors to be used for default coloring by series `key`s. */
   colors: string[];
   /** Styles to applied to HMTL labels. */
-  htmlLabelStyles: HTMLTextStyles;
+  htmlLabel: HTMLTextStyles;
+  /** Styles to applied to big SVG labels (axis label, annotation title, etc.). */
+  svgLabelBig: SVGTextProps;
+  /** Styles to applied to small SVG labels (tick label, annotation subtitle, etc.). */
+  svgLabelSmall: SVGTextProps;
   /** Styles to be applied to chart grids. */
   gridStyles: GridStyles;
   /** Styles to be applied to axes (axis labels, ticks, tick labels). */

--- a/packages/visx-xychart/test/theme.test.tsx
+++ b/packages/visx-xychart/test/theme.test.tsx
@@ -35,8 +35,8 @@ describe('theme', () => {
       colors: ['violet'],
       gridStyles: { strokeDasharray: '1,5' },
       tickLength: 7.5,
-      labelStyles: { fontFamily: 'Comic Sans', fill: 'grape' },
-      tickLabelStyles: { fontSize: 100, fill: 'banana' },
+      svgLabelBig: { fontFamily: 'Comic Sans', fill: 'grape' },
+      svgLabelSmall: { fontSize: 100, fill: 'banana' },
       xTickLineStyles: { strokeWidth: 2.4 },
     });
 
@@ -44,7 +44,9 @@ describe('theme', () => {
       backgroundColor: 'white',
       colors: ['violet'],
       gridStyles: { stroke: 'fuchsia', strokeDasharray: '1,5' },
-      htmlLabelStyles: { color: 'grape' },
+      htmlLabel: { color: 'grape' },
+      svgLabelBig: { fill: 'grape' },
+      svgLabelSmall: { fill: 'banana' },
       axisStyles: {
         x: {
           top: {


### PR DESCRIPTION
#### :rocket: Enhancements

This PR integrates the new `@visx/annotation`s into `@visx/xychart` and updates the demo. Most of the work is wrappers around the annotation components to provide theme + dimensions from `XYChart`'s context, and I also added an `AnimatedAnnotation` variant so that they can animate upon data changes. 


A quick summary of components added for ease of review

- `private/BaseAnnotation` powers `Annotation` and `AnimatedAnnotation` (mirrors how `AnimatedSeries` work)
- `Annotation`
- `AnimatedAnnotation`

**Animation**
<img src="https://user-images.githubusercontent.com/4496521/99608151-2f5dc200-29c2-11eb-9dd3-8e13dd8ce3d3.gif" width="500" />

**Editable**
<img src="https://user-images.githubusercontent.com/4496521/99608618-20c3da80-29c3-11eb-8101-392c95f07083.gif" width="500" />

**Theme support**
<img src="https://user-images.githubusercontent.com/4496521/99608605-1acdf980-29c3-11eb-86ad-b50d72118adc.gif" width="500" />

**Horizontal line annotations**
<img src="https://user-images.githubusercontent.com/4496521/99607253-44d1ec80-29c0-11eb-9798-8579ae843407.png" width="500" />

Noting that you can render an annotation per data point, so this PR fixes #903 
<img src="https://user-images.githubusercontent.com/4496521/99744215-1e798300-2a8c-11eb-9029-99f0d217f6e8.png" width="500" />

Something like this
```tsx
{data.map((d, i) => (
  <AnimatedAnnotation key={i} dataKey="New York" datum={d} dx={0} dy={-10}>
    <AnnotationLabel
      subtitle={`${d['New York']}°F`}
      horizontalAnchor="middle"
      verticalAnchor="middle"
      showBackground={false}
      showAnchorLine={false}
      width={50}
    />
  </AnimatedAnnotation>
))}
```

#### :boom: Breaking Changes

This updates the shape of the `xychart` `theme`, but since it's not released it's not technically breaking in a semantic version sense.

@kristw @hshoff 