### PR TITLE
test(xychart): add focus/blur handler tests

### DIFF
--- a/packages/visx-xychart/src/hooks/useEventEmitter.ts
+++ b/packages/visx-xychart/src/hooks/useEventEmitter.ts
@@ -12,6 +12,7 @@ export type HandlerParams = {
   /** The source of the event. This can be anything, but for this package is the name of the component which emitted the event. */
   source?: string;
 };
+
 export type Handler = (params?: HandlerParams) => void;
 
 /**

--- a/packages/visx-xychart/src/utils/findNearestGroupDatum.ts
+++ b/packages/visx-xychart/src/utils/findNearestGroupDatum.ts
@@ -23,26 +23,28 @@ export default function findNearestGroupDatum<
   if (!datum || !point) return null;
 
   const barGroupOffset = groupScale(dataKey);
-  const barWidth = groupScale.step(); // @TODO this doesn't currently account for initial paddingOuter
+  const barWidth = groupScale.step();
 
   if (horizontal) {
     const groupPosition = yScale(yAccessor(datum.datum));
     const barStart = (groupPosition ?? Infinity) + (barGroupOffset ?? Infinity);
     const barEnd = barStart + barWidth;
+    const barMiddle = (barStart + barEnd) / 2;
     const cursorIsOnBar = point.y >= barStart && point.y <= barEnd;
     return {
       ...datum,
-      distanceX: 0,
-      distanceY: cursorIsOnBar ? 0 : datum.distanceY,
+      distanceX: 0, // we want all group bars to have same X distance so only Y distance matters
+      distanceY: cursorIsOnBar ? 0 : Math.abs(point.y - barMiddle),
     };
   }
   const groupPosition = xScale(xAccessor(datum.datum));
   const barStart = (groupPosition ?? Infinity) + (barGroupOffset ?? Infinity);
   const barEnd = barStart + barWidth;
+  const barMiddle = (barStart + barEnd) / 2;
   const cursorIsOnBar = point.x >= barStart && point.x <= barEnd;
   return {
     ...datum,
-    distanceY: 0,
-    distanceX: cursorIsOnBar ? 0 : datum.distanceX,
+    distanceY: 0, // we want all group bars to have same Y distance so only X distance matters
+    distanceX: cursorIsOnBar ? 0 : Math.abs(point.x - barMiddle),
   };
 }

--- a/packages/visx-xychart/test/components/AreaSeries.test.tsx
+++ b/packages/visx-xychart/test/components/AreaSeries.test.tsx
@@ -38,6 +38,17 @@ describe('<AreaSeries />', () => {
     expect(wrapper.find(LinePath)).toHaveLength(1);
   });
 
+  it('should render Glyphs if focus/blur handlers are set', () => {
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <AreaSeries dataKey={series.key} {...series} onFocus={() => {}} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    expect(wrapper.find('circle')).toHaveLength(series.data.length);
+  });
+
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
     expect.assertions(2);
 

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -26,6 +26,17 @@ describe('<LineSeries />', () => {
     expect(wrapper.find(LinePath)).toHaveLength(1);
   });
 
+  it('should render Glyphs if focus/blur handlers are set', () => {
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <LineSeries dataKey={series.key} {...series} onFocus={() => {}} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    expect(wrapper.find('circle')).toHaveLength(series.data.length);
+  });
+
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
     expect.assertions(2);
 

--- a/packages/visx-xychart/test/hooks/useEventEmitters.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventEmitters.test.tsx
@@ -12,8 +12,15 @@ describe('useEventEmitters', () => {
     expect.assertions(1);
 
     const Component = () => {
-      const emitters = useEventEmitters({ source: 'visx', onPointerOut: false });
+      const emitters = useEventEmitters({
+        source: 'visx',
+        onPointerOut: false,
+        onBlur: true,
+        onFocus: true,
+      });
       expect(emitters).toEqual({
+        onBlur: expect.any(Function),
+        onFocus: expect.any(Function),
         onPointerMove: expect.any(Function),
         onPointerOut: undefined,
         onPointerUp: expect.any(Function),

--- a/packages/visx-xychart/test/hooks/useEventHandlers.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventHandlers.test.tsx
@@ -23,18 +23,22 @@ describe('useEventHandlers', () => {
     expect(useEventHandlers).toBeDefined();
   });
   it('should invoke handlers for each pointer event handler specified', () => {
-    expect.assertions(3);
+    expect.assertions(5);
 
     const Component = () => {
       const sourceId = 'sourceId';
       const pointerMoveListener = jest.fn();
       const pointerOutListener = jest.fn();
       const pointerUpListener = jest.fn();
+      const focusListener = jest.fn();
+      const blurListener = jest.fn();
       const emit = useEventEmitter();
 
       useEventHandlers({
         allowedSources: [sourceId],
         dataKey: series1.key,
+        onFocus: focusListener,
+        onBlur: blurListener,
         onPointerMove: pointerMoveListener,
         onPointerOut: pointerOutListener,
         onPointerUp: pointerUpListener,
@@ -53,6 +57,14 @@ describe('useEventHandlers', () => {
           emit('pointerup', getEvent('pointerup'), sourceId);
           emit('pointerup', getEvent('pointerup'), 'invalidSource');
           expect(pointerUpListener).toHaveBeenCalledTimes(1);
+
+          emit('focus', (new FocusEvent('focus') as unknown) as React.FocusEvent, sourceId);
+          emit('focus', (new FocusEvent('focus') as unknown) as React.FocusEvent, 'invalidSource');
+          expect(focusListener).toHaveBeenCalledTimes(1);
+
+          emit('blur', (new FocusEvent('blur') as unknown) as React.FocusEvent, sourceId);
+          emit('blur', (new FocusEvent('blur') as unknown) as React.FocusEvent, 'invalidSource');
+          expect(blurListener).toHaveBeenCalledTimes(1);
         }
       });
 

--- a/packages/visx-xychart/test/utils/findNearestDatum.test.ts
+++ b/packages/visx-xychart/test/utils/findNearestDatum.test.ts
@@ -1,10 +1,13 @@
 import { AxisScale } from '@visx/axis';
 import { scaleBand, scaleLinear } from '@visx/scale';
+import { PositionScale } from '@visx/shape/lib/types';
+
 import findNearestDatumX from '../../src/utils/findNearestDatumX';
 import findNearestDatumY from '../../src/utils/findNearestDatumY';
 import findNearestDatumXY from '../../src/utils/findNearestDatumXY';
 import findNearestDatumSingleDimension from '../../src/utils/findNearestDatumSingleDimension';
 import findNearestStackDatum from '../../src/utils/findNearestStackDatum';
+import findNearestGroupDatum from '../../src/utils/findNearestGroupDatum';
 import { BarStackDatum, NearestDatumArgs } from '../../src';
 
 type Datum = { xVal: number; yVal: string };
@@ -134,5 +137,34 @@ describe('findNearestStackDatum', () => {
         true,
       )!.datum,
     ).toEqual(d2); // nearest datum index=1
+  });
+});
+
+describe('findNearestGroupDatum', () => {
+  it('should be defined', () => {
+    expect(findNearestGroupDatum).toBeDefined();
+  });
+
+  it('should find the nearest datum', () => {
+    expect(
+      findNearestGroupDatum(
+        {
+          ...params,
+        } as NearestDatumArgs<PositionScale, PositionScale, Datum>,
+        scaleBand({ domain: [params.dataKey], range: [0, 10] }),
+      )!.datum,
+    ).toEqual({ xVal: 0, yVal: '0' }); // non-horizontal means nearest x value
+  });
+
+  it('should set distance to 0', () => {
+    expect(
+      findNearestGroupDatum(
+        {
+          ...params,
+        } as NearestDatumArgs<PositionScale, PositionScale, Datum>,
+        scaleBand({ domain: [params.dataKey], range: [0, 10] }),
+        true,
+      )!.distanceY,
+    ).toEqual(0);
   });
 });


### PR DESCRIPTION
#### :house: Internal

- Adds tests for `FocusEvent` logic added in #959 
- improves logic in `findNearestGroupDatum` to better handle band scale padding (space between bars)

#### :bug: Bug Fix

Always nice when tests reveal bugs – `onFocus` handlers weren't being invoked correctly in `useEventHandlers`, so fixed that in the process.

@hshoff @kristw 