### PR TITLE
docs(xychart): add README, add docs/xychart page, add XYChart gallery tile

### DIFF
--- a/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
@@ -5,7 +5,6 @@ import GalleryTile from '../GalleryTile';
 export { default as packageJson } from '../../sandboxes/visx-xychart/package.json';
 
 const tileStyles = { background: '#222' };
-const detailsStyles = { color: '#ccc' };
 
 export default function XYChartITile() {
   return (
@@ -15,7 +14,6 @@ export default function XYChartITile() {
       exampleRenderer={XYChartI}
       exampleUrl="/xychart"
       tileStyles={tileStyles}
-      detailsStyles={detailsStyles}
       detailsHeight={0}
     />
   );

--- a/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import XYChartI, { XYChartProps } from '../../sandboxes/visx-xychart/Example';
+import XYChart, { XYChartProps } from '../../sandboxes/visx-xychart/Example';
 import GalleryTile from '../GalleryTile';
 
 export { default as packageJson } from '../../sandboxes/visx-xychart/package.json';
@@ -11,7 +11,7 @@ export default function XYChartITile() {
     <GalleryTile<XYChartProps>
       title="XYChart"
       description="<XYChart />"
-      exampleRenderer={XYChartI}
+      exampleRenderer={XYChart}
       exampleUrl="/xychart"
       tileStyles={tileStyles}
       detailsHeight={0}

--- a/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import XYChartI, { XYChartProps } from '../../sandboxes/visx-xychart/Example';
+import GalleryTile from '../GalleryTile';
+
+export { default as packageJson } from '../../sandboxes/visx-xychart/package.json';
+
+const tileStyles = { background: '#222' };
+const detailsStyles = { color: '#ccc' };
+
+export default function XYChartITile() {
+  return (
+    <GalleryTile<XYChartProps>
+      title="XYChart"
+      description="<XYChart />"
+      exampleRenderer={XYChartI}
+      exampleUrl="/xychart"
+      tileStyles={tileStyles}
+      detailsStyles={detailsStyles}
+      detailsHeight={0}
+    />
+  );
+}

--- a/packages/visx-demo/src/components/Gallery/index.tsx
+++ b/packages/visx-demo/src/components/Gallery/index.tsx
@@ -44,6 +44,7 @@ import * as TooltipTile from './TooltipTile';
 import * as TreemapTile from './TreemapTile';
 import * as TreesTile from './TreesTile';
 import * as VoronoiTile from './VoronoiTile';
+import * as XYChartTile from './XYChartTile';
 import * as ZoomITile from './ZoomITile';
 import { VisxPackage } from '../../types';
 import exampleToVisxDependencyLookup, {
@@ -77,6 +78,7 @@ const tiles = [
   BarStackHorizontalTile,
   DendrogramsTile,
   DragIITile,
+  XYChartTile,
   GeoCustomTile,
   GeoMercatorTile,
   GlyphsTile,

--- a/packages/visx-demo/src/components/PackageList.tsx
+++ b/packages/visx-demo/src/components/PackageList.tsx
@@ -132,6 +132,16 @@ export default function PackageList({
               </Link>
               {!compact && <p>Difference charts to compare the delta between two time series</p>}
             </li>
+            <li className={cx(emphasizePackage === 'xychart' && 'emphasize')}>
+              <Link href="/docs/xychart">
+                <a>xychart</a>
+              </Link>
+              {!compact && (
+                <p>
+                  A chart-level API built on & integrated with several other visx building blocks
+                </p>
+              )}
+            </li>
           </ul>
         </div>
         <div>

--- a/packages/visx-demo/src/pages/docs/xychart.tsx
+++ b/packages/visx-demo/src/pages/docs/xychart.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import XYChartReadme from '!!raw-loader!../../../../visx-xychart/Readme.md';
+import * as XYChartPackage from '../../../../visx-xychart/src';
+import DocPage from '../../components/DocPage';
+import XYChartTile from '../../components/Gallery/XYChartTile';
+
+const components = Object.values(XYChartPackage);
+
+const examples = [XYChartTile];
+
+const XYChartDocs = () => (
+  <DocPage
+    components={components}
+    examples={examples}
+    readme={XYChartReadme}
+    visxPackage="xychart"
+  />
+);
+
+export default XYChartDocs;

--- a/packages/visx-demo/src/pages/docs/xychart.tsx
+++ b/packages/visx-demo/src/pages/docs/xychart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import XYChartReadme from '!!raw-loader!../../../../visx-xychart/Readme.md';
+import XYChartReadme from '!!raw-loader!../../../../visx-xychart/README.md';
 import * as XYChartPackage from '../../../../visx-xychart/src';
 import DocPage from '../../components/DocPage';
 import XYChartTile from '../../components/Gallery/XYChartTile';

--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -20,14 +20,14 @@ import {
 import ExampleControls from './ExampleControls';
 import CustomChartBackground from './CustomChartBackground';
 
-type Props = {
+export type XYChartProps = {
   width: number;
   height: number;
 };
 
 type City = 'San Francisco' | 'New York' | 'Austin';
 
-export default function Example({ height }: Props) {
+export default function Example({ height }: XYChartProps) {
   return (
     <ExampleControls>
       {({

--- a/packages/visx-demo/src/sandboxes/visx-xychart/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/package.json
@@ -17,6 +17,7 @@
     "react": "^16",
     "react-dom": "^16",
     "react-scripts-ts": "3.1.0",
+    "react-spring": "^8.0.27",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/visx-demo/src/sandboxes/visx-xychart/sandbox-styles.css
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/sandbox-styles.css
@@ -1,7 +1,6 @@
 html,
 body,
 #root {
-  height: 100%;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
     'Open Sans', 'Helvetica Neue', sans-serif;
   line-height: 2em;

--- a/packages/visx-demo/src/types/index.ts
+++ b/packages/visx-demo/src/types/index.ts
@@ -50,6 +50,7 @@ export type VisxPackage =
   | 'tooltip'
   | 'voronoi'
   | 'visx'
+  | 'xychart'
   | 'zoom';
 
 export type PackageJson = { dependencies?: { [packageName: string]: string } };

--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -15,37 +15,40 @@ Out of the box it supports the following:
 - \* `<Tooltip />`
 - \* `theme`ing
 
-The following illustrates basic usage for an animated line chart with a bottom `Axis`, `Grid`, and
-`Tooltip`, try it on codesandbox [here](todo, simplify code below):
+The following illustrates basic usage to create an animated line chart with a bottom `Axis`, `Grid`,
+and `Tooltip`, try it on codesandbox [here](todo, simplify code below):
 
 ```tsx
-import { AnimatedAxis, AnimatedGrid, AnimatedLineSeries, XYChart } from '@visx/xychart';
+import {
+  AnimatedAxis, // any of these can be non-animated equivalents
+  AnimatedGrid,
+  AnimatedLineSeries,
+  XYChart,
+} from '@visx/xychart';
 
 const data1 = [
   { x: '2020-01-01', y: 50 },
   { x: '2020-01-02', y: 10 },
   { x: '2020-01-03', y: 20 },
-  { x: '2020-01-04', y: 10 },
-  { x: '2020-01-05', y: 0 },
 ];
 
 const data2 = [
   { x: '2020-01-01', y: 30 },
   { x: '2020-01-02', y: 40 },
   { x: '2020-01-03', y: 80 },
-  { x: '2020-01-04', y: 70 },
-  { x: '2020-01-05', y: 20 },
 ];
 
-const xAccessor = d => d.x;
-const yAccessor = d => d.y;
+const accessors = {
+  xAccessor: d => d.x,
+  yAccessor: d => d.y,
+};
 
 const render = () => (
   <XYChart height={300} xScale={{ type: 'band' }} yScale={{ type: 'linear' }}>
     <AnimatedAxis orientation="bottom" />
     <AnimatedGrid columns={false} numTicks={4} />
-    <AnimatedLineSeries dataKey="Line 1" data={data1} xAccessor={xAccessor} yAccessor={yAccessor} />
-    <AnimatedLineSeries dataKey="Line 2" data={data2} xAccessor={xAccessor} yAccessor={yAccessor} />
+    <AnimatedLineSeries dataKey="Line 1" data={data1} {...accessors} />
+    <AnimatedLineSeries dataKey="Line 2" data={data2} {...accessors} />
     <Tooltip
       snapTooltipToDatumX
       snapTooltipToDatumY
@@ -54,11 +57,11 @@ const render = () => (
       renderTooltip={({ tooltipData, colorScale }) => (
         <div>
           <div style={{ color: colorScale(tooltipData.nearestDatum.key) }}>
-            {tooltipData.nearestDatum.key || 'No key'}
+            {tooltipData.nearestDatum.key}
           </div>
-          {tooltipData.nearestDatum.datum.x || 'No date'}
+          {accessors.xAccessor(tooltipData.nearestDatum.datum)}
           {', '}
-          {tooltipData.nearestDatum.datum.y || 'No value'}
+          {accessors.yAccessor(tooltipData.nearestDatum.datum)}
         </div>
       )}
     />
@@ -66,15 +69,15 @@ const render = () => (
 );
 ```
 
-Expand sections for more, or explore the detailed API below.
+See sections below for more detailed guidance and advanced usage, or explore the comprehensive API
+below.
 
 <hr />
 
 ## Basic usage
 
 <details>
-
-<summary>Series types</summary>
+  <summary>Series types</summary>
 
 The following `Series` types are currently supported and we are happy to review or consider
 additional Series types in the future.
@@ -94,8 +97,7 @@ support missing (`null`) data, and can be rendered vertically or horizontally.
 </details>
 
 <details>
-
-<summary>Theming</summary>
+  <summary>Theming</summary>
 
 Default `lightTheme` and `darkTheme` themes are exported from `@visx/xychart` and the utility
 `buildChartTheme` is exported to support easy creation of custom themes.
@@ -133,8 +135,7 @@ const customTheme = buildTheme({
 </details>
 
 <details>
-
-<summary>Tooltips</summary>
+  <summary>Tooltips</summary>
 
 `@visx/tooltip` `Tooltip`s are integrated into `@visx/xychart`, and should be rendered as a child of
 `XYChart` (or a child where `TooltipContext` is provided).
@@ -154,8 +155,7 @@ snapping to data point positions and rendering cross-hairs.
 </details>
 
 <details>
-
-<summary>Event handlers</summary>
+  <summary>Event handlers</summary>
 
 The following `PointerEvent`s (handling both `MouseEvent`s and `TouchEvent`s) are currently
 supported. They may be set on individual `Series` components (e.g.,
@@ -188,11 +188,49 @@ type EventHandlerParams<Datum> = {
 </details>
 
 <details>
+  <summary>Annotations</summary>
 
-<summary>Annotations</summary>
+Composable `@visx/annotations` annotations are integrated into `@visx/xychart` and use its theme and
+dimension context. These components allow for annotation of individual points using
+`AnnotationCircleSubject`, or x- or y-thresholds using `AnnotationLineSubject`.
 
-`@visx/annotations` annotations are integrated into `@visx/xychart`, and allow you to annotate
-individual points, or x- or y-thresholds.
+```tsx
+import {
+  XYChart,
+  AnimatedAnnotation,
+  AnnotationLabel,
+  AnnotationConnector,
+  AnnotationCircleSubject,
+} from '@visx/xychart';
+
+const data = [
+  { x: '2020-01-01', y: 50 },
+  { x: '2020-01-02', y: 10 },
+  { x: '2020-01-03', y: 20 },
+];
+
+() => (
+  <XYChart {...}>
+    <LineSeries dataKey="line" data={data} xAccessor={...} yAccessor={...} />
+    <AnimatedAnnotation
+      dataKey="line" // use this Series's accessor functions, alternatively specify x/yAccessor here
+      datum={data[0]}
+      dx={labelXOffset}
+      dy={labelYOffset}
+      editable={isEditable}
+      onDragEnd={({ x, y, dx, dy }) => /** handle edit */}
+    >
+      {/** Text label */}
+      <AnnotationLabel title="My point" subtitle="More deets" />
+      {/** Draw circle around point */}
+      <AnnotationCircleSubject />
+      {/** Connect label to CircleSubject */}
+      <AnnotationConnector />
+    </AnimatedAnnotation>
+  </XYChart>
+)
+
+```
 
 </details>
 
@@ -201,8 +239,7 @@ individual points, or x- or y-thresholds.
 ## Advanced usage
 
 <details>
-
-<summary>Examples</summary>
+  <summary>Examples</summary>
 
 `XYChart` is implemented using modularized `React.context` layers for scales, canvas dimensions,
 data, events, and tooltips which enables more advanced usage than many other chart-level
@@ -212,15 +249,14 @@ By default `XYChart` renders all context providers if a given context is not ava
 share context across multiple `XYChart`s to implement functionality such as linked tooltips, shared
 themes, or shared data.
 
-- TODO - Custom chart background using theme and chart dimensions
-- TODO - Linked tooltips
-- TODO - Programmatically control tooltips
+- 🔜 Custom chart background using theme and chart dimensions
+- 🔜 Linked tooltips
+- 🔜 Programmatically control tooltips
 
 </details>
 
 <details>
-
-<summary>DataContext</summary>
+  <summary>DataContext</summary>
 
 This context provides chart canvas dimensions (`width`, `height`, and `margin`), x/y/color scales,
 and a data registry. The data registry includes data from all child `*Series`, and x/y/color scales
@@ -229,16 +265,15 @@ are updated accordingly accounting for canvas dimensions.
 </details>
 
 <details>
+  <summary>ThemeContext</summary>
 
-<summary>ThemeContext</summary>
-
-This context provides an `XYChart` theme.
+This context provides an `XYChart` theme, its used by all visual elements that compose a chart, and
+can be used to render custom visual elements that are on theme.
 
 </details>
 
 <details>
-
-<summary>EventEmitterContext</summary>
+  <summary>EventEmitterContext</summary>
 
 This context provides an event publishing / subscription object which can be used via the
 `useEventEmitter` hook. `Series` and `XYChart` events, including tooltip updates, are emitted and

--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -1,5 +1,9 @@
 # @visx/xychart
 
+<a title="@visx/xychart npm downloads" href="https://www.npmjs.com/package/@visx/xychart">
+  <img src="https://img.shields.io/npm/dm/@visx/xychart.svg?style=flat-square" />
+</a>
+
 In contrast to other `visx` packages which are low-level, this package seeks to abstract some of the
 complexity of common visualization engineering, and exposes a **high-level** x,y (cartesian
 coordinate) chart API. However, it is implemented using modularized `React.context` layers for
@@ -75,6 +79,15 @@ below.
 <hr />
 
 ## Basic usage
+
+<details>
+  <summary>Installation</summary>
+
+```
+npm install --save @visx/xychart react-spring
+```
+
+Note: `react-spring` is a required `peerDependency` for importing `Animated*` components.
 
 <details>
   <summary>Series types</summary>

--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -1,3 +1,254 @@
 # @visx/xychart
 
-Coming 🔜
+In contrast to other `visx` packages which are low-level, this package seeks to abstract some of the
+complexity of common visualization engineering, and exposes a **high-level** x,y (cartesian
+coordinate) chart API. However, it is implemented using modularized `React.context` layers for
+theme, canvas dimensions, x/y/color scales, data, events, and tooltips which allows for more
+expressivity and advanced use cases.
+
+Out of the box it supports the following:
+
+- many common `<*Series />` types (animated or not) such as lines, bars, etc. (can be easily
+  extended to support more in the future)
+- `<Axis />` (animated or not)
+- `<Grid />` (animated or not)
+- `<Annotation />` (animated or not)
+- `<Tooltip />`
+- `theme`ing
+
+See the comprehensive API below for more details.
+
+<hr />
+
+## Basic usage
+
+The following illustrates basic usage for an animated line chart with a bottom `Axis`, `Grid`, and
+`Tooltip`, try it on codesandbox [here](todo, simplify code below):
+
+```tsx
+import { AnimatedAxis, AnimatedGrid, AnimatedLineSeries, XYChart } from '@visx/xychart';
+
+const data1 = [
+  { x: '2020-01-01', y: 50 },
+  { x: '2020-01-02', y: 10 },
+  { x: '2020-01-03', y: 20 },
+  { x: '2020-01-04', y: 10 },
+  { x: '2020-01-05', y: 0 },
+];
+
+const data2 = [
+  { x: '2020-01-01', y: 30 },
+  { x: '2020-01-02', y: 40 },
+  { x: '2020-01-03', y: 80 },
+  { x: '2020-01-04', y: 70 },
+  { x: '2020-01-05', y: 20 },
+];
+
+const xAccessor = d => d.x;
+const yAccessor = d => d.y;
+
+const render = () => (
+  <XYChart height={300} xScale={{ type: 'band' }} yScale={{ type: 'linear' }}>
+    <AnimatedAxis orientation="bottom" />
+    <AnimatedGrid columns={false} numTicks={4} />
+    <AnimatedLineSeries dataKey="Line 1" data={data1} xAccessor={xAccessor} yAccessor={yAccessor} />
+    <AnimatedLineSeries dataKey="Line 2" data={data2} xAccessor={xAccessor} yAccessor={yAccessor} />
+    <Tooltip
+      snapTooltipToDatumX
+      snapTooltipToDatumY
+      showVerticalCrosshair
+      showSeriesGlyphs
+      renderTooltip={({ tooltipData, colorScale }) => (
+        <div>
+          <div style={{ color: colorScale(tooltipData.nearestDatum.key) }}>
+            {tooltipData.nearestDatum.key || 'No key'}
+          </div>
+          {tooltipData.nearestDatum.datum.x || 'No date'}
+          {', '}
+          {tooltipData.nearestDatum.datum.y || 'No value'}
+        </div>
+      )}
+    />
+  </XYChart>
+);
+```
+
+### Series types
+
+The following `Series` types are currently supported and we are happy to review or consider
+additional Series types in the future.
+
+| Component name        | Description                                                                                      | Usage                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| (Animated)AreaSeries  | Connect data points with a `<path />`, with a color fill to the zero baseline                    | `<AreaSeries />`                                     |
+| (Animated)BarSeries   | Render a `<rect />` for each data point                                                          | `<BarSeries />`                                      |
+| (Animated)BarGroup    | Group multiple child `<BarSeries />` values together                                             | `<BarGroup><BarSeries /><BarSeries />...</BarGroup>` |
+| (Animated)BarStack    | Stack multiple child `<BarSeries />` values together                                             | `<BarStack><BarSeries /><BarSeries />...</BarStack>` |  |
+| (Animated)GlyphSeries | Render a `Glyph` (any shape, defaults to `<circle />`) for each data point, e.g., a scatter plot | `<GlyphSeries renderGlyph={() => ...} />`            |
+| (Animated)LineSeries  | Connect data points with a `<path>`                                                              | `<GlyphSeries />`                                    |
+
+All `Series` have animated and non-animated variants to give you more control over your bundle size,
+support missing (`null`) data, and can be rendered vertically or horizontally.
+
+### Theming
+
+Default `lightTheme` and `darkTheme` themes are exported from `@visx/xychart` and the utility
+`buildChartTheme` is exported to support easy creation of custom themes.
+
+```ts
+import { buildTheme, XYChart } from '@visx/xychart';
+import { TextProps as SVGTextProps } from '@visx/text/lib/Text'; // just for types
+
+const customTheme = buildTheme({
+  // colors
+  backgroundColor: string; // used by Tooltip, Annotation
+  colors: string[]; // categorical colors, mapped to series via `dataKey`s
+
+  // labels
+  svgLabelBig?: SVGTextProps;
+  svgLabelSmall?: SVGTextProps;
+  htmlLabel?: HTMLTextStyles;
+
+  // lines
+  xAxisLineStyles?: LineStyles;
+  yAxisLineStyles?: LineStyles;
+  xTickLineStyles?: LineStyles;
+  yTickLineStyles?: LineStyles;
+  tickLength: number;
+
+  // grid
+  gridColor: string;
+  gridColorDark: string; // used for axis baseline if x/yxAxisLineStyles not set
+  gridStyles?: CSSProperties;
+});
+
+() => <XYChart theme={customTheme} />
+
+```
+
+### Tooltips
+
+`@visx/tooltip` `Tooltip`s are integrated into `@visx/xychart`, and should be rendered as a child of
+`XYChart` (or a child where `TooltipContext` is provided).
+
+**`Tooltip` positioning** is handled by the `Tooltip` itself, based on `TooltipContext`. `Tooltip`
+is rendered inside a `Portal`, avoiding clipping by parent DOM elements with higher z-index
+contexts. See the API below for a full list of `props` to support additional behavior, such as
+snapping to data point positions and rendering cross-hairs.
+
+**`Tooltip` content** is controlled by the specified `prop.renderTooltip` which has access to:
+
+- `tooltipData.nearestDatum` – the globally closest `Datum`, **across all** `Series`'s `dataKey`s
+- `tooltipData.datumByKey` – the closest `Datum` **for each** `Series`'s `dataKey`; this enables
+  "shared tooltips" where you can render the nearest data point for each `Series`.
+- a shared `colorScale` which maps `Series`'s `dataKey`s to `theme` colors
+
+### Event handlers
+
+The following `PointerEvent`s (handling both `MouseEvent`s and `TouchEvent`s) are currently
+supported. They may be set on individual `Series` components (e.g.,
+`<BarSeries onPointerMove={() => ...} />`), or at the chart level (e.g.,
+`<XYChart onPointerMove={() => {}} />`) in which case they are invoked once for _every_ `*Series`.
+To **disable** event emitting for any `Series` set `<*Series enableEvents=false />`.
+
+Below, `HandlerParms` has the following type signature:
+
+```ts
+type EventHandlerParams<Datum> = {
+  datum: Datum; // nearest Datum to event, for Series with `dataKey=key`
+  distanceX: number; // x distance between event and Datum, in px
+  distanceY;: number; // y distance between event and Datum, in px
+  event: React.PointerEvent | React.FocusEvent; // the event
+  index: number; // index of Datum in Series `data` array
+  key: string; // `dataKey` of Series to which `Datum` belongs
+  svgPoint: { x: number; y: number }; // event position in svg-coordinates
+};
+```
+
+| Prop name       | Signature                                     | `XYChart` support | `*Series` support |
+| --------------- | --------------------------------------------- | ----------------- | ----------------- |
+| `onPointerMove` | `(params: EventHandlerParams<Datum>) => void` | ✅                | ✅                |
+| `onPointerOut`  | `(event: React.PointerEvent) => void`         | ✅                | ✅                |
+| `onPointerUp`   | `(params: EventHandlerParams<Datum>) => void` | ✅                | ✅                |
+| `onFocus`       | `(params: EventHandlerParams<Datum>) => void` | ❌                | ✅                |
+| `onBlur`        | `(event: React.TouchEvent) => void`           | ❌                | ✅                |
+
+### Annotations
+
+`@visx/annotations` annotations are integrated into `@visx/xychart`, and allow you to annotate
+individual points, or x- or y-thresholds
+
+<hr />
+
+## Advanced usage
+
+`XYChart` is implemented using modularized `React.context` layers for scales, canvas dimensions,
+data, events, and tooltips which enables more advanced usage than many other chart-level
+abstractions.
+
+By default `XYChart` renders all context providers if a given context is not available, but you can
+share context across multiple `XYChart`s to implement functionality such as linked tooltips, shared
+themes, or shared data.
+
+**Examples**
+
+- TODO - Custom chart background using theme and chart dimensions
+- TODO - Linked tooltips
+- TODO - Programmatically control tooltips
+
+### DataContext
+
+This context provides chart canvas dimensions (`width`, `height`, and `margin`), x/y/color scales,
+and a data registry. The data registry includes data from all child `*Series`, and x/y/color scales
+are updated accordingly accounting for canvas dimensions.
+
+### ThemeContext
+
+This context provides an `XYChart` theme.
+
+### EventEmitterContext
+
+This context provides an event publishing / subscription object which can be used via the
+`useEventEmitter` hook. `Series` and `XYChart` events, including tooltip updates, are emitted and
+handled with through this context.
+
+```tsx
+import { useEventEmitter, EventEmitterContext } from '@visx/xychart';
+
+const eventSourceId = 'optional-source-id-filter';
+
+() => (
+  <EventEmitterContext>
+    {/** emit events */}
+    {() => {
+      const emit = useEventEmitter();
+      return (
+        <button onPointerUp={event => emit('pointerup', event, eventSourceId)}>emit event</button>
+      );
+    }}
+    {/** subscribe to events */}
+    {() => {
+      const [clickCount, setClickCount] = useState(0);
+      useEventEmitter('pointerUp', () => setClickCount(clickCount + 1), [eventSourceId]);
+
+      return <div>Pressed {clickCount} times</div>;
+    }}
+  </EventEmitterContext>
+);
+```
+
+### TooltipContext
+
+This context provides access to `@visx/tooltip`s `useTooltip` state, including whether the tooltip
+is visible (`tooltipOpen`), tooltlip position (`tooltipLeft`, `tooltipTop`),
+`tooltipData: { nearestDatum, datumByKey }` described above, and functions to update context
+(`hideTooltip`, `showTooltip`, and `updateTooltip`).
+
+## Roadmap 🔜
+
+- new `*Series` types
+  - `StackedAreaSeries`
+  - `BoxPlotSeries`
+  - `ViolinPlotSeries`
+- integrate `@visx/brush`
+- integrate `@visx/zoom` + `@visx/drag` for panning and zooming

--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -16,7 +16,7 @@ Out of the box it supports the following:
 - \* `theme`ing
 
 The following illustrates basic usage to create an animated line chart with a bottom `Axis`, `Grid`,
-and `Tooltip`, try it on codesandbox [here](todo, simplify code below):
+and `Tooltip`:
 
 ```tsx
 import {

--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -161,7 +161,10 @@ The following `PointerEvent`s (handling both `MouseEvent`s and `TouchEvent`s) ar
 supported. They may be set on individual `Series` components (e.g.,
 `<BarSeries onPointerMove={() => ...} />`), or at the chart level (e.g.,
 `<XYChart onPointerMove={() => {}} />`) in which case they are invoked once for _every_ `*Series`.
-To **disable** event emitting for any `Series` set `<*Series enableEvents=false />`.
+To **disable** event emitting for any `Series` set `<*Series enableEvents=false />`. The
+`onFocus/onBlur` handlers enable you to make your chart events and `Tooltip`s accessible via
+keyboard interaction. Note that the current implementation requires your target browser to support
+the `SVG 2.0` spec for `tabIndex` on `SVG` elements.
 
 Below, `HandlerParms` has the following type signature:
 
@@ -315,5 +318,45 @@ is visible (`tooltipOpen`), tooltlip position (`tooltipLeft`, `tooltipTop`),
 (`hideTooltip`, `showTooltip`, and `updateTooltip`).
 
 </details>
+
+<hr />
+
+##### ⚠️ `ResizeObserver` dependency
+
+The `Tooltip` and `AnnotationLabel` components rely on
+[`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)s. If your
+browswer target needs a polyfill, you can either polute the `window` object or inject it cleanly
+using the `resizeObserverPolyfill` prop for these components.
+
+<details>
+  <summary>Examples</summary>
+
+❌ `Error: This browser does not support ResizeObserver out of the box`
+
+```tsx
+// no polyfill, no browser support
+() => <XYChart {...}><Tooltip /></XYChart>
+```
+
+✅ No errors
+
+```tsx
+// no polyfill, target browser supports ResizeObserver
+() => <XYChart {...}><Tooltip /></XYChart>
+
+// import the polyfill in the needed module, or set it on `window` object
+import ResizeObserver from 'resize-observer-polyfill';
+() => <XYChart {...}><Tooltip /></XYChart> // 😎
+
+// cleanly pass polyfill to component that needs it
+import ResizeObserver from 'resize-observer-polyfill';
+() => (
+  <XYChart {...}>
+    <Tooltip resizeObserverPolyfill={ResizeObserver} />
+  </XYChart>
+)
+```
+
+  </details>
 
 <hr />

--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -8,19 +8,12 @@ expressivity and advanced use cases.
 
 Out of the box it supports the following:
 
-- many common `<*Series />` types (animated or not) such as lines, bars, etc. (can be easily
-  extended to support more in the future)
-- `<Axis />` (animated or not)
-- `<Grid />` (animated or not)
-- `<Annotation />` (animated or not)
-- `<Tooltip />`
-- `theme`ing
-
-See the comprehensive API below for more details.
-
-<hr />
-
-## Basic usage
+- \* many common `<*Series />` types (animated or not) such as lines, bars, etc.
+- \* `<Axis />` (animated or not)
+- \* `<Grid />` (animated or not)
+- \* `<Annotation />` (animated or not)
+- \* `<Tooltip />`
+- \* `theme`ing
 
 The following illustrates basic usage for an animated line chart with a bottom `Axis`, `Grid`, and
 `Tooltip`, try it on codesandbox [here](todo, simplify code below):
@@ -73,7 +66,15 @@ const render = () => (
 );
 ```
 
-### Series types
+Expand sections for more, or explore the detailed API below.
+
+<hr />
+
+## Basic usage
+
+<details>
+
+<summary>Series types</summary>
 
 The following `Series` types are currently supported and we are happy to review or consider
 additional Series types in the future.
@@ -90,7 +91,11 @@ additional Series types in the future.
 All `Series` have animated and non-animated variants to give you more control over your bundle size,
 support missing (`null`) data, and can be rendered vertically or horizontally.
 
-### Theming
+</details>
+
+<details>
+
+<summary>Theming</summary>
 
 Default `lightTheme` and `darkTheme` themes are exported from `@visx/xychart` and the utility
 `buildChartTheme` is exported to support easy creation of custom themes.
@@ -123,10 +128,13 @@ const customTheme = buildTheme({
 });
 
 () => <XYChart theme={customTheme} />
-
 ```
 
-### Tooltips
+</details>
+
+<details>
+
+<summary>Tooltips</summary>
 
 `@visx/tooltip` `Tooltip`s are integrated into `@visx/xychart`, and should be rendered as a child of
 `XYChart` (or a child where `TooltipContext` is provided).
@@ -143,7 +151,11 @@ snapping to data point positions and rendering cross-hairs.
   "shared tooltips" where you can render the nearest data point for each `Series`.
 - a shared `colorScale` which maps `Series`'s `dataKey`s to `theme` colors
 
-### Event handlers
+</details>
+
+<details>
+
+<summary>Event handlers</summary>
 
 The following `PointerEvent`s (handling both `MouseEvent`s and `TouchEvent`s) are currently
 supported. They may be set on individual `Series` components (e.g.,
@@ -173,14 +185,24 @@ type EventHandlerParams<Datum> = {
 | `onFocus`       | `(params: EventHandlerParams<Datum>) => void` | ❌                | ✅                |
 | `onBlur`        | `(event: React.TouchEvent) => void`           | ❌                | ✅                |
 
-### Annotations
+</details>
+
+<details>
+
+<summary>Annotations</summary>
 
 `@visx/annotations` annotations are integrated into `@visx/xychart`, and allow you to annotate
-individual points, or x- or y-thresholds
+individual points, or x- or y-thresholds.
+
+</details>
 
 <hr />
 
 ## Advanced usage
+
+<details>
+
+<summary>Examples</summary>
 
 `XYChart` is implemented using modularized `React.context` layers for scales, canvas dimensions,
 data, events, and tooltips which enables more advanced usage than many other chart-level
@@ -190,23 +212,33 @@ By default `XYChart` renders all context providers if a given context is not ava
 share context across multiple `XYChart`s to implement functionality such as linked tooltips, shared
 themes, or shared data.
 
-**Examples**
-
 - TODO - Custom chart background using theme and chart dimensions
 - TODO - Linked tooltips
 - TODO - Programmatically control tooltips
 
-### DataContext
+</details>
+
+<details>
+
+<summary>DataContext</summary>
 
 This context provides chart canvas dimensions (`width`, `height`, and `margin`), x/y/color scales,
 and a data registry. The data registry includes data from all child `*Series`, and x/y/color scales
 are updated accordingly accounting for canvas dimensions.
 
-### ThemeContext
+</details>
+
+<details>
+
+<summary>ThemeContext</summary>
 
 This context provides an `XYChart` theme.
 
-### EventEmitterContext
+</details>
+
+<details>
+
+<summary>EventEmitterContext</summary>
 
 This context provides an event publishing / subscription object which can be used via the
 `useEventEmitter` hook. `Series` and `XYChart` events, including tooltip updates, are emitted and
@@ -237,18 +269,16 @@ const eventSourceId = 'optional-source-id-filter';
 );
 ```
 
-### TooltipContext
+</details>
+
+<details>
+  <summary>TooltipContext</summary>
 
 This context provides access to `@visx/tooltip`s `useTooltip` state, including whether the tooltip
 is visible (`tooltipOpen`), tooltlip position (`tooltipLeft`, `tooltipTop`),
 `tooltipData: { nearestDatum, datumByKey }` described above, and functions to update context
 (`hideTooltip`, `showTooltip`, and `updateTooltip`).
 
-## Roadmap 🔜
+</details>
 
-- new `*Series` types
-  - `StackedAreaSeries`
-  - `BoxPlotSeries`
-  - `ViolinPlotSeries`
-- integrate `@visx/brush`
-- integrate `@visx/zoom` + `@visx/drag` for panning and zooming
+<hr />

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.3.0-0",
+    "react": "^16.4.0-0",
     "react-spring": "^8.0.27"
   },
   "dependencies": {


### PR DESCRIPTION
#### :memo: Documentation

This PR
- fleshes out the `README` for `@visx/xychart` to cover most aspects of the API, including some example code snippets
  - note I've added `<details />` sections so that the rest of the `/docs/xychart` page with example tile(s) + comprehensive API will be visible without needed to scroll a lot
- adds a `/docs/xychart` page to the demo site, and the `XYChartTile` to the gallery 🎉 

I plan to add a couple more examples but non-gallery codesandboxes will be easier to create when the package is published

![image](https://user-images.githubusercontent.com/4496521/101686149-841eb680-3a1d-11eb-8fa8-70056cbe6c5b.png)

![image](https://user-images.githubusercontent.com/4496521/101686010-520d5480-3a1d-11eb-9308-8d71b1a2590e.png)


@kristw @hshoff 
