### PR TITLE
internal(xychart): make package public

### DIFF
--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -3,7 +3,6 @@
   "version": "1.2.0",
   "description": "Composable cartesian coordinate chart built with visx primitives",
   "sideEffects": false,
-  "private": true,
   "main": "lib/index.js",
   "module": "esm/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Closes #884

#### :house: Internal

This updates the `@visx/xychart` config to make it a non-private package, to support publishing for `1.3.0` 🎉   

Note I did publish a pre-release version of this for testing and it was [successful](https://unpkg.com/browse/@visx/xychart@1.3.0-alpha.0/lib/index.js).

![image](https://user-images.githubusercontent.com/4496521/101692835-a288b000-3a25-11eb-9acf-572d3afba54b.png)


@kristw @hshoff 