### PR TITLE
Switch @visx/annotation to use React Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "@airbnb/config-prettier": "^2.0.4",
     "@airbnb/config-typescript": "^2.1.2",
     "@airbnb/nimbus": "^2.1.3",
+    "@testing-library/jest-dom": "^5.11.6",
+    "@testing-library/react": "^11.2.2",
     "@types/enzyme": "^3.10.3",
     "@types/jest": "^24.0.18",
     "@types/jsdom": "^12.2.4",
@@ -97,7 +99,12 @@
     },
     "babel": {
       "plugins": [
-        ["@babel/plugin-proposal-private-methods", { "loose": false }]
+        [
+          "@babel/plugin-proposal-private-methods",
+          {
+            "loose": false
+          }
+        ]
       ]
     },
     "typescript": {
@@ -118,9 +125,9 @@
         "!packages/visx-demo/**",
         "!packages/visx-visx/**"
       ],
-      "testPathIgnorePatterns" : [
+      "testPathIgnorePatterns": [
         "<rootDir>/packages/visx-demo",
-        "<rootDir>/packages/visx-visx" 
+        "<rootDir>/packages/visx-visx"
       ],
       "coverageThreshold": {
         "global": {
@@ -131,7 +138,8 @@
         }
       },
       "setupFilesAfterEnv": [
-        "@airbnb/config-jest/enzyme"
+        "@airbnb/config-jest/enzyme",
+        "./setupTests.js"
       ]
     },
     "eslint": {

--- a/packages/visx-annotation/test/Annotation.test.tsx
+++ b/packages/visx-annotation/test/Annotation.test.tsx
@@ -1,25 +1,33 @@
-import { mount } from 'enzyme';
-import React, { useContext } from 'react';
-import { Annotation } from '../src';
-import AnnotationContext from '../src/context/AnnotationContext';
+import React, { useContext } from "react";
+import { Annotation } from "../src";
+import AnnotationContext from "../src/context/AnnotationContext";
+import { render, screen } from "@testing-library/react";
 
-describe('<Annotation />', () => {
-  it('should be defined', () => {
-    expect(Annotation).toBeDefined();
-  });
-  it('should provide AnnotationContext', () => {
-    expect.assertions(1);
-    const annotation = { x: -50, y: 100, dx: 1000, dy: 7 };
+describe("<Annotation /> RTL", () => {
+  it("should provide AnnotationContext", () => {
     function AnnotationChild() {
-      const annotationContext = useContext(AnnotationContext);
-      expect(annotationContext).toEqual(annotation);
-      return null;
+      const { x, y, dx, dy } = useContext(AnnotationContext);
+      return (
+        <>
+          <p data-testid="x">{x}</p>
+          <p data-testid="y">{y}</p>
+          <p data-testid="dx">{dx}</p>
+          <p data-testid="dy">{dy}</p>
+        </>
+      );
     }
 
-    mount(
+    const annotation = { x: -50, y: 100, dx: 1000, dy: 7 };
+
+    render(
       <Annotation {...annotation}>
         <AnnotationChild />
-      </Annotation>,
+      </Annotation>
     );
+
+    expect(screen.getByTestId("x")).toHaveTextContent(`${annotation.x}`);
+    expect(screen.getByTestId("y")).toHaveTextContent(`${annotation.y}`);
+    expect(screen.getByTestId("dx")).toHaveTextContent(`${annotation.dx}`);
+    expect(screen.getByTestId("dy")).toHaveTextContent(`${annotation.dy}`);
   });
 });

--- a/packages/visx-annotation/test/CircleSubject.test.tsx
+++ b/packages/visx-annotation/test/CircleSubject.test.tsx
@@ -1,12 +1,45 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { CircleSubject } from '../src';
+import React from "react";
+import { AnnotationContext, CircleSubject } from "../src";
+import { render } from "@testing-library/react";
 
-describe('<CircleSubject />', () => {
-  it('should be defined', () => {
-    expect(CircleSubject).toBeDefined();
+describe("<CircleSubject />", () => {
+  const wrapper: React.FunctionComponent = ({ children }) => (
+    <svg>{children}</svg>
+  );
+  it("should render a cirlce", () => {
+    render(<CircleSubject />, { wrapper });
+
+    expect(document.querySelector("circle")).toBeVisible();
   });
-  it('should render a cirlce', () => {
-    expect(shallow(<CircleSubject />).find('circle')).toHaveLength(1);
+  it("should have default attributes", () => {
+    const context = { x: -50, y: 100, dx: 1000, dy: 7 };
+    render(
+      <AnnotationContext.Provider value={context}>
+        <CircleSubject />
+      </AnnotationContext.Provider>,
+      { wrapper }
+    );
+
+    const circle = document.querySelector("circle");
+    expect(circle).toHaveAttribute("cx", `${context.x}`);
+    expect(circle).toHaveAttribute("cy", `${context.y}`);
+    expect(circle).toHaveAttribute("r", "16");
+    expect(circle).toHaveAttribute("stroke", "#222");
+  });
+  it("should override default attributes with props", () => {
+    const context = { x: -50, y: 100, dx: 1000, dy: 7 };
+    const props = { x: 1, y: 2, stroke: "#123", radius: 3 };
+    render(
+      <AnnotationContext.Provider value={context}>
+        <CircleSubject {...props} />
+      </AnnotationContext.Provider>,
+      { wrapper }
+    );
+
+    const circle = document.querySelector("circle");
+    expect(circle).toHaveAttribute("cx", `${props.x}`);
+    expect(circle).toHaveAttribute("cy", `${props.y}`);
+    expect(circle).toHaveAttribute("r", `${props.radius}`);
+    expect(circle).toHaveAttribute("stroke", `${props.stroke}`);
   });
 });

--- a/packages/visx-annotation/test/Connector.test.tsx
+++ b/packages/visx-annotation/test/Connector.test.tsx
@@ -1,12 +1,53 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { Connector } from '../src';
+import React from "react";
+import { AnnotationContext, Connector } from "../src";
+import { render } from "@testing-library/react";
 
-describe('<Connector />', () => {
-  it('should be defined', () => {
-    expect(Connector).toBeDefined();
+describe("<Connector />", () => {
+  const wrapper: React.FunctionComponent = ({ children }) => (
+    <svg>{children}</svg>
+  );
+  it("should render a path", () => {
+    render(<Connector />, { wrapper });
+
+    expect(document.querySelector("path")).toBeVisible();
   });
-  it('should render a path', () => {
-    expect(shallow(<Connector />).find('path')).toHaveLength(1);
+  it("should have default attributes", () => {
+    render(<Connector />, { wrapper });
+    const path = document.querySelector("path");
+
+    expect(path).toHaveAttribute("d", "M0,0L0,0L0,0");
+    expect(path).toHaveAttribute("stroke", "#222");
+  });
+  it("should use the context for attributes", () => {
+    const context = { x: -50, y: 100, dx: 1000, dy: 7 };
+    render(
+      <AnnotationContext.Provider value={context}>
+        <Connector />
+      </AnnotationContext.Provider>,
+      { wrapper }
+    );
+    const path = document.querySelector("path");
+
+    expect(path).toHaveAttribute("d", "M-50,100L-43,107L950,107");
+    expect(path).toHaveAttribute("stroke", "#222");
+  });
+  it("should use props for attributes", () => {
+    const context = { x: -50, y: 100, dx: 1000, dy: 7 };
+    render(
+      <AnnotationContext.Provider value={context}>
+        <Connector {...{ x: 1, y: 2, dx: 3, dy: 4, stroke: '#123' }} />
+      </AnnotationContext.Provider>,
+      { wrapper }
+    );
+    const path = document.querySelector("path");
+
+    expect(path).toHaveAttribute("d", "M1,2L4,5L4,6");
+    expect(path).toHaveAttribute("stroke", "#123");
+  });
+  it("should not have the middle lineTo when type is line", () => {
+    render(<Connector type="line" />, { wrapper });
+    const path = document.querySelector("path");
+
+    expect(path).toHaveAttribute("d", "M0,0L0,0");
   });
 });

--- a/packages/visx-annotation/test/EditableAnnotation.test.tsx
+++ b/packages/visx-annotation/test/EditableAnnotation.test.tsx
@@ -1,27 +1,35 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { Annotation, EditableAnnotation } from '../src';
-import { EditableAnnotationProps } from '../lib/components/EditableAnnotation';
+import React, { ReactNode } from "react";
+import { EditableAnnotation } from "../src";
+import { EditableAnnotationProps } from "../lib/components/EditableAnnotation";
+import { render, screen } from "@testing-library/react";
 
-describe('<EditableAnnotation />', () => {
-  function setup(props?: Partial<EditableAnnotationProps>) {
-    return shallow(
-      <EditableAnnotation width={100} height={100} {...props}>
-        <div />
-      </EditableAnnotation>,
+describe("<EditableAnnotation />", () => {
+  function setup(
+    props?: Partial<EditableAnnotationProps> & { children?: ReactNode }
+  ) {
+    return (
+      <svg>
+        <EditableAnnotation width={100} height={100} {...props}>
+          {props?.children ?? <div />}
+        </EditableAnnotation>
+      </svg>
     );
   }
-  it('should be defined', () => {
-    expect(EditableAnnotation).toBeDefined();
+
+  it("should render two resize handles", () => {
+    render(setup());
+    expect(document.querySelectorAll("circle")).toHaveLength(2);
   });
-  it('should render two resize handles', () => {
-    expect(setup().find('circle')).toHaveLength(2);
+  it("should render one resize handle if canEditLabel is false", () => {
+    render(setup({ canEditLabel: false }));
+    expect(document.querySelector("circle")).toBeVisible();
   });
-  it('should render one resize handle if canEditLabel or canEditSubject are false', () => {
-    expect(setup({ canEditLabel: false }).find('circle')).toHaveLength(1);
-    expect(setup({ canEditSubject: false }).find('circle')).toHaveLength(1);
+  it("should render one resize handle if canEditSubject is false", () => {
+    render(setup({ canEditSubject: false }));
+    expect(document.querySelector("circle")).toBeVisible();
   });
-  it('should render an Annotation', () => {
-    expect(setup().find(Annotation)).toHaveLength(1);
+  it("should render an Annotation", () => {
+    render(setup({ children: "test" }));
+    expect(screen.getByText(/test/i)).toBeVisible();
   });
 });

--- a/packages/visx-annotation/test/Label.test.tsx
+++ b/packages/visx-annotation/test/Label.test.tsx
@@ -1,48 +1,49 @@
-import React from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
-import Text from '@visx/text/lib/Text';
-import { shallow } from 'enzyme';
-import { Label } from '../src';
+import React from "react";
+import ResizeObserver from "resize-observer-polyfill";
+import { Label } from "../src";
+import { render, screen } from "@testing-library/react";
 
-describe('<Label />', () => {
-  it('should be defined', () => {
-    expect(Label).toBeDefined();
+describe("<Label />", () => {
+  const wrapper: React.FunctionComponent = ({ children }) => (
+    <svg>{children}</svg>
+  );
+  it("should render title Text", () => {
+    render(
+      <Label title="title test" resizeObserverPolyfill={ResizeObserver} />,
+      { wrapper }
+    );
+    expect(screen.getByText("title test")).toBeVisible();
   });
-  it('should render title Text', () => {
-    expect(
-      shallow(<Label title="title test" resizeObserverPolyfill={ResizeObserver} />)
-        .children()
-        .find(Text)
-        .prop('children'),
-    ).toBe('title test');
+  it("should render subtitle Text", () => {
+    render(
+      <Label
+        subtitle="subtitle test"
+        resizeObserverPolyfill={ResizeObserver}
+      />,
+      { wrapper }
+    );
+    expect(screen.getByText("subtitle test")).toBeVisible();
   });
-  it('should render subtitle Text', () => {
-    expect(
-      shallow(
-        <Label
-          title="title test"
-          subtitle="subtitle test"
-          resizeObserverPolyfill={ResizeObserver}
-        />,
-      )
-        .children()
-        .find(Text)
-        .at(1)
-        .prop('children'),
-    ).toBe('subtitle test');
+  it("should render a background", () => {
+    render(
+      <Label
+        title="test"
+        showBackground
+        resizeObserverPolyfill={ResizeObserver}
+      />,
+      { wrapper }
+    );
+    expect(document.querySelector("rect")).toBeVisible();
   });
-  it('should render a background', () => {
-    expect(
-      shallow(
-        <Label title="title test" showBackground resizeObserverPolyfill={ResizeObserver} />,
-      ).find('rect'),
-    ).toHaveLength(1);
-  });
-  it('should render an anchor line', () => {
-    expect(
-      shallow(
-        <Label title="title test" showAnchorLine resizeObserverPolyfill={ResizeObserver} />,
-      ).find('line'),
-    ).toHaveLength(1);
+  it("should render an anchor line", () => {
+    render(
+      <Label
+        title="test"
+        showAnchorLine
+        resizeObserverPolyfill={ResizeObserver}
+      />,
+      { wrapper }
+    );
+    expect(document.querySelector("line")).toBeVisible();
   });
 });

--- a/packages/visx-annotation/test/LineSubject.test.tsx
+++ b/packages/visx-annotation/test/LineSubject.test.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { LineSubject } from '../src';
+import React from "react";
+import { LineSubject } from "../src";
+import { render } from "@testing-library/react";
 
-describe('<LineSubject />', () => {
-  it('should be defined', () => {
-    expect(LineSubject).toBeDefined();
-  });
-  it('should render a line', () => {
-    expect(shallow(<LineSubject min={0} max={100} />).find('line')).toHaveLength(1);
+describe("<LineSubject />", () => {
+  const wrapper: React.FunctionComponent = ({ children }) => (
+    <svg>{children}</svg>
+  );
+  it("should render a line", () => {
+    render(<LineSubject min={0} max={100} />, { wrapper });
+    expect(document.querySelector("line")).toBeVisible();
   });
 });

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,6 +1901,14 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-transform-typescript" "^7.10.1"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz#ffee91da0eb4c6dae080774e94ba606368e414f4"
+  integrity sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.8.3":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz#3511797ddf9a3d6f3ce46b99cc835184817eaa4e"
@@ -1913,6 +1921,13 @@
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2454,6 +2469,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@lerna/add@3.21.0":
   version "3.21.0"
@@ -3328,10 +3354,59 @@
   dependencies:
     type-detect "4.0.8"
 
+"@testing-library/dom@^7.28.1":
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.28.1.tgz#dea78be6e1e6db32ddcb29a449e94d9700c79eb9"
+  integrity sha512-acv3l6kDwZkQif/YqJjstT3ks5aaI33uxGNVIQmdKzbZ2eMKgg3EV2tB84GDdc72k3Kjhl6mO8yUt6StVIdRDg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/jest-dom@^5.11.6":
+  version "5.11.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
+  integrity sha512-cVZyUNRWwUKI0++yepYpYX7uhrP398I+tGz4zOlLVlUYnZS+Svuxv4fwLeCIy7TnBYKXUaOlQr3vopxL8ZfEnA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react-hooks@^3.4.2":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.7.0.tgz#6d75c5255ef49bce39b6465bf6b49e2dac84919e"
+  integrity sha512-TwfbY6BWtWIHitjT05sbllyLIProcysC0dF0q1bbDa7OHLC6A6rJOYJwZ13hzfz3O4RtOuInmprBozJRyyo7/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
+"@testing-library/react@^11.2.2":
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.2.tgz#099c6c195140ff069211143cb31c0f8337bdb7b7"
+  integrity sha512-jaxm0hwUjv+hzC+UFEywic7buDC9JQ1q3cDsrWVSDAPmLotfA6E6kUHlYm/zOeGCac6g48DR36tFHxl7Zb+N5A==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.7":
   version "7.1.8"
@@ -3535,6 +3610,21 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "26.0.18"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.18.tgz#3c5f9228e9ac15bd42f903f1acf2ad6ea5ed73d9"
+  integrity sha512-scDPs+mELZgsFetTgBSsIxKGrlitn9t/d2ecP+S1QSIGD+31fkMBEftLfOAX5k3tU06/0PjreJIQ+gWEbbHqpw==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/jest@^24.0.18":
   version "24.9.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
@@ -3630,6 +3720,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
+  integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@^16.9.0":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
@@ -3659,6 +3756,20 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/topojson-client@^3.0.0":
   version "3.0.0"
@@ -3769,19 +3880,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@visx/text@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@visx/text/-/text-1.0.0.tgz#1a14f2ad4c63d0c8ee14da15f09ce32bb496046a"
-  integrity sha512-5PCKVmYH6z8++SQpARokJtd9zu/XVi2NxTmNwg18IXtiWBo468Jt2wVUmvvDUHF80Aig+Z1VmmVAMKw5jVYyTg==
-  dependencies:
-    "@types/classnames" "^2.2.9"
-    "@types/lodash" "^4.14.160"
-    "@types/react" "*"
-    classnames "^2.2.5"
-    lodash "^4.17.20"
-    prop-types "^15.7.2"
-    reduce-css-calc "^1.3.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4268,6 +4366,14 @@ aria-query@^3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -5109,6 +5215,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-case@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
@@ -5805,7 +5919,7 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css.escape@^1.5.0:
+css.escape@^1.5.0, css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
@@ -5819,6 +5933,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -6277,6 +6400,11 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -6319,6 +6447,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
@@ -8844,6 +8977,16 @@ jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-docblock@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
@@ -8895,6 +9038,11 @@ jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-haste-map@^25.5.1:
   version "25.5.1"
@@ -9665,6 +9813,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -11387,6 +11540,16 @@ pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-ms@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-5.1.0.tgz#b906bdd1ec9e9799995c372e2b1c34f073f95384"
@@ -11691,6 +11854,11 @@ react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-i
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-markdown@^4.3.1:
   version "4.3.1"
@@ -12689,6 +12857,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"


### PR DESCRIPTION
This PR is a start to addressing #918 

I purposefully did not work on `LinePathAnnotation` because it is deprecated.

#### :boom: Breaking Changes

- none

#### :rocket: Enhancements

- none

#### :memo: Documentation

- none

#### :bug: Bug Fix

- none

#### :house: Internal

- use React Testing Library instead of Enzyme
