### PR TITLE
docs(xychart): Add missing import in example (#975)

### DIFF
--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -28,6 +28,7 @@ import {
   AnimatedGrid,
   AnimatedLineSeries,
   XYChart,
+  Tooltip,
 } from '@visx/xychart';
 
 const data1 = [


### PR DESCRIPTION
#### :memo: Documentation

Fixed missing import in example xychart code.

Closes #975 