### PR TITLE
Add XYChart to @visx/visx

### DIFF
--- a/packages/visx-visx/package.json
+++ b/packages/visx-visx/package.json
@@ -60,6 +60,7 @@
     "@visx/text": "1.3.0",
     "@visx/tooltip": "1.3.0",
     "@visx/voronoi": "1.0.0",
+    "@visx/xychart": "1.3.0",
     "@visx/zoom": "1.3.0"
   }
 }

--- a/packages/visx-visx/src/index.ts
+++ b/packages/visx-visx/src/index.ts
@@ -25,4 +25,5 @@ export * from '@visx/shape';
 export * from '@visx/text';
 export * from '@visx/tooltip';
 export * from '@visx/voronoi';
+export * from '@visx/xychart';
 export * from '@visx/zoom';

--- a/packages/visx-visx/test/index.test.ts
+++ b/packages/visx-visx/test/index.test.ts
@@ -110,6 +110,10 @@ describe('visx', () => {
     expect(visx.voronoi).toBeDefined();
   });
 
+  test('it should export @visx/xychart', () => {
+    expect(visx.XYChart).toBeDefined();
+  });
+
   test('it should export @visx/zoom', () => {
     expect(visx.Zoom).toBeDefined();
   });


### PR DESCRIPTION
This PR relates to https://github.com/airbnb/visx/issues/974 to ensure XYChart is in the package that includes all other packages.

#### :boom: Breaking Changes
- none

#### :rocket: Enhancements
- Adds XYChart to the @visx/visx package.

#### :memo: Documentation
- none

#### :bug: Bug Fix
- none

#### :house: Internal
- none