### PR TITLE
Fix scale options in xychart

### DIFF
--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -31,7 +31,6 @@ export default function useScales<
   const memoizedXScale = useMemo(() => {
     const registryEntries = registryKeys.map(key => dataRegistry.get(key));
 
-    let xScale = createScale(xScaleConfig) as XScale;
     type XScaleInput = ScaleInput<XScale>;
 
     const xValues = registryEntries.reduce<XScaleInput[]>(
@@ -42,8 +41,11 @@ export default function useScales<
 
     const xDomain = isDiscreteScale(xScaleConfig) ? xValues : d3Extent(xValues);
 
-    xScale.range(xScaleConfig.range || [xMin, xMax]);
-    xScale.domain(xScaleConfig.domain || xDomain);
+    let xScale = createScale({
+      range: [xMin, xMax],
+      domain: xDomain as [number, number],
+      ...xScaleConfig,
+    }) as XScale;
 
     // apply any scale updates from the registy
     registryEntries.forEach(entry => {
@@ -57,7 +59,6 @@ export default function useScales<
   const memoizedYScale = useMemo(() => {
     const registryEntries = registryKeys.map(key => dataRegistry.get(key));
 
-    let yScale = createScale(yScaleConfig) as YScale;
     type YScaleInput = ScaleInput<YScale>;
 
     const yValues = registryEntries.reduce<YScaleInput[]>(
@@ -68,8 +69,11 @@ export default function useScales<
 
     const yDomain = isDiscreteScale(yScaleConfig) ? yValues : d3Extent(yValues);
 
-    yScale.range(yScaleConfig.range || [yMin, yMax]);
-    yScale.domain(yScaleConfig.domain || yDomain);
+    let yScale = createScale({
+      range: [yMin, yMax],
+      domain: yDomain as [number, number],
+      ...yScaleConfig,
+    }) as YScale;
 
     // apply any scale updates from the registy
     registryEntries.forEach(entry => {


### PR DESCRIPTION
#### :bug: Bug Fix

Fixes scale options  not applying in `XYChart`. See https://github.com/airbnb/visx/issues/986

`zero`, `nice`,... options are applied in `createScale`. they were overwritten by setting the `domain` and `range` afterwards. this PR makes sure the `domain` and `range` are set in the `createScale` call directly so that other options are applied in the correct order.