### PR TITLE
fix(annotation/Label): fix doc types and padding

### DIFF
--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -61,11 +61,11 @@ function getCompletePadding(padding: LabelProps['backgroundPadding']) {
   if (typeof padding === 'number') {
     return { top: padding, right: padding, bottom: padding, left: padding };
   }
-  return { ...DEFAULT_PADDING, padding };
+  return { ...DEFAULT_PADDING, ...padding };
 }
 
-export default function AnnotationLabel({
-  anchorLineStroke,
+export default function Label({
+  anchorLineStroke = '#222',
   backgroundFill = '#eaeaea',
   backgroundPadding,
   backgroundProps,

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -1,5 +1,5 @@
 /* eslint jsx-a11y/label-has-associated-control: 'off', @typescript-eslint/no-explicit-any: 'off' */
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import appleStock, { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
 import { PickD3Scale, scaleTime, scaleLinear } from '@visx/scale';
 import { extent } from 'd3-array';
@@ -86,6 +86,14 @@ export default function ExampleControls({
     dx: compact ? -50 : -100,
     dy: compact ? -30 : -50,
   });
+  // update annotation position when scale's change
+  useEffect(() => {
+    setAnnotationPosition(currPosition => ({
+      ...currPosition,
+      x: xScale(getDate(annotateDatum)) ?? 0,
+      y: yScale(getStockValue(annotateDatum)) ?? 0,
+    }));
+  }, [xScale, yScale]);
 
   return (
     <>


### PR DESCRIPTION
#### :memo: Documentation
#### :bug: Bug Fix

This fixes a couple of small issues with `Label` from `@visx/annotation`:
- the prop types for `Label` were not correctly generated in `docs/annotation` because the exported component name did not match the file name (this is a limitation of the TS doc type generation, should turn on the lint rule for this)
- `Label`'s `props.backgroundPadding` can be of shape `number | { top?: number, right: ..., bottom: ..., left: ... }`. the logic for the `object` shape was currently broken / this fixes it.
- there was no default for `anchorLineStroke`, so if you set `showAnchorLine={true}` it wasn't visible by default. should have a default so users aren't confused!
- Previously the `/annotation` demo didn't update the annotation position on screen size changes. This results in a broken example in codesandbox when it initially renders with 0 width/height or if the dimensions changed. Added a fix.

Here's the verified doc fix:
<img width="500" src="https://user-images.githubusercontent.com/4496521/103599796-d4712300-4eba-11eb-8248-075d63215778.png" />

Before/after in code sandbox:
<img width="500" src="https://user-images.githubusercontent.com/4496521/103813577-2d54ce80-5015-11eb-9ac2-820187ea31e8.png" />
<img width="500" src="https://user-images.githubusercontent.com/4496521/103813523-144c1d80-5015-11eb-82db-a52be6d55117.png" />


@hshoff 