### PR TITLE
[annotation] Fix LineSubject types and strokeWidth

### DIFF
--- a/packages/visx-annotation/src/components/LineSubject.tsx
+++ b/packages/visx-annotation/src/components/LineSubject.tsx
@@ -29,7 +29,6 @@ export default function LineSubject({
   min,
   max,
   stroke = '#222',
-  strokeWidth = 2,
   ...restProps
 }: LineSubjectProps & Omit<React.SVGProps<SVGLineElement>, keyof LineSubjectProps>) {
   // if props are provided, they take precedence over context

--- a/packages/visx-annotation/src/components/LineSubject.tsx
+++ b/packages/visx-annotation/src/components/LineSubject.tsx
@@ -19,7 +19,7 @@ export interface LineSubjectProps extends React.SVGProps<SVGLineElement> {
   min: number;
   /** The maximum coordinate of the line. */
   max: number;
-};
+}
 
 export default function LineSubject({
   className,

--- a/packages/visx-annotation/src/components/LineSubject.tsx
+++ b/packages/visx-annotation/src/components/LineSubject.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import cx from 'classnames';
 import AnnotationContext from '../context/AnnotationContext';
 
-export interface LineSubjectProps extends React.SVGProps<SVGLineElement> {
+export type LineSubjectProps = {
   /** Optional className to apply to LineSubject in addition to 'visx-annotation-subject'. */
   className?: string;
   /** Color of LineSubject. */
@@ -19,7 +19,7 @@ export interface LineSubjectProps extends React.SVGProps<SVGLineElement> {
   min: number;
   /** The maximum coordinate of the line. */
   max: number;
-}
+};
 
 export default function LineSubject({
   className,
@@ -29,8 +29,9 @@ export default function LineSubject({
   min,
   max,
   stroke = '#222',
+  strokeWidth = 2,
   ...restProps
-}: LineSubjectProps) {
+}: LineSubjectProps & Omit<React.SVGProps<SVGLineElement>, keyof LineSubjectProps>) {
   // if props are provided, they take precedence over context
   const annotationContext = useContext(AnnotationContext);
   const lineIsVertical = orientation === 'vertical';

--- a/packages/visx-annotation/src/components/LineSubject.tsx
+++ b/packages/visx-annotation/src/components/LineSubject.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import cx from 'classnames';
 import AnnotationContext from '../context/AnnotationContext';
 
-export type LineSubjectProps = {
+export interface LineSubjectProps extends React.SVGProps<SVGLineElement> {
   /** Optional className to apply to LineSubject in addition to 'visx-annotation-subject'. */
   className?: string;
   /** Color of LineSubject. */
@@ -29,9 +29,8 @@ export default function LineSubject({
   min,
   max,
   stroke = '#222',
-  strokeWidth = 2,
   ...restProps
-}: LineSubjectProps & Omit<React.SVGProps<SVGLineElement>, keyof LineSubjectProps>) {
+}: LineSubjectProps) {
   // if props are provided, they take precedence over context
   const annotationContext = useContext(AnnotationContext);
   const lineIsVertical = orientation === 'vertical';

--- a/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnnotationLineSubject.tsx
@@ -9,7 +9,12 @@ export type AnnotationLineSubjectProps = Omit<LineSubjectProps, 'min' | 'max'> &
 };
 
 /** AnnotationLineSubject which provides color and dimensions from context. */
-export default function AnnotationLineSubject({ min, max, ...props }: AnnotationLineSubjectProps) {
+export default function AnnotationLineSubject({
+  min,
+  max,
+  ...props
+}: AnnotationLineSubjectProps &
+  Omit<React.SVGProps<SVGLineElement>, keyof AnnotationLineSubjectProps>) {
   const { theme, margin, innerHeight = 0, innerWidth = 0 } = useContext(DataContext);
   return (
     <BaseLineSubject


### PR DESCRIPTION
#### :bug: Bug Fix

It was impossible to set `strokeWidth` on `LineSubject`s because the property was never passed through. I also augmented the types with the svg line properties because I was getting type errors when trying to set `strokeDasharray`