### PR TITLE
fix(stats): passing value 0 to valueScale

### DIFF
--- a/packages/visx-stats/src/BoxPlot.tsx
+++ b/packages/visx-stats/src/BoxPlot.tsx
@@ -93,10 +93,10 @@ export default function BoxPlot({
   const valueRange = valueScale.range();
 
   const minValue = valueScale(min ?? 0);
-  const firstQuartileValue = firstQuartile ? valueScale(firstQuartile) ?? 0 : 0;
-  const medianValue = median ? valueScale(median) ?? 0 : 0;
-  const thirdQuartileValue = thirdQuartile ? valueScale(thirdQuartile) ?? 0 : 0;
-  const maxValue = max ? valueScale(max) ?? 0 : 0;
+  const firstQuartileValue = valueScale(firstQuartile ?? 0);
+  const medianValue = valueScale(median ?? 0);
+  const thirdQuartileValue = valueScale(thirdQuartile ?? 0);
+  const maxValue = valueScale(max ?? 0);
 
   const boxplot: ChildRenderProps = {
     valueRange,

--- a/packages/visx-stats/src/BoxPlot.tsx
+++ b/packages/visx-stats/src/BoxPlot.tsx
@@ -92,7 +92,7 @@ export default function BoxPlot({
   const center = offset + (boxWidth || 0) / 2;
   const valueRange = valueScale.range();
 
-  const minValue = min ? valueScale(min) ?? 0 : 0;
+  const minValue = valueScale(min ?? 0);
   const firstQuartileValue = firstQuartile ? valueScale(firstQuartile) ?? 0 : 0;
   const medianValue = median ? valueScale(median) ?? 0 : 0;
   const thirdQuartileValue = thirdQuartile ? valueScale(thirdQuartile) ?? 0 : 0;


### PR DESCRIPTION
#### :bug: Bug Fix

- right now there is a check for the values before calling `valueScale` which is supposed to check `undefined` and `null` value but it is filtering out the value `0`
when an inverted linear scale is passed as `valueScale` the value 0 is at the top, not the bottom. And values can be 0 and it is a valid value for `valueScale` function.
