### PR TITLE
fix(xychart/Tooltip): enable style overflow in crosshairs

### DIFF
--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -204,7 +204,7 @@ export default function Tooltip<Datum extends object>({
               detectBounds={false}
               style={TOOLTIP_NO_STYLE}
             >
-              <svg width="1" height={innerHeight}>
+              <svg width="1" height={innerHeight} overflow="visible">
                 <line
                   x1={0}
                   x2={0}
@@ -227,7 +227,7 @@ export default function Tooltip<Datum extends object>({
               detectBounds={false}
               style={TOOLTIP_NO_STYLE}
             >
-              <svg width={innerWidth} height={1}>
+              <svg width={innerWidth} height="1" overflow="visible">
                 <line
                   x1={0}
                   x2={innerWidth}
@@ -277,7 +277,6 @@ export default function Tooltip<Datum extends object>({
               boxShadow: `0 1px 2px ${
                 theme?.htmlLabel?.color ? `${theme?.htmlLabel?.color}55` : '#22222255'
               }`,
-
               ...theme?.htmlLabel,
             }}
             {...tooltipProps}


### PR DESCRIPTION

#### :bug: Bug Fix

Fixes #990. Previously setting `strokeWidth` on `Tooltip` crosshair styles had no effect because the parent `SVG` width/height of `1px` didn't allow it. Fixed by setting `overflow: visible`.

**Before** 
for `vertical/horizontalCrosshairStyle={{ strokeWidth: 8, strokeDasharray: '4,4', stroke: 'yellow' }}`
<img src="https://user-images.githubusercontent.com/4496521/103817778-31381f00-501c-11eb-8355-a7c44b77fb15.png" width="500" />

**After**
for same styles
<img src="https://user-images.githubusercontent.com/4496521/103817694-09e15200-501c-11eb-832b-d25493018a73.png" width="500" />

@hshoff 
cc @Janpot