### PR TITLE
fix(xychart): include zero in scale domains by default

### DIFF
--- a/packages/visx-scale/src/index.ts
+++ b/packages/visx-scale/src/index.ts
@@ -20,6 +20,7 @@ export { default as inferScaleType } from './utils/inferScaleType';
 export { default as coerceNumber } from './utils/coerceNumber';
 export { default as getTicks } from './utils/getTicks';
 export { default as toString } from './utils/toString';
+export { default as scaleCanBeZeroed } from './utils/scaleCanBeZeroed';
 
 // export types
 export * from './types/Base';

--- a/packages/visx-scale/src/utils/scaleCanBeZeroed.ts
+++ b/packages/visx-scale/src/utils/scaleCanBeZeroed.ts
@@ -1,0 +1,26 @@
+import { DefaultOutput, StringLike } from '../types/Base';
+import { DefaultThresholdInput } from '../types/Scale';
+import {
+  LinearScaleConfig,
+  PowScaleConfig,
+  QuantizeScaleConfig,
+  ScaleConfig,
+  ScaleType,
+  SqrtScaleConfig,
+  SymlogScaleConfig,
+} from '../types/ScaleConfig';
+
+type ZeroableScaleConfigs<Output = DefaultOutput> =
+  | LinearScaleConfig<Output>
+  | PowScaleConfig<Output>
+  | SqrtScaleConfig<Output>
+  | SymlogScaleConfig<Output>
+  | QuantizeScaleConfig<Output>;
+
+const zeroableScaleTypes = new Set<ScaleType>(['linear', 'pow', 'quantize', 'sqrt', 'symlog']);
+
+export default function scaleCanBeZeroed<Output = DefaultOutput>(
+  scaleConfig: ScaleConfig<Output>,
+): scaleConfig is ZeroableScaleConfigs<Output> {
+  return zeroableScaleTypes.has(scaleConfig.type);
+}

--- a/packages/visx-scale/src/utils/scaleCanBeZeroed.ts
+++ b/packages/visx-scale/src/utils/scaleCanBeZeroed.ts
@@ -1,5 +1,4 @@
-import { DefaultOutput, StringLike } from '../types/Base';
-import { DefaultThresholdInput } from '../types/Scale';
+import { DefaultOutput } from '../types/Base';
 import {
   LinearScaleConfig,
   PowScaleConfig,

--- a/packages/visx-scale/test/utils/getTicks.test.ts
+++ b/packages/visx-scale/test/utils/getTicks.test.ts
@@ -1,5 +1,5 @@
 import getTicks from '../../src/utils/getTicks';
-import { scaleLinear, scaleBand } from '../../lib';
+import { scaleLinear, scaleBand } from '../../src';
 
 describe('getTicks(scale)', () => {
   it('linear', () => {

--- a/packages/visx-scale/test/utils/scaleCanBeZeroed.test.ts
+++ b/packages/visx-scale/test/utils/scaleCanBeZeroed.test.ts
@@ -2,21 +2,23 @@ import scaleCanBeZeroed from '../../src/utils/scaleCanBeZeroed';
 
 describe('scaleCanBeZeroed(scaleConfig)', () => {
   it('returns true for zero-able scales', () => {
-    expect(scaleCanBeZeroed({ type: 'linear' })).toBe(true);
-    expect(scaleCanBeZeroed({ type: 'pow' })).toBe(true);
-    expect(scaleCanBeZeroed({ type: 'quantize' })).toBe(true);
-    expect(scaleCanBeZeroed({ type: 'sqrt' })).toBe(true);
-    expect(scaleCanBeZeroed({ type: 'symlog' })).toBe(true);
+    const zeroAble = ['linear', 'pow', 'quantize', 'sqrt', 'symlog'] as const;
+    expect.assertions(zeroAble.length);
+    zeroAble.forEach(type => expect(scaleCanBeZeroed({ type })).toBe(true));
   });
   it('returns false for non-zero-able scales', () => {
-    expect(scaleCanBeZeroed({ type: 'log' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'radial' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'time' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'utc' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'quantile' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'threshold' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'ordinal' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'point' })).toBe(false);
-    expect(scaleCanBeZeroed({ type: 'band' })).toBe(false);
+    const notZeroAble = [
+      'log',
+      'radial',
+      'time',
+      'utc',
+      'quantile',
+      'threshold',
+      'ordinal',
+      'point',
+      'band',
+    ] as const;
+    expect.assertions(notZeroAble.length);
+    notZeroAble.forEach(type => expect(scaleCanBeZeroed({ type })).toBe(false));
   });
 });

--- a/packages/visx-scale/test/utils/scaleCanBeZeroed.test.ts
+++ b/packages/visx-scale/test/utils/scaleCanBeZeroed.test.ts
@@ -1,0 +1,22 @@
+import scaleCanBeZeroed from '../../src/utils/scaleCanBeZeroed';
+
+describe('scaleCanBeZeroed(scaleConfig)', () => {
+  it('returns true for zero-able scales', () => {
+    expect(scaleCanBeZeroed({ type: 'linear' })).toBe(true);
+    expect(scaleCanBeZeroed({ type: 'pow' })).toBe(true);
+    expect(scaleCanBeZeroed({ type: 'quantize' })).toBe(true);
+    expect(scaleCanBeZeroed({ type: 'sqrt' })).toBe(true);
+    expect(scaleCanBeZeroed({ type: 'symlog' })).toBe(true);
+  });
+  it('returns false for non-zero-able scales', () => {
+    expect(scaleCanBeZeroed({ type: 'log' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'radial' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'time' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'utc' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'quantile' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'threshold' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'ordinal' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'point' })).toBe(false);
+    expect(scaleCanBeZeroed({ type: 'band' })).toBe(false);
+  });
+});

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -43,6 +43,8 @@ export type XYChartProps<
   xScale?: DataProviderProps<XScaleConfig, YScaleConfig>['xScale'];
   /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the yScale config. */
   yScale?: DataProviderProps<XScaleConfig, YScaleConfig>['yScale'];
+  /* If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as horizontal. Determines whether Series will be plotted horizontally (e.g., horizontal bars). By default this will try to be inferred based on scale types. */
+  horizontal?: boolean | 'auto';
   /** Callback invoked for onPointerMove events for the nearest Datum to the PointerEvent _for each Series with pointerEvents={true}_. */
   onPointerMove?: ({
     datum,
@@ -84,6 +86,7 @@ export default function XYChart<
     captureEvents = true,
     children,
     height,
+    horizontal,
     margin = DEFAULT_MARGIN,
     onPointerMove,
     onPointerOut,
@@ -128,6 +131,7 @@ export default function XYChart<
         yScale={yScale}
         theme={theme}
         initialDimensions={{ width, height, margin }}
+        horizontal={horizontal}
       >
         <XYChart {...props} />
       </DataProvider>

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -41,18 +41,18 @@ export default function useScales<
 
     const xDomain = isDiscreteScale(xScaleConfig) ? xValues : d3Extent(xValues);
 
-    let xScale = scaleCanBeZeroed(xScaleConfig)
+    let xScale = (scaleCanBeZeroed(xScaleConfig)
       ? createScale({
           range: [xMin, xMax],
           domain: xDomain as [XScaleInput, XScaleInput],
           zero: true,
           ...xScaleConfig,
         })
-      : (createScale({
+      : createScale({
           range: [xMin, xMax],
           domain: xDomain as [XScaleInput, XScaleInput],
           ...xScaleConfig,
-        }) as XScale);
+        })) as XScale;
 
     // apply any scale updates from the registy
     registryEntries.forEach(entry => {
@@ -60,7 +60,7 @@ export default function useScales<
     });
 
     return xScale;
-  }, [dataRegistry, horizontal, xScaleConfig, registryKeys, xMin, xMax]);
+  }, [dataRegistry, xScaleConfig, registryKeys, xMin, xMax]);
 
   // same for yScale. this logic is hard to apply generically because of the scale types / accessors
   const memoizedYScale = useMemo(() => {
@@ -76,18 +76,18 @@ export default function useScales<
 
     const yDomain = isDiscreteScale(yScaleConfig) ? yValues : d3Extent(yValues);
 
-    let yScale = scaleCanBeZeroed(yScaleConfig)
+    let yScale = (scaleCanBeZeroed(yScaleConfig)
       ? createScale({
           range: [yMin, yMax],
           domain: yDomain as [YScaleInput, YScaleInput],
           zero: true,
           ...yScaleConfig,
         })
-      : (createScale({
+      : createScale({
           range: [yMin, yMax],
           domain: yDomain as [YScaleInput, YScaleInput],
           ...yScaleConfig,
-        }) as YScale);
+        })) as YScale;
 
     // apply any scale updates from the registy
     registryEntries.forEach(entry => {
@@ -95,7 +95,7 @@ export default function useScales<
     });
 
     return yScale;
-  }, [dataRegistry, yScaleConfig, horizontal, registryKeys, yMin, yMax]);
+  }, [dataRegistry, yScaleConfig, registryKeys, yMin, yMax]);
 
   return { xScale: memoizedXScale, yScale: memoizedYScale };
 }

--- a/packages/visx-xychart/src/hooks/useScales.ts
+++ b/packages/visx-xychart/src/hooks/useScales.ts
@@ -1,5 +1,5 @@
 import { AxisScaleOutput, AxisScale } from '@visx/axis';
-import { ScaleConfig, createScale, ScaleInput } from '@visx/scale';
+import { ScaleConfig, createScale, ScaleInput, scaleCanBeZeroed } from '@visx/scale';
 import { extent as d3Extent } from 'd3-array';
 import { useMemo } from 'react';
 import DataRegistry from '../classes/DataRegistry';
@@ -11,11 +11,11 @@ export default function useScales<
   YScale extends AxisScale,
   Datum extends object
 >({
-  xScaleConfig,
-  yScaleConfig,
   dataRegistry,
   xRange,
+  xScaleConfig,
   yRange,
+  yScaleConfig,
 }: {
   xScaleConfig: ScaleConfig<AxisScaleOutput>;
   yScaleConfig: ScaleConfig<AxisScaleOutput>;
@@ -41,11 +41,18 @@ export default function useScales<
 
     const xDomain = isDiscreteScale(xScaleConfig) ? xValues : d3Extent(xValues);
 
-    let xScale = createScale({
-      range: [xMin, xMax],
-      domain: xDomain as [number, number],
-      ...xScaleConfig,
-    }) as XScale;
+    let xScale = scaleCanBeZeroed(xScaleConfig)
+      ? createScale({
+          range: [xMin, xMax],
+          domain: xDomain as [XScaleInput, XScaleInput],
+          zero: true,
+          ...xScaleConfig,
+        })
+      : (createScale({
+          range: [xMin, xMax],
+          domain: xDomain as [XScaleInput, XScaleInput],
+          ...xScaleConfig,
+        }) as XScale);
 
     // apply any scale updates from the registy
     registryEntries.forEach(entry => {
@@ -53,7 +60,7 @@ export default function useScales<
     });
 
     return xScale;
-  }, [dataRegistry, xScaleConfig, registryKeys, xMin, xMax]);
+  }, [dataRegistry, horizontal, xScaleConfig, registryKeys, xMin, xMax]);
 
   // same for yScale. this logic is hard to apply generically because of the scale types / accessors
   const memoizedYScale = useMemo(() => {
@@ -69,11 +76,18 @@ export default function useScales<
 
     const yDomain = isDiscreteScale(yScaleConfig) ? yValues : d3Extent(yValues);
 
-    let yScale = createScale({
-      range: [yMin, yMax],
-      domain: yDomain as [number, number],
-      ...yScaleConfig,
-    }) as YScale;
+    let yScale = scaleCanBeZeroed(yScaleConfig)
+      ? createScale({
+          range: [yMin, yMax],
+          domain: yDomain as [YScaleInput, YScaleInput],
+          zero: true,
+          ...yScaleConfig,
+        })
+      : (createScale({
+          range: [yMin, yMax],
+          domain: yDomain as [YScaleInput, YScaleInput],
+          ...yScaleConfig,
+        }) as YScale);
 
     // apply any scale updates from the registy
     registryEntries.forEach(entry => {
@@ -81,7 +95,7 @@ export default function useScales<
     });
 
     return yScale;
-  }, [dataRegistry, yScaleConfig, registryKeys, yMin, yMax]);
+  }, [dataRegistry, yScaleConfig, horizontal, registryKeys, yMin, yMax]);
 
   return { xScale: memoizedXScale, yScale: memoizedYScale };
 }

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -26,7 +26,7 @@ export type DataProviderProps<
   yScale: YScaleConfig;
   /* Any React children. */
   children: React.ReactNode;
-  /* Determines whether data will be plotted horizontally. @TODO elaborate */
+  /* Determines whether Series will be plotted horizontally (e.g., horizontal bars). By default this will try to be inferred based on scale types. */
   horizontal?: boolean | 'auto';
 };
 


### PR DESCRIPTION
#### :bug: Bug Fix

This fixes a default behavior issue with `XYChart` scales, where their domains don't include `zero` by default if the scale allows. Including `zero` in the axis domain is generally best practice, and users can still opt out by setting `x/yScaleConfig={{ zero: false }}`. 

**Before** 
This `AreaSeries` has 3 y-values which are all equal and non-zero. It renders like this because the y-domain is `[100, 100]`. This was also reported in #1003 
<img src="https://user-images.githubusercontent.com/4496521/104064891-93775800-51b3-11eb-89d9-e3bee416604e.png" width="500" />

**After**
With the same data + chart config, the y-domain is now `[0, 100]`. 
<img src="https://user-images.githubusercontent.com/4496521/104064397-bce3b400-51b2-11eb-8a4d-89f6afe35f7d.png" width="550" />
Verified it works for negative values, and horizontal orientation.
<img src="https://user-images.githubusercontent.com/4496521/104065171-2617f700-51b4-11eb-96d5-e23bbb7ae260.png" width="550" />

#### :rocket: Enhancements

- Adds a `scaleCanBeZeroed` typeguard util to `@visx/scale` (needed for typing these changes)
- exposes `DataProvider`'s `horizontal` prop in `XYChart` (noticed a small TODO during this work)

@hshoff @kristw 
cc @RIP21
