### PR TITLE
fix(demo/barstack): improve Tooltip positioning logic

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-barstack/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-barstack/package.json
@@ -8,6 +8,7 @@
     "@types/react": "^16",
     "@types/react-dom": "^16",
     "@visx/axis": "latest",
+    "@visx/event": "latest",
     "@visx/grid": "latest",
     "@visx/group": "latest",
     "@visx/legend": "latest",


### PR DESCRIPTION
#### :memo: Documentation
#### :bug: Bug Fix

This closes #1016 and improves the logic for tooltip positioning in the `/barstack` demo. That example was refactored to use `TooltipInPortal` when it was added, and the logic wasn't as robust as it should have been. 

**tl;dr** `left/top` should have been in SVG coordinates, but `top` was in viewport coordinates. If anything is rendered above the chart this breaks (as shown in the issue, reproduced with the yellow box below).

**Before**
<img src="https://user-images.githubusercontent.com/4496521/104265071-a901b180-5441-11eb-8fbd-8978ecd39063.gif" width="500" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/104265069-a56e2a80-5441-11eb-81b3-26555824e101.gif" width="500" />

@hshoff 
cc @wisyr