### PR TITLE
new(axis): pass all tick values in tickLabelProps signature

### DIFF
--- a/packages/visx-axis/src/axis/AxisRenderer.tsx
+++ b/packages/visx-axis/src/axis/AxisRenderer.tsx
@@ -34,7 +34,7 @@ export default function AxisRenderer<Scale extends AxisScale>({
   strokeWidth = 1,
   tickClassName,
   tickComponent,
-  tickLabelProps = (/** tickValue, index */) => defaultTextProps,
+  tickLabelProps = (/** tickValue, index, tickValues */) => defaultTextProps,
   tickLength = 8,
   tickStroke = '#222',
   tickTransform,
@@ -42,7 +42,7 @@ export default function AxisRenderer<Scale extends AxisScale>({
   ticksComponent = Ticks,
 }: AxisRendererProps<Scale>) {
   // compute the max tick label size to compute label offset
-  const allTickLabelProps = ticks.map(({ value, index }) => tickLabelProps(value, index));
+  const allTickLabelProps = ticks.map(({ value, index }) => tickLabelProps(value, index, ticks));
   const maxTickLabelFontSize = Math.max(
     10,
     ...allTickLabelProps.map(props => (typeof props.fontSize === 'number' ? props.fontSize : 0)),

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -19,7 +19,7 @@ export type TickFormatter<T> = (
   values: { value: T; index: number }[],
 ) => FormattedValue;
 
-export type TickLabelProps<T> = (value: T, index: number) => Partial<TextProps>;
+export type TickLabelProps<T> = (value: T, index: number, ticks: T[]) => Partial<TextProps>;
 
 export type TickRendererProps = Partial<TextProps> & {
   x: number;

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -19,7 +19,11 @@ export type TickFormatter<T> = (
   values: { value: T; index: number }[],
 ) => FormattedValue;
 
-export type TickLabelProps<T> = (value: T, index: number, ticks: T[]) => Partial<TextProps>;
+export type TickLabelProps<T> = (
+  value: T,
+  index: number,
+  values: { value: T; index: number }[],
+) => Partial<TextProps>;
 
 export type TickRendererProps = Partial<TextProps> & {
   x: number;

--- a/packages/visx-axis/test/Axis.test.tsx
+++ b/packages/visx-axis/test/Axis.test.tsx
@@ -78,15 +78,22 @@ describe('<Axis />', () => {
     expect.hasAssertions();
   });
 
-  it('should call the tickLabelProps func with the signature (tickValue, index, tickValues)', () => {
+  it('should call the tickLabelProps func with the signature (value, index, values)', () => {
     expect.hasAssertions();
     shallow(
       <Axis
         {...axisProps}
-        tickLabelProps={(value, index, tickValues) => {
+        tickLabelProps={(value, index, values) => {
           expect(value).toEqual(expect.any(Number));
           expect(index).toBeGreaterThan(-1);
-          expect(tickValues).toEqual(expect.arrayContaining(expect.any(Number)));
+          expect(values).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                value: expect.any(Number),
+                index: expect.any(Number),
+              }),
+            ]),
+          );
           return {};
         }}
       />,

--- a/packages/visx-axis/test/Axis.test.tsx
+++ b/packages/visx-axis/test/Axis.test.tsx
@@ -17,16 +17,16 @@ const axisProps = {
 };
 
 describe('<Axis />', () => {
-  test('it should be defined', () => {
+  it('should be defined', () => {
     expect(Axis).toBeDefined();
   });
 
-  test('it should render with class .visx-axis', () => {
+  it('should render with class .visx-axis', () => {
     const wrapper = shallow(<Axis {...axisProps} />);
     expect(wrapper.prop('className')).toEqual('visx-axis');
   });
 
-  test('it should call children function with required args', () => {
+  it('should call children function with required args', () => {
     const mockFn = jest.fn();
     shallow(<Axis {...axisProps}>{mockFn}</Axis>);
     const args = mockFn.mock.calls[0][0];
@@ -44,7 +44,7 @@ describe('<Axis />', () => {
     expect(Object.keys(args.ticks[0])).toEqual(['value', 'index', 'from', 'to', 'formattedValue']);
   });
 
-  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+  it('should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
     const axisClassName = 'axis-test-class';
     const axisLineClassName = 'axisline-test-class';
     const labelClassName = 'label-test-class';
@@ -66,7 +66,7 @@ describe('<Axis />', () => {
     expect(wrapper.find(`.${tickClassName}`).length).toBeGreaterThan(0);
   });
 
-  test('it should pass the output of tickLabelProps to tick labels', () => {
+  it('should pass the output of tickLabelProps to tick labels', () => {
     const tickProps = { fontSize: 50, fill: 'magenta' };
     const wrapper = shallow(<Axis {...axisProps} tickLabelProps={() => tickProps} />);
 
@@ -78,13 +78,15 @@ describe('<Axis />', () => {
     expect.hasAssertions();
   });
 
-  test('it should call the tickLabelProps func with the signature (tickValue, index)', () => {
+  it('should call the tickLabelProps func with the signature (tickValue, index, tickValues)', () => {
+    expect.hasAssertions();
     shallow(
       <Axis
         {...axisProps}
-        tickLabelProps={(value, index) => {
+        tickLabelProps={(value, index, tickValues) => {
           expect(value).toEqual(expect.any(Number));
           expect(index).toBeGreaterThan(-1);
+          expect(tickValues).toEqual(expect.arrayContaining(expect.any(Number)));
           return {};
         }}
       />,
@@ -93,7 +95,7 @@ describe('<Axis />', () => {
     expect.hasAssertions();
   });
 
-  test('it should pass labelProps to the axis label', () => {
+  it('should pass labelProps to the axis label', () => {
     const labelProps = { fontSize: 50, fill: 'magenta' };
     const wrapper = shallow(<Axis {...axisProps} labelProps={labelProps} />);
 
@@ -101,7 +103,7 @@ describe('<Axis />', () => {
     expect(label.find(Text).props()).toEqual(expect.objectContaining(labelProps));
   });
 
-  test('it should render the 0th tick if hideZero is false', () => {
+  it('should render the 0th tick if hideZero is false', () => {
     const wrapper = shallow(<Axis {...axisProps} hideZero={false} />);
     expect(
       wrapper
@@ -111,7 +113,7 @@ describe('<Axis />', () => {
     ).toBe('visx-tick-0-0');
   });
 
-  test('it should not show 0th tick if hideZero is true', () => {
+  it('should not show 0th tick if hideZero is true', () => {
     const wrapper = shallow(<Axis {...axisProps} hideZero />);
     expect(
       wrapper
@@ -121,7 +123,7 @@ describe('<Axis />', () => {
     ).toBe('visx-tick-1-0');
   });
 
-  test('it should SHOW an axis line if hideAxisLine is false', () => {
+  it('should SHOW an axis line if hideAxisLine is false', () => {
     const wrapper = shallow(<Axis {...axisProps} hideAxisLine={false} />);
     expect(
       wrapper
@@ -131,7 +133,7 @@ describe('<Axis />', () => {
     ).toHaveLength(1);
   });
 
-  test('it should HIDE an axis line if hideAxisLine is true', () => {
+  it('should HIDE an axis line if hideAxisLine is true', () => {
     const wrapper = shallow(<Axis {...axisProps} hideAxisLine />);
     expect(
       wrapper
@@ -141,12 +143,12 @@ describe('<Axis />', () => {
     ).toHaveLength(0);
   });
 
-  test('it should SHOW ticks if hideTicks is false', () => {
+  it('should SHOW ticks if hideTicks is false', () => {
     const wrapper = shallow(<Axis {...axisProps} hideTicks={false} />);
     expect(wrapper.children().find('.visx-axis-tick').length).toBeGreaterThan(0);
   });
 
-  test('it should HIDE ticks if hideTicks is true', () => {
+  it('should HIDE ticks if hideTicks is true', () => {
     const wrapper = shallow(<Axis {...axisProps} hideTicks />);
     expect(
       wrapper
@@ -156,7 +158,7 @@ describe('<Axis />', () => {
     ).toHaveLength(0);
   });
 
-  test('it should render one tick for each value specified in tickValues', () => {
+  it('should render one tick for each value specified in tickValues', () => {
     let wrapper = shallow(<Axis {...axisProps} tickValues={[]} />);
     expect(
       wrapper
@@ -173,7 +175,7 @@ describe('<Axis />', () => {
     expect(wrapper.children().find('.visx-axis-tick')).toHaveLength(7);
   });
 
-  test('it should use tickFormat to format ticks if passed', () => {
+  it('should use tickFormat to format ticks if passed', () => {
     const wrapper = shallow(<Axis {...axisProps} tickValues={[0]} tickFormat={() => 'test!!!'} />);
     expect(
       wrapper
@@ -197,7 +199,7 @@ describe('<Axis />', () => {
     ).toBe('0');
   });
 
-  test('it should use center if scale is band', () => {
+  it('should use center if scale is band', () => {
     const wrapper = shallow(
       <Axis
         orientation="bottom"

--- a/packages/visx-axis/test/AxisBottom.test.tsx
+++ b/packages/visx-axis/test/AxisBottom.test.tsx
@@ -13,16 +13,16 @@ const axisProps = {
 };
 
 describe('<AxisBottom />', () => {
-  test('it should be defined', () => {
+  it('should be defined', () => {
     expect(AxisBottom).toBeDefined();
   });
 
-  test('it should render with class .visx-axis-bottom', () => {
+  it('should render with class .visx-axis-bottom', () => {
     const wrapper = shallow(<AxisBottom {...axisProps} />);
     expect(wrapper.prop('axisClassName')).toEqual('visx-axis-bottom');
   });
 
-  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+  it('should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
     const axisClassName = 'axis-test-class';
     const axisLineClassName = 'axisline-test-class';
     const labelClassName = 'label-test-class';
@@ -45,29 +45,29 @@ describe('<AxisBottom />', () => {
     expect(axis.prop('tickClassName')).toBe(tickClassName);
   });
 
-  test('it should default labelOffset prop to 8', () => {
+  it('should default labelOffset prop to 8', () => {
     const wrapper = shallow(<AxisBottom {...axisProps} />);
     expect(wrapper.prop('labelOffset')).toEqual(8);
   });
 
-  test('it should set labelOffset prop', () => {
+  it('should set labelOffset prop', () => {
     const labelOffset = 3;
     const wrapper = shallow(<AxisBottom {...axisProps} labelOffset={labelOffset} />);
     expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
   });
 
-  test('it should default tickLength prop to 8', () => {
+  it('should default tickLength prop to 8', () => {
     const wrapper = shallow(<AxisBottom {...axisProps} />);
     expect(wrapper.prop('tickLength')).toEqual(8);
   });
 
-  test('it should set tickLength prop', () => {
+  it('should set tickLength prop', () => {
     const tickLength = 15;
     const wrapper = shallow(<AxisBottom {...axisProps} tickLength={tickLength} />);
     expect(wrapper.prop('tickLength')).toEqual(tickLength);
   });
 
-  test('it should set label prop', () => {
+  it('should set label prop', () => {
     const label = 'test';
     const wrapper = shallow(<AxisBottom {...axisProps} label={label} />).dive();
     const text = wrapper.find('.visx-axis-label');

--- a/packages/visx-axis/test/AxisLeft.test.tsx
+++ b/packages/visx-axis/test/AxisLeft.test.tsx
@@ -13,16 +13,16 @@ const axisProps = {
 };
 
 describe('<AxisLeft />', () => {
-  test('it should be defined', () => {
+  it('should be defined', () => {
     expect(AxisLeft).toBeDefined();
   });
 
-  test('it should render with class .visx-axis-left', () => {
+  it('should render with class .visx-axis-left', () => {
     const wrapper = shallow(<AxisLeft {...axisProps} />);
     expect(wrapper.prop('axisClassName')).toEqual('visx-axis-left');
   });
 
-  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+  it('should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
     const axisClassName = 'axis-test-class';
     const axisLineClassName = 'axisline-test-class';
     const labelClassName = 'label-test-class';
@@ -45,29 +45,29 @@ describe('<AxisLeft />', () => {
     expect(axis.prop('tickClassName')).toBe(tickClassName);
   });
 
-  test('it should default labelOffset prop to 36', () => {
+  it('should default labelOffset prop to 36', () => {
     const wrapper = shallow(<AxisLeft {...axisProps} />);
     expect(wrapper.prop('labelOffset')).toEqual(36);
   });
 
-  test('it should set labelOffset prop', () => {
+  it('should set labelOffset prop', () => {
     const labelOffset = 3;
     const wrapper = shallow(<AxisLeft {...axisProps} labelOffset={labelOffset} />);
     expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
   });
 
-  test('it should default tickLength prop to 8', () => {
+  it('should default tickLength prop to 8', () => {
     const wrapper = shallow(<AxisLeft {...axisProps} />);
     expect(wrapper.prop('tickLength')).toEqual(8);
   });
 
-  test('it should set tickLength prop', () => {
+  it('should set tickLength prop', () => {
     const tickLength = 15;
     const wrapper = shallow(<AxisLeft {...axisProps} tickLength={tickLength} />);
     expect(wrapper.prop('tickLength')).toEqual(tickLength);
   });
 
-  test('it should set label prop', () => {
+  it('should set label prop', () => {
     const label = 'test';
     const wrapper = shallow(<AxisLeft {...axisProps} label={label} />).dive();
     const text = wrapper.find('.visx-axis-label');

--- a/packages/visx-axis/test/AxisRight.test.tsx
+++ b/packages/visx-axis/test/AxisRight.test.tsx
@@ -13,16 +13,16 @@ const axisProps = {
 };
 
 describe('<AxisRight />', () => {
-  test('it should be defined', () => {
+  it('should be defined', () => {
     expect(AxisRight).toBeDefined();
   });
 
-  test('it should render with class .visx-axis-right', () => {
+  it('should render with class .visx-axis-right', () => {
     const wrapper = shallow(<AxisRight {...axisProps} />);
     expect(wrapper.prop('axisClassName')).toEqual('visx-axis-right');
   });
 
-  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+  it('should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
     const axisClassName = 'axis-test-class';
     const axisLineClassName = 'axisline-test-class';
     const labelClassName = 'label-test-class';
@@ -45,29 +45,29 @@ describe('<AxisRight />', () => {
     expect(axis.prop('tickClassName')).toBe(tickClassName);
   });
 
-  test('it should default labelOffset prop to 36', () => {
+  it('should default labelOffset prop to 36', () => {
     const wrapper = shallow(<AxisRight {...axisProps} />);
     expect(wrapper.prop('labelOffset')).toEqual(36);
   });
 
-  test('it should set labelOffset prop', () => {
+  it('should set labelOffset prop', () => {
     const labelOffset = 3;
     const wrapper = shallow(<AxisRight {...axisProps} labelOffset={labelOffset} />);
     expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
   });
 
-  test('it should default tickLength prop to 8', () => {
+  it('should default tickLength prop to 8', () => {
     const wrapper = shallow(<AxisRight {...axisProps} />);
     expect(wrapper.prop('tickLength')).toEqual(8);
   });
 
-  test('it should set tickLength prop', () => {
+  it('should set tickLength prop', () => {
     const tickLength = 15;
     const wrapper = shallow(<AxisRight {...axisProps} tickLength={tickLength} />);
     expect(wrapper.prop('tickLength')).toEqual(tickLength);
   });
 
-  test('it should set label prop', () => {
+  it('should set label prop', () => {
     const label = 'test';
     const wrapper = shallow(<AxisRight {...axisProps} label={label} />).dive();
     const text = wrapper.find('.visx-axis-label');

--- a/packages/visx-axis/test/AxisTop.test.tsx
+++ b/packages/visx-axis/test/AxisTop.test.tsx
@@ -13,16 +13,16 @@ const axisProps = {
 };
 
 describe('<AxisTop />', () => {
-  test('it should be defined', () => {
+  it('should be defined', () => {
     expect(AxisTop).toBeDefined();
   });
 
-  test('it should render with class .visx-axis-top', () => {
+  it('should render with class .visx-axis-top', () => {
     const wrapper = shallow(<AxisTop {...axisProps} />);
     expect(wrapper.prop('axisClassName')).toEqual('visx-axis-top');
   });
 
-  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+  it('should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
     const axisClassName = 'axis-test-class';
     const axisLineClassName = 'axisline-test-class';
     const labelClassName = 'label-test-class';
@@ -45,29 +45,29 @@ describe('<AxisTop />', () => {
     expect(axis.prop('tickClassName')).toBe(tickClassName);
   });
 
-  test('it should default labelOffset prop to 8', () => {
+  it('should default labelOffset prop to 8', () => {
     const wrapper = shallow(<AxisTop {...axisProps} />);
     expect(wrapper.prop('labelOffset')).toEqual(8);
   });
 
-  test('it should set labelOffset prop', () => {
+  it('should set labelOffset prop', () => {
     const labelOffset = 3;
     const wrapper = shallow(<AxisTop {...axisProps} labelOffset={labelOffset} />);
     expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
   });
 
-  test('it should default tickLength prop to 8', () => {
+  it('should default tickLength prop to 8', () => {
     const wrapper = shallow(<AxisTop {...axisProps} />);
     expect(wrapper.prop('tickLength')).toEqual(8);
   });
 
-  test('it should set tickLength prop', () => {
+  it('should set tickLength prop', () => {
     const tickLength = 15;
     const wrapper = shallow(<AxisTop {...axisProps} tickLength={tickLength} />);
     expect(wrapper.prop('tickLength')).toEqual(tickLength);
   });
 
-  test('it should set label prop', () => {
+  it('should set label prop', () => {
     const label = 'test';
     const wrapper = shallow(<AxisTop {...axisProps} label={label} />).dive();
     const text = wrapper.find('.visx-axis-label');

--- a/packages/visx-axis/test/Orientation.test.ts
+++ b/packages/visx-axis/test/Orientation.test.ts
@@ -1,19 +1,12 @@
 import { Orientation } from '../src';
 
 describe('Orientation', () => {
-  test('it should be defined', () => {
-    expect(Orientation).toBeDefined();
-  });
-  test('top should be defined', () => {
-    expect(Orientation.top).toBeDefined();
-  });
-  test('left should be defined', () => {
-    expect(Orientation.left).toBeDefined();
-  });
-  test('right should be defined', () => {
-    expect(Orientation.right).toBeDefined();
-  });
-  test('bottom should be defined', () => {
-    expect(Orientation.bottom).toBeDefined();
+  it('should have keys for top/right/bottom/left', () => {
+    expect(Orientation).toEqual({
+      top: expect.any(String),
+      right: expect.any(String),
+      bottom: expect.any(String),
+      left: expect.any(String),
+    });
   });
 });

--- a/packages/visx-xychart/src/components/axis/BaseAxis.tsx
+++ b/packages/visx-xychart/src/components/axis/BaseAxis.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useContext } from 'react';
-import { AxisScale } from '@visx/axis';
+import { AxisScale, TickLabelProps } from '@visx/axis';
 import { AxisProps as VxAxisProps } from '@visx/axis/lib/axis/Axis';
 import { ScaleInput } from '@visx/scale';
 import DataContext from '../../context/DataContext';
@@ -34,10 +34,10 @@ export default function BaseAxis<Scale extends AxisScale>({
     [theme, orientation],
   );
 
-  const tickLabelProps = useMemo(
+  const tickLabelProps = useMemo<TickLabelProps<ScaleInput<Scale>> | undefined>(
     () =>
       props.tickLabelProps || axisStyles // construct from props + theme if possible
-        ? (value: ScaleInput<Scale>, index: number) =>
+        ? (value, index, values) =>
             // by default, wrap vertical-axis tick labels within the allotted margin space
             // this does not currently account for axis label
             ({
@@ -46,10 +46,9 @@ export default function BaseAxis<Scale extends AxisScale>({
                 orientation === 'left' || orientation === 'right'
                   ? margin?.[orientation]
                   : undefined,
-              ...props.tickLabelProps?.(value, index),
+              ...props.tickLabelProps?.(value, index, values),
             })
         : undefined,
-
     [props.tickLabelProps, axisStyles, orientation, margin],
   );
 


### PR DESCRIPTION
#### :rocket: Enhancements

This updates the signature of `@visx/axis`'s `Axis.props.tickLabelProps`:

```ts
// before
(tickValue, index) => TextProps

// after
(tickValue, index, tickValues) => TextProps
```

This is consistent with how many `d3` accessors work (gives you access to the data point, index, and all data points) as well as matches the signature of [`Axis.props.tickFormat`](https://github.com/airbnb/visx/blob/master/packages/visx-axis/src/types.ts#L16). 

I noticed this as a limitation when using `xychart` in an internal app (e.g., if you want to right-align the last tick, but don't know how many ticks you have since `numTicks` is approximate).

@kristw @hshoff 