### PR TITLE
new(tooltip, xychart): force update TooltipInPortal bounds

### DIFF
--- a/packages/visx-tooltip/src/hooks/useTooltipInPortal.tsx
+++ b/packages/visx-tooltip/src/hooks/useTooltipInPortal.tsx
@@ -10,6 +10,7 @@ export type TooltipInPortalProps = TooltipProps & Pick<UseTooltipPortalOptions, 
 export type UseTooltipInPortal = {
   containerRef: (element: HTMLElement | SVGElement | null) => void;
   containerBounds: RectReadOnly;
+  forceRefreshBounds: () => void;
   TooltipInPortal: React.FC<TooltipInPortalProps>;
 };
 
@@ -32,7 +33,7 @@ export default function useTooltipInPortal({
   detectBounds: detectBoundsOption = true,
   ...useMeasureOptions
 }: UseTooltipPortalOptions | undefined = {}): UseTooltipInPortal {
-  const [containerRef, containerBounds] = useMeasure(useMeasureOptions);
+  const [containerRef, containerBounds, forceRefreshBounds] = useMeasure(useMeasureOptions);
 
   const TooltipInPortal = useMemo(
     () => ({
@@ -61,6 +62,7 @@ export default function useTooltipInPortal({
     // @ts-ignore fixed here https://github.com/react-spring/react-use-measure/pull/17
     containerRef,
     containerBounds,
+    forceRefreshBounds,
     TooltipInPortal,
   };
 }

--- a/packages/visx-xychart/test/components/Tooltip.test.tsx
+++ b/packages/visx-xychart/test/components/Tooltip.test.tsx
@@ -77,7 +77,7 @@ describe('<Tooltip />', () => {
       props: { renderTooltip },
       context: { tooltipOpen: true },
     });
-    expect(renderTooltip).toHaveBeenCalledTimes(1);
+    expect(renderTooltip).toHaveBeenCalled(); // may be invoked more than once due to forceRefreshBounds invocation
   });
 
   it('should render a vertical crosshair if showVerticalCrossHair=true', () => {


### PR DESCRIPTION
#### :rocket: Enhancements

This PR fixes an issue with `XYChart`'s `Tooltip` described in #983, where `Tooltip` position does **not** correctly update when the chart container changes position due to limitations with `react-use-measure` (note that position **does** update upon page scroll or container resize). It's not obvious how to fix this with `IntersectionObserver`, etc. so I used a relatively simple approach:

- expose `react-use-measure`'s `forceRefreshBounds` function in the `@visx/tooltip` `useTooltipInPortal` hook, which will force update the `Tooltip` container bounds
- invoke ^`forceRefreshBounds` whenever `@visx/xychart`'s `Tooltip` goes from the `unopen => open` state

Closes #983.

**Before**
In this case, the chart animates in from the left so the `Portal` thinks its bounds are way left/off screen until I scroll, at which point `react-use-measure` updates the position and the tooltip is correctly positioned; see #983 for a different example with drag & drop
<img src="https://user-images.githubusercontent.com/4496521/106806832-4c974980-661d-11eb-9047-546bd31116ae.gif" width="500" />

**After**
Tooltip has correct position from the outset
<img src="https://user-images.githubusercontent.com/4496521/106806897-5c169280-661d-11eb-8ea1-ddd72b03501a.gif" width="500" />

@kristw @hshoff 
cc @valtism 