### PR TITLE
fix(xychart): improve positioning with missing data

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/Example.tsx
@@ -304,25 +304,30 @@ export default function Example({ height }: XYChartProps) {
                   {((sharedTooltip
                     ? Object.keys(tooltipData?.datumByKey ?? {})
                     : [tooltipData?.nearestDatum?.key]
-                  ).filter(city => city) as City[]).map(city => (
-                    <div key={city}>
-                      <em
-                        style={{
-                          color: colorScale?.(city),
-                          textDecoration:
-                            tooltipData?.nearestDatum?.key === city ? 'underline' : undefined,
-                        }}
-                      >
-                        {city}
-                      </em>{' '}
-                      {tooltipData?.nearestDatum?.datum
-                        ? accessors[renderHorizontally ? 'x' : 'y'][city](
-                            tooltipData?.nearestDatum?.datum,
-                          )
-                        : '–'}
-                      ° F
-                    </div>
-                  ))}
+                  ).filter(city => city) as City[]).map(city => {
+                    const temperature =
+                      tooltipData?.nearestDatum?.datum &&
+                      accessors[renderHorizontally ? 'x' : 'y'][city](
+                        tooltipData?.nearestDatum?.datum,
+                      );
+
+                    return (
+                      <div key={city}>
+                        <em
+                          style={{
+                            color: colorScale?.(city),
+                            textDecoration:
+                              tooltipData?.nearestDatum?.key === city ? 'underline' : undefined,
+                          }}
+                        >
+                          {city}
+                        </em>{' '}
+                        {temperature == null || Number.isNaN(temperature)
+                          ? '–'
+                          : `${temperature}° F`}
+                      </div>
+                    );
+                  })}
                 </>
               )}
             />

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -8,6 +8,7 @@ import TooltipContext from '../context/TooltipContext';
 import DataContext from '../context/DataContext';
 import { TooltipContextType } from '../types';
 import getScaleBandwidth from '../utils/getScaleBandwidth';
+import isValidNumber from '../typeguards/isValidNumber';
 
 /** fontSize + lineHeight from default styles break precise location of crosshair, etc. */
 const TOOLTIP_NO_STYLE: React.CSSProperties = {
@@ -158,8 +159,8 @@ export default function Tooltip<Datum extends object>({
   // snap x- or y-coord to the actual data point (not event coordinates)
   if (showTooltip && nearestDatum && (snapTooltipToDatumX || snapTooltipToDatumY)) {
     const { left, top } = getDatumLeftTop(nearestDatumKey, nearestDatum.datum);
-    tooltipLeft = snapTooltipToDatumX ? left : tooltipLeft;
-    tooltipTop = snapTooltipToDatumY ? top : tooltipTop;
+    tooltipLeft = snapTooltipToDatumX && isValidNumber(left) ? left : tooltipLeft;
+    tooltipTop = snapTooltipToDatumY && isValidNumber(top) ? top : tooltipTop;
   }
 
   // collect positions + styles for glyphs; glyphs always snap to Datum, not event coords
@@ -173,9 +174,13 @@ export default function Tooltip<Datum extends object>({
       Object.values(tooltipContext?.tooltipData?.datumByKey ?? {}).forEach(({ key, datum }) => {
         const color = colorScale?.(key) ?? theme?.htmlLabel?.color ?? '#222';
         const { left, top } = getDatumLeftTop(key, datum);
+
+        // don't show glyphs if coords are unavailable
+        if (!isValidNumber(left) || !isValidNumber(top)) return;
+
         glyphProps.push({
-          left: left == null ? left : left - radius - strokeWidth,
-          top: top == null ? top : top - radius - strokeWidth,
+          left: left - radius - strokeWidth,
+          top: top - radius - strokeWidth,
           fill: color,
           stroke: theme?.backgroundColor,
           strokeWidth,


### PR DESCRIPTION
#### :bug: Bug Fix

Closes #1054. 

Previously when either `snapTooltipToDataX`/`snapTooltipToDataY` were set on `<Tooltip />`, and a hovered `datum` had a missing value for the corresponding `x`/`y`, we rendered the tooltip at `0,0` and also rendered the tooltip glyphs (circles corresponding to the hovered points) incorrectly.

Also fixes the demo to not show `NaN` values for missing data.

**Before**
<img src="https://user-images.githubusercontent.com/4496521/107729173-f7a2a580-6ca4-11eb-8d9a-ecf5e72fff56.png" width="600" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/107729119-cfb34200-6ca4-11eb-844b-64ce5a0aac7c.png" width="600" />

@kristw @hshoff 
cc @mira-t