### PR TITLE
new(xychart/BaseAreaSeries): add x/y0Accessor functions to support bands

### DIFF
--- a/packages/visx-xychart/src/components/series/AnimatedAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/AnimatedAreaSeries.tsx
@@ -8,5 +8,7 @@ export default function AnimatedAreaSeries<
   YScale extends AxisScale,
   Datum extends object
 >(props: Omit<BaseAreaSeriesProps<XScale, YScale, Datum>, 'PathComponent'>) {
+  // @TODO currently generics for non-SeriesProps are not passed correctly in withRegisteredData HOC
+  // @ts-expect-error
   return <BaseAreaSeries<XScale, YScale, Datum> {...props} PathComponent={AnimatedPath} />;
 }

--- a/packages/visx-xychart/src/components/series/AreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/AreaSeries.tsx
@@ -7,5 +7,7 @@ export default function AreaSeries<
   YScale extends AxisScale,
   Datum extends object
 >(props: Omit<BaseAreaSeriesProps<XScale, YScale, Datum>, 'PathComponent'>) {
+  // @TODO currently generics for non-SeriesProps are not passed correctly in withRegisteredData HOC
+  // @ts-expect-error
   return <BaseAreaSeries<XScale, YScale, Datum> {...props} />;
 }

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -18,10 +18,10 @@ export type BaseAreaSeriesProps<
   YScale extends AxisScale,
   Datum extends object
 > = SeriesProps<XScale, YScale, Datum> & {
-  /** Optional accessor to override the baseline value of Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value, not compatible with AreaStack. */
-  y0Accessor?: SeriesProps<XScale, YScale, Datum>['yAccessor'];
   /** Optional accessor to override the baseline value of Area shapes per datum (useful to generate band shapes) when chart is rendered horizontally (vertical line). Defaults to the scale zero value, not compatible with AreaStack. */
   x0Accessor?: SeriesProps<XScale, YScale, Datum>['xAccessor'];
+  /** Optional accessor to override the baseline value of Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value, not compatible with AreaStack. */
+  y0Accessor?: SeriesProps<XScale, YScale, Datum>['yAccessor'];
   /** Whether to render a Line along value of the Area shape (area is fill only). */
   renderLine?: boolean;
   /** Sets the curve factory (from @visx/curve or d3-curve) for the line generator. Defaults to curveLinear. */

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -18,9 +18,9 @@ export type BaseAreaSeriesProps<
   YScale extends AxisScale,
   Datum extends object
 > = SeriesProps<XScale, YScale, Datum> & {
-  /** Optional accessor to override the baseline value of vertically-oriented Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value. Mot compatible with AreaStack. */
+  /** Optional accessor to override the baseline value of Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value, not compatible with AreaStack. */
   y0Accessor?: SeriesProps<XScale, YScale, Datum>['yAccessor'];
-  /** Optional accessor to override the baseline value of horizontally-oriented Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value. Mot compatible with AreaStack. */
+  /** Optional accessor to override the baseline value of Area shapes per datum (useful to generate band shapes) when chart is rendered horizontally (vertical line). Defaults to the scale zero value, not compatible with AreaStack. */
   x0Accessor?: SeriesProps<XScale, YScale, Datum>['xAccessor'];
   /** Whether to render a Line along value of the Area shape (area is fill only). */
   renderLine?: boolean;

--- a/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaSeries.tsx
@@ -18,6 +18,10 @@ export type BaseAreaSeriesProps<
   YScale extends AxisScale,
   Datum extends object
 > = SeriesProps<XScale, YScale, Datum> & {
+  /** Optional accessor to override the baseline value of vertically-oriented Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value. Mot compatible with AreaStack. */
+  y0Accessor?: SeriesProps<XScale, YScale, Datum>['yAccessor'];
+  /** Optional accessor to override the baseline value of horizontally-oriented Area shapes per datum (useful to generate band shapes). Defaults to the scale zero value. Mot compatible with AreaStack. */
+  x0Accessor?: SeriesProps<XScale, YScale, Datum>['xAccessor'];
   /** Whether to render a Line along value of the Area shape (area is fill only). */
   renderLine?: boolean;
   /** Sets the curve factory (from @visx/curve or d3-curve) for the line generator. Defaults to curveLinear. */
@@ -45,13 +49,23 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
   enableEvents = true,
   renderLine = true,
   xAccessor,
+  x0Accessor,
   xScale,
   yAccessor,
+  y0Accessor,
   yScale,
   ...areaProps
 }: BaseAreaSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
   const { colorScale, theme, horizontal } = useContext(DataContext);
+  const getScaledX0 = useMemo(
+    () => (x0Accessor ? getScaledValueFactory(xScale, x0Accessor) : undefined),
+    [xScale, x0Accessor],
+  );
   const getScaledX = useCallback(getScaledValueFactory(xScale, xAccessor), [xScale, xAccessor]);
+  const getScaledY0 = useMemo(
+    () => (y0Accessor ? getScaledValueFactory(yScale, y0Accessor) : undefined),
+    [yScale, y0Accessor],
+  );
   const getScaledY = useCallback(getScaledValueFactory(yScale, yAccessor), [yScale, yAccessor]);
   const isDefined = useCallback(
     (d: Datum) => isValidNumber(xScale(xAccessor(d))) && isValidNumber(yScale(yAccessor(d))),
@@ -77,16 +91,16 @@ function BaseAreaSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
     const numericScaleBaseline = getScaleBaseline(horizontal ? xScale : yScale);
     return horizontal
       ? {
-          x0: numericScaleBaseline,
+          x0: getScaledX0 ?? numericScaleBaseline,
           x1: getScaledX,
           y: getScaledY,
         }
       : {
           x: getScaledX,
-          y0: numericScaleBaseline,
+          y0: getScaledY0 ?? numericScaleBaseline,
           y1: getScaledY,
         };
-  }, [xScale, yScale, horizontal, getScaledX, getScaledY]);
+  }, [xScale, yScale, horizontal, getScaledX, getScaledY, getScaledX0, getScaledY0]);
 
   // render invisible glyphs for focusing if onFocus/onBlur are defined
   const captureFocusEvents = Boolean(onFocus || onBlur);

--- a/packages/visx-xychart/test/components/AreaSeries.test.tsx
+++ b/packages/visx-xychart/test/components/AreaSeries.test.tsx
@@ -26,6 +26,23 @@ describe('<AreaSeries />', () => {
     expect(wrapper.find(Area)).toHaveLength(1);
   });
 
+  it('should use x/y0Accessors an Area', () => {
+    const y0Accessor = jest.fn(() => 3);
+    const wrapper = mount(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <AreaSeries dataKey={series.key} {...series} y0Accessor={y0Accessor} />
+        </svg>
+      </DataContext.Provider>,
+    );
+
+    const callCount = y0Accessor.mock.calls.length;
+    expect(y0Accessor).toHaveBeenCalled();
+    const y0Area = wrapper.find(Area).prop('y0') as Function;
+    y0Area();
+    expect(y0Accessor).toHaveBeenCalledTimes(callCount + 1);
+  });
+
   it('should render a LinePath is renderLine=true', () => {
     const wrapper = mount(
       <DataContext.Provider value={getDataContext(series)}>


### PR DESCRIPTION
#### :rocket: Enhancements

Adds optional `x0Accessor` and `y0Accessor` functions to `AreaSeries` in order to override the scale baseline _per datum_ and support bands. 

Couple notes:
- this currently doesn't account for `x0/y0` values in the scale domain, so implicitly `x0/y0` should be within the `x/y` domain as defined by the `x/yAccessors`.
- these accessors are incompatible with `AreaStack`, `<AreaStack><AreaSeries y0Acessor={..} {...} /> </AreaStack>` will have no effect

Tested 
- [x] functionally (below is a `LineSeries` rendered on top of an `AreaSeries` with either `x0Accessor` [temp on x-axis] or `y0Accessor` [temp on y-axis] set)
- [x] new unit tests

<img src="https://user-images.githubusercontent.com/4496521/108272949-cb18de80-7127-11eb-8db2-fa5985bb53f2.png" width="600" />

<img src="https://user-images.githubusercontent.com/4496521/108273116-fd2a4080-7127-11eb-8cff-4e8d7aa9f881.png" width="600" />

@kristw @hshoff 