### PR TITLE
fix(network): string type in node/linkComponent

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-network/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-network/Example.tsx
@@ -33,11 +33,7 @@ export default function Example({ width, height }: NetworkProps) {
         graph={graph}
         top={50}
         left={100}
-        nodeComponent={() => (
-          <text dx="-0.5em" dy="0.5em" fontSize={28}>
-            💜
-          </text>
-        )}
+        nodeComponent={() => <rect x={-25} y={-15} width={50} height={30} fill="purple" />}
         linkComponent={({ link: { source, target } }) => (
           <>
             <line

--- a/packages/visx-demo/src/sandboxes/visx-network/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-network/Example.tsx
@@ -29,7 +29,39 @@ export default function Example({ width, height }: NetworkProps) {
   return width < 10 ? null : (
     <svg width={width} height={height}>
       <rect width={width} height={height} rx={14} fill={background} />
-      <Graph graph={graph} />
+      <Graph
+        graph={graph}
+        top={50}
+        left={100}
+        nodeComponent={() => (
+          <text dx="-0.5em" dy="0.5em" fontSize={28}>
+            💜
+          </text>
+        )}
+        linkComponent={({ link: { source, target } }) => (
+          <>
+            <line
+              x1={source.x}
+              y1={source.y}
+              x2={target.x}
+              y2={target.y}
+              strokeWidth={2}
+              stroke="pink"
+              strokeOpacity={0.5}
+              strokeDasharray="8,4"
+            />
+            <text
+              textAnchor="middle"
+              x={Math.abs(source.x + target.x) / 2}
+              y={Math.abs(source.y + target.y) / 2}
+              dy="0.25em"
+              fill="white"
+            >
+              link
+            </text>
+          </>
+        )}
+      />
     </svg>
   );
 }

--- a/packages/visx-demo/src/sandboxes/visx-network/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-network/Example.tsx
@@ -1,21 +1,33 @@
 import React from 'react';
-import { Graph } from '@visx/network';
+import { DefaultNode, Graph } from '@visx/network';
 
 export type NetworkProps = {
   width: number;
   height: number;
 };
 
-const nodes = [
+interface CustomNode {
+  x: number;
+  y: number;
+  color?: string;
+}
+
+interface CustomLink {
+  source: CustomNode;
+  target: CustomNode;
+  dashed?: boolean;
+}
+
+const nodes: CustomNode[] = [
   { x: 50, y: 20 },
-  { x: 200, y: 300 },
-  { x: 300, y: 40 },
+  { x: 200, y: 250 },
+  { x: 300, y: 40, color: '#26deb0' },
 ];
 
-const links = [
+const links: CustomLink[] = [
   { source: nodes[0], target: nodes[1] },
   { source: nodes[1], target: nodes[2] },
-  { source: nodes[2], target: nodes[0] },
+  { source: nodes[2], target: nodes[0], dashed: true },
 ];
 
 const graph = {
@@ -29,33 +41,24 @@ export default function Example({ width, height }: NetworkProps) {
   return width < 10 ? null : (
     <svg width={width} height={height}>
       <rect width={width} height={height} rx={14} fill={background} />
-      <Graph
+      <Graph<CustomLink, CustomNode>
         graph={graph}
-        top={50}
+        top={20}
         left={100}
-        nodeComponent={() => <rect x={-25} y={-15} width={50} height={30} fill="purple" />}
-        linkComponent={({ link: { source, target } }) => (
-          <>
-            <line
-              x1={source.x}
-              y1={source.y}
-              x2={target.x}
-              y2={target.y}
-              strokeWidth={2}
-              stroke="pink"
-              strokeOpacity={0.5}
-              strokeDasharray="8,4"
-            />
-            <text
-              textAnchor="middle"
-              x={Math.abs(source.x + target.x) / 2}
-              y={Math.abs(source.y + target.y) / 2}
-              dy="0.25em"
-              fill="white"
-            >
-              link
-            </text>
-          </>
+        nodeComponent={({ node: { color } }) =>
+          color ? <DefaultNode fill={color} /> : <DefaultNode />
+        }
+        linkComponent={({ link: { source, target, dashed } }) => (
+          <line
+            x1={source.x}
+            y1={source.y}
+            x2={target.x}
+            y2={target.y}
+            strokeWidth={2}
+            stroke="#999"
+            strokeOpacity={0.6}
+            strokeDasharray={dashed ? '8,4' : undefined}
+          />
         )}
       />
     </svg>

--- a/packages/visx-network/src/Graph.tsx
+++ b/packages/visx-network/src/Graph.tsx
@@ -17,12 +17,10 @@ type Props<Link, Node> = {
   graph?: GraphType<Link, Node>;
   /** Component for rendering a single Link. */
   linkComponent?:
-    | string
     | React.FunctionComponent<LinkProvidedProps<Link>>
     | React.ComponentClass<LinkProvidedProps<Link>>;
   /** Component for rendering a single Node. */
   nodeComponent?:
-    | string
     | React.FunctionComponent<NodeProvidedProps<Node>>
     | React.ComponentClass<NodeProvidedProps<Node>>;
   /** Top transform offset to apply to links and nodes. */

--- a/packages/visx-network/src/Links.tsx
+++ b/packages/visx-network/src/Links.tsx
@@ -8,7 +8,6 @@ export type LinkProps<Link> = {
   links?: Link[];
   /** Component for rendering a single link. */
   linkComponent:
-    | string
     | React.FunctionComponent<LinkProvidedProps<Link>>
     | React.ComponentClass<LinkProvidedProps<Link>>;
   /** Classname to add to each link parent g element. */

--- a/packages/visx-network/src/Nodes.tsx
+++ b/packages/visx-network/src/Nodes.tsx
@@ -10,7 +10,6 @@ export type NodeProps<Node> = {
   nodes?: Node[];
   /** Component for rendering a single link. */
   nodeComponent:
-    | string
     | React.FunctionComponent<NodeProvidedProps<Node>>
     | React.ComponentClass<NodeProvidedProps<Node>>;
   /** Classname to add to each node parent g element. */


### PR DESCRIPTION
Fixes #939 

#### :boom: Breaking Changes

- This changes the type signature of a public-facing prop, so it might be considered a breaking change. However, the type option that's being removed was broken anyway, so this doesn't break any functionality.

#### :memo: Documentation

- Extended `network` example to show use of `nodeComponent` and `linkComponent`, as well as `top` and `left` props. Adapted from demo in comment of https://github.com/airbnb/visx/issues/939

#### :bug: Bug Fix

- Remove string type from `nodeComponent` and `linkComponent` props in `network` package. This type was invalid in spite of being in the type signature. See https://github.com/airbnb/visx/issues/939