### PR TITLE
fix(xychart/Axis): export AxisScale type, set default Scale generic

### DIFF
--- a/packages/visx-xychart/src/components/axis/Axis.tsx
+++ b/packages/visx-xychart/src/components/axis/Axis.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Axis as VisxAxis, AxisScale as AxisAxisScale } from '@visx/axis';
+import { Axis as VisxAxis, AxisScale } from '@visx/axis';
 import BaseAxis, { BaseAxisProps } from './BaseAxis';
-
-export type AxisScale = AxisAxisScale;
 
 export type AxisProps<Scale extends AxisScale = AxisScale> = Omit<
   BaseAxisProps<Scale>,

--- a/packages/visx-xychart/src/components/axis/Axis.tsx
+++ b/packages/visx-xychart/src/components/axis/Axis.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { Axis as VisxAxis, AxisScale } from '@visx/axis';
+import { Axis as VisxAxis, AxisScale as AxisAxisScale } from '@visx/axis';
 import BaseAxis, { BaseAxisProps } from './BaseAxis';
 
-export type AxisProps<Scale extends AxisScale> = Omit<BaseAxisProps<Scale>, 'AxisComponent'>;
+export type AxisScale = AxisAxisScale;
 
-export default function Axis<Scale extends AxisScale>(props: AxisProps<Scale>) {
+export type AxisProps<Scale extends AxisScale = AxisScale> = Omit<
+  BaseAxisProps<Scale>,
+  'AxisComponent'
+>;
+
+export default function Axis<Scale extends AxisScale = AxisScale>(props: AxisProps<Scale>) {
   return <BaseAxis<Scale> AxisComponent={VisxAxis} {...props} />;
 }

--- a/packages/visx-xychart/src/types/axis.ts
+++ b/packages/visx-xychart/src/types/axis.ts
@@ -1,0 +1,3 @@
+import { AxisScale as AxisAxisScale } from '@visx/axis';
+
+export type AxisScale = AxisAxisScale;

--- a/packages/visx-xychart/src/types/index.ts
+++ b/packages/visx-xychart/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './axis';
 export * from './data';
 export * from './event';
 export * from './series';


### PR DESCRIPTION
#### :bug: Bug Fix

Somewhere between a bug fix and a feature, this just updates the `@visx/xychart` `Axis` component to export the `AxisScale` generic type so users don't need to import it from (or even install) `@visx/axis`. It also sets a default for the generic. 

I'd maybe consider it a :bug: in the sense that users can't reference the correct generic without `@visx/axis`.

@kristw @hshoff 