### PR TITLE
new(xychart/BarSeries,BarGroup,BarStack): add support for bar radius

### DIFF
--- a/packages/visx-xychart/src/components/series/BarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/BarSeries.tsx
@@ -6,7 +6,7 @@ import Bars from './private/Bars';
 function BarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   colorAccessor,
   ...props
-}: Omit<BaseBarSeriesProps<XScale, YScale, Datum>, 'BarsComponent'>) {
+}: BaseBarSeriesProps<XScale, YScale, Datum>) {
   return (
     <BaseBarSeries<XScale, YScale, Datum>
       {...props}

--- a/packages/visx-xychart/src/components/series/BarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/BarSeries.tsx
@@ -6,7 +6,7 @@ import Bars from './private/Bars';
 function BarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
   colorAccessor,
   ...props
-}: BaseBarSeriesProps<XScale, YScale, Datum>) {
+}: Omit<BaseBarSeriesProps<XScale, YScale, Datum>, 'BarsComponent'>) {
   return (
     <BaseBarSeries<XScale, YScale, Datum>
       {...props}

--- a/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
@@ -1,9 +1,11 @@
 import { AxisScale } from '@visx/axis';
+import { BarRounded } from '@visx/shape';
 import React, { useMemo } from 'react';
 import { animated, useTransition } from 'react-spring';
 import { Bar, BarsProps } from '../../../types';
 import { cleanColor, colorHasUrl } from '../../../utils/cleanColorString';
 import getScaleBaseline from '../../../utils/getScaleBaseline';
+import AnimatedPath from './AnimatedPath';
 
 function enterUpdate({ x, y, width, height, fill }: Bar) {
   return {
@@ -51,11 +53,64 @@ function useBarTransitionConfig<Scale extends AxisScale>({
   }, [scale, shouldAnimateX]);
 }
 
-export default function AnimatedBars<XScale extends AxisScale, YScale extends AxisScale>({
+/** Wrapper component which renders a Bars component depending on whether it needs rounded corners. */
+export default function AnimatedBars<XScale extends AxisScale, YScale extends AxisScale>(
+  props: BarsProps<XScale, YScale>,
+) {
+  return props.radius == null ? (
+    <AnimatedBarsUnrounded {...props} />
+  ) : (
+    <AnimatedBarsRounded {...props} radius={props.radius} />
+  );
+}
+
+function AnimatedBarsRounded<XScale extends AxisScale, YScale extends AxisScale>({
   bars,
   xScale,
   yScale,
   horizontal,
+  radius,
+  radiusAll,
+  radiusTop,
+  radiusRight,
+  radiusBottom,
+  radiusLeft,
+  ...pathProps
+}: BarsProps<XScale, YScale> & { radius: number }) {
+  return (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>
+      {bars.map(({ key, fill, x, y, width, height }) => (
+        <BarRounded
+          key={key}
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          radius={radius}
+          top={radiusTop}
+          right={radiusRight}
+          bottom={radiusBottom}
+          left={radiusLeft}
+        >
+          {({ path }) => <AnimatedPath d={path} fill={fill} {...pathProps} />}
+        </BarRounded>
+      ))}
+    </>
+  );
+}
+
+function AnimatedBarsUnrounded<XScale extends AxisScale, YScale extends AxisScale>({
+  bars,
+  xScale,
+  yScale,
+  horizontal,
+  radius,
+  radiusAll,
+  radiusTop,
+  radiusRight,
+  radiusBottom,
+  radiusLeft,
   ...rectProps
 }: BarsProps<XScale, YScale>) {
   const animatedBars = useTransition(bars, {

--- a/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
@@ -93,7 +93,14 @@ function AnimatedBarsRounded<XScale extends AxisScale, YScale extends AxisScale>
           bottom={radiusBottom}
           left={radiusLeft}
         >
-          {({ path }) => <AnimatedPath d={path} fill={fill} {...pathProps} />}
+          {({ path }) => (
+            <AnimatedPath
+              className="visx-bar visx-bar-rounded"
+              d={path}
+              fill={fill}
+              {...pathProps}
+            />
+          )}
         </BarRounded>
       ))}
     </>

--- a/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
@@ -88,6 +88,7 @@ function AnimatedBarsRounded<XScale extends AxisScale, YScale extends AxisScale>
           width={width}
           height={height}
           radius={radius}
+          all={radiusAll}
           top={radiusTop}
           right={radiusRight}
           bottom={radiusBottom}

--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -6,8 +6,8 @@ import debounce from 'lodash/debounce';
 
 export default function AnimatedPath({
   d,
-  stroke,
-  fill,
+  stroke = 'transparent',
+  fill = 'transparent',
   ...lineProps
 }: Omit<React.SVGProps<SVGPathElement>, 'ref'>) {
   const previousD = useRef(d);

--- a/packages/visx-xychart/src/components/series/private/Bars.tsx
+++ b/packages/visx-xychart/src/components/series/private/Bars.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { AxisScale } from '@visx/axis';
+import { BarRounded } from '@visx/shape';
 import React from 'react';
 import { BarsProps } from '../../../types';
 
@@ -7,20 +9,42 @@ export default function Bars({
   horizontal,
   xScale,
   yScale,
-  ...rectProps
-}: BarsProps<any, any>) {
-  const isFocusable = Boolean(rectProps.onFocus || rectProps.onBlur);
+  radius,
+  radiusAll,
+  radiusTop,
+  radiusRight,
+  radiusBottom,
+  radiusLeft,
+  ...restProps
+}: BarsProps<AxisScale, AxisScale>) {
+  const isFocusable = Boolean(restProps.onFocus || restProps.onBlur);
   return (
     <>
-      {bars.map(({ key, ...barProps }) => (
-        <rect
-          key={key}
-          className="visx-bar"
-          tabIndex={isFocusable ? 0 : undefined}
-          {...barProps}
-          {...rectProps}
-        />
-      ))}
+      {bars.map(({ key, ...barProps }) =>
+        radius == null ? (
+          <rect
+            key={key}
+            className="visx-bar"
+            tabIndex={isFocusable ? 0 : undefined}
+            {...barProps}
+            {...restProps}
+          />
+        ) : (
+          <BarRounded
+            key={key}
+            className="visx-bar"
+            tabIndex={isFocusable ? 0 : undefined}
+            radius={radius}
+            all={radiusAll}
+            top={radiusTop}
+            right={radiusRight}
+            bottom={radiusBottom}
+            left={radiusLeft}
+            {...barProps}
+            {...restProps}
+          />
+        ),
+      )}
     </>
   );
 }

--- a/packages/visx-xychart/src/components/series/private/BaseBarGroup.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarGroup.tsx
@@ -121,7 +121,7 @@ export default function BaseBarGroup<
 
   const barThickness = getScaleBandwidth(groupScale);
 
-  const bars = registryEntries.flatMap(({ xAccessor, yAccessor, data, key }) => {
+  const barSeries = registryEntries.map(({ xAccessor, yAccessor, data, key }) => {
     const getLength = (d: Datum) =>
       horizontal
         ? (xScale(xAccessor(d)) ?? NaN) - xZeroPosition
@@ -143,41 +143,59 @@ export default function BaseBarGroup<
 
     const getWidth = horizontal ? (d: Datum) => Math.abs(getLength(d)) : () => barThickness;
     const getHeight = horizontal ? () => barThickness : (d: Datum) => Math.abs(getLength(d));
-    const colorAccessor = barSeriesChildren.find((child) => child.props.dataKey === key)?.props
-      ?.colorAccessor;
+    // get props from child BarSeries, if available
+    const childBarSeries:
+      | React.ReactElement<BaseBarSeriesProps<XScale, YScale, Datum>>
+      | undefined = barSeriesChildren.find(child => child.props.dataKey === key);
+    const { colorAccessor, radius, radiusAll, radiusBottom, radiusLeft, radiusRight, radiusTop } =
+      childBarSeries?.props || {};
 
-    return data
-      .map((bar, index) => {
-        const barX = getX(bar);
-        if (!isValidNumber(barX)) return null;
-        const barY = getY(bar);
-        if (!isValidNumber(barY)) return null;
-        const barWidth = getWidth(bar);
-        if (!isValidNumber(barWidth)) return null;
-        const barHeight = getHeight(bar);
-        if (!isValidNumber(barHeight)) return null;
+    return {
+      key,
+      radius,
+      radiusAll,
+      radiusBottom,
+      radiusLeft,
+      radiusRight,
+      radiusTop,
+      bars: data
+        .map((bar, index) => {
+          const barX = getX(bar);
+          if (!isValidNumber(barX)) return null;
+          const barY = getY(bar);
+          if (!isValidNumber(barY)) return null;
+          const barWidth = getWidth(bar);
+          if (!isValidNumber(barWidth)) return null;
+          const barHeight = getHeight(bar);
+          if (!isValidNumber(barHeight)) return null;
 
-        return {
-          key: `${key}-${index}`,
-          x: barX,
-          y: barY,
-          width: barWidth,
-          height: barHeight,
-          fill: colorAccessor?.(bar, index) ?? colorScale(key),
-        };
-      })
-      .filter((bar) => bar) as Bar[];
+          return {
+            key: `${key}-${index}`,
+            x: barX,
+            y: barY,
+            width: barWidth,
+            height: barHeight,
+            fill: colorAccessor?.(bar, index) ?? colorScale(key),
+          };
+        })
+        .filter(bar => bar) as Bar[],
+    };
   });
 
   return (
     <g className="visx-bar-group">
-      <BarsComponent
-        bars={bars}
-        horizontal={horizontal}
-        xScale={xScale}
-        yScale={yScale}
-        {...eventEmitters}
-      />
+      {barSeries.map(
+        series =>
+          series && (
+            <BarsComponent
+              horizontal={horizontal}
+              xScale={xScale}
+              yScale={yScale}
+              {...series}
+              {...eventEmitters}
+            />
+          ),
+      )}
     </g>
   );
 }

--- a/packages/visx-xychart/src/components/series/private/BaseBarGroup.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarGroup.tsx
@@ -146,7 +146,7 @@ export default function BaseBarGroup<
     // get props from child BarSeries, if available
     const childBarSeries:
       | React.ReactElement<BaseBarSeriesProps<XScale, YScale, Datum>>
-      | undefined = barSeriesChildren.find(child => child.props.dataKey === key);
+      | undefined = barSeriesChildren.find((child) => child.props.dataKey === key);
     const { colorAccessor, radius, radiusAll, radiusBottom, radiusLeft, radiusRight, radiusTop } =
       childBarSeries?.props || {};
 
@@ -178,14 +178,14 @@ export default function BaseBarGroup<
             fill: colorAccessor?.(bar, index) ?? colorScale(key),
           };
         })
-        .filter(bar => bar) as Bar[],
+        .filter((bar) => bar) as Bar[],
     };
   });
 
   return (
     <g className="visx-bar-group">
       {barSeries.map(
-        series =>
+        (series) =>
           series && (
             <BarsComponent
               horizontal={horizontal}

--- a/packages/visx-xychart/src/components/series/private/BaseBarSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarSeries.tsx
@@ -24,7 +24,10 @@ export type BaseBarSeriesProps<
   barPadding?: number;
   /** Given a Datum, returns its color. Falls back to theme color if unspecified or if a null-ish value is returned. */
   colorAccessor?: (d: Datum, index: number) => string | null | undefined;
-};
+} & Pick<
+    BarsProps<XScale, YScale>,
+    'radius' | 'radiusAll' | 'radiusTop' | 'radiusRight' | 'radiusBottom' | 'radiusLeft'
+  >;
 
 // Fallback bandwidth estimate assumes no missing data values (divides chart space by # datum)
 const getFallbackBandwidth = (fullBarWidth: number, barPadding: number) =>
@@ -47,6 +50,7 @@ function BaseBarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum
   xScale,
   yAccessor,
   yScale,
+  ...barComponentProps
 }: BaseBarSeriesProps<XScale, YScale, Datum> & WithRegisteredDataProps<XScale, YScale, Datum>) {
   const {
     colorScale,
@@ -122,6 +126,7 @@ function BaseBarSeries<XScale extends AxisScale, YScale extends AxisScale, Datum
         xScale={xScale}
         yScale={yScale}
         {...eventEmitters}
+        {...barComponentProps}
       />
     </g>
   );

--- a/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
@@ -106,10 +106,10 @@ function BaseBarStack<
     allowedSources: [XYCHART_EVENT_SOURCE, ownEventSourceKey],
   });
 
-  const registryEntries = dataKeys.map(key => dataRegistry.get(key));
+  const registryEntries = dataKeys.map((key) => dataRegistry.get(key));
 
   // if scales and data are not available in the registry, bail
-  if (registryEntries.some(entry => entry == null) || !xScale || !yScale || !colorScale) {
+  if (registryEntries.some((entry) => entry == null) || !xScale || !yScale || !colorScale) {
     return null;
   }
 
@@ -147,7 +147,7 @@ function BaseBarStack<
       // get props from child BarSeries, if available
       const childBarSeries:
         | React.ReactElement<BaseBarSeriesProps<XScale, YScale, Datum>>
-        | undefined = seriesChildren.find(child => child.props.dataKey === barStack.key);
+        | undefined = seriesChildren.find((child) => child.props.dataKey === barStack.key);
       const { colorAccessor, radius, radiusAll, radiusBottom, radiusLeft, radiusRight, radiusTop } =
         childBarSeries?.props || {};
 
@@ -184,15 +184,15 @@ function BaseBarStack<
                   : colorScale(barStack.key),
             };
           })
-          .filter(bar => bar) as Bar[],
+          .filter((bar) => bar) as Bar[],
       };
     })
-    .filter(series => series);
+    .filter((series) => series);
 
   return (
     <g className="visx-bar-stack">
       {barSeries.map(
-        series =>
+        (series) =>
           series && (
             <BarsComponent
               horizontal={horizontal}

--- a/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
@@ -106,8 +106,10 @@ function BaseBarStack<
     allowedSources: [XYCHART_EVENT_SOURCE, ownEventSourceKey],
   });
 
+  const registryEntries = dataKeys.map(key => dataRegistry.get(key));
+
   // if scales and data are not available in the registry, bail
-  if (dataKeys.some((key) => dataRegistry.get(key) == null) || !xScale || !yScale || !colorScale) {
+  if (registryEntries.some(entry => entry == null) || !xScale || !yScale || !colorScale) {
     return null;
   }
 
@@ -137,52 +139,70 @@ function BaseBarStack<
     getY = (bar) => yScale(getSecondItem(bar));
   }
 
-  const bars = stackedData
-    .flatMap((barStack, stackIndex) => {
+  const barSeries = stackedData
+    .map((barStack, stackIndex) => {
       const entry = dataRegistry.get(barStack.key);
       if (!entry) return null;
 
-      // get colorAccessor from child BarSeries, if available
-      const barSeries: React.ReactElement<BaseBarSeriesProps<XScale, YScale, Datum>> | undefined =
-        seriesChildren.find((child) => child.props.dataKey === barStack.key);
-      const colorAccessor = barSeries?.props?.colorAccessor;
+      // get props from child BarSeries, if available
+      const childBarSeries:
+        | React.ReactElement<BaseBarSeriesProps<XScale, YScale, Datum>>
+        | undefined = seriesChildren.find(child => child.props.dataKey === barStack.key);
+      const { colorAccessor, radius, radiusAll, radiusBottom, radiusLeft, radiusRight, radiusTop } =
+        childBarSeries?.props || {};
 
-      return barStack.map((bar, index) => {
-        const barX = getX(bar);
-        if (!isValidNumber(barX)) return null;
-        const barY = getY(bar);
-        if (!isValidNumber(barY)) return null;
-        const barWidth = getWidth(bar);
-        if (!isValidNumber(barWidth)) return null;
-        const barHeight = getHeight(bar);
-        if (!isValidNumber(barHeight)) return null;
+      return {
+        key: barStack.key,
+        radius,
+        radiusAll,
+        radiusBottom,
+        radiusLeft,
+        radiusRight,
+        radiusTop,
+        bars: barStack
+          .map((bar, index) => {
+            const barX = getX(bar);
+            if (!isValidNumber(barX)) return null;
+            const barY = getY(bar);
+            if (!isValidNumber(barY)) return null;
+            const barWidth = getWidth(bar);
+            if (!isValidNumber(barWidth)) return null;
+            const barHeight = getHeight(bar);
+            if (!isValidNumber(barHeight)) return null;
 
-        const barSeriesDatum = colorAccessor ? barSeries?.props?.data[index] : null;
+            const barSeriesDatum = colorAccessor ? childBarSeries?.props?.data[index] : null;
 
-        return {
-          key: `${stackIndex}-${barStack.key}-${index}`,
-          x: barX,
-          y: barY,
-          width: barWidth,
-          height: barHeight,
-          fill:
-            barSeriesDatum && colorAccessor
-              ? colorAccessor(barSeriesDatum, index)
-              : colorScale(barStack.key),
-        };
-      });
+            return {
+              key: `${stackIndex}-${barStack.key}-${index}`,
+              x: barX,
+              y: barY,
+              width: barWidth,
+              height: barHeight,
+              fill:
+                barSeriesDatum && colorAccessor
+                  ? colorAccessor(barSeriesDatum, index)
+                  : colorScale(barStack.key),
+            };
+          })
+          .filter(bar => bar) as Bar[],
+      };
     })
-    .filter((bar) => bar) as Bar[];
+    .filter(series => series);
 
   return (
     <g className="visx-bar-stack">
-      <BarsComponent
-        bars={bars}
-        horizontal={horizontal}
-        xScale={xScale}
-        yScale={yScale}
-        {...eventEmitters}
-      />
+      {barSeries.map(
+        series =>
+          series && (
+            <BarsComponent
+              horizontal={horizontal}
+              xScale={xScale}
+              yScale={yScale}
+              {...series}
+              {...eventEmitters}
+            />
+          ),
+      )}
     </g>
   );
 }

--- a/packages/visx-xychart/src/types/series.ts
+++ b/packages/visx-xychart/src/types/series.ts
@@ -107,9 +107,9 @@ export type Bar = {
   x: number;
   /** Y coordinate of Bar. */
   y: number;
-  /** Width coordinate of Bar. */
+  /** Width of Bar. */
   width: number;
-  /** Height coordinate of Bar. */
+  /** Height of Bar. */
   height: number;
   /** Fill color of Bar */
   fill?: string;
@@ -121,7 +121,22 @@ export type BarsProps<XScale extends AxisScale, YScale extends AxisScale> = {
   xScale: XScale;
   yScale: YScale;
   horizontal?: boolean;
-} & Omit<React.SVGProps<SVGRectElement>, 'x' | 'y' | 'width' | 'height' | 'ref'>;
+  /** Optional radius to apply to bar corners. */
+  radius?: number;
+  /** Whether to apply radius to all corners. */
+  radiusAll?: boolean;
+  /** Whether to apply radius to top corners. */
+  radiusTop?: boolean;
+  /** Whether to apply radius to right corners. */
+  radiusRight?: boolean;
+  /** Whether to apply radius to bottom corners. */
+  radiusBottom?: boolean;
+  /** Whether to apply radius to left corners. */
+  radiusLeft?: boolean;
+} & Omit<
+  React.SVGProps<SVGRectElement | SVGPathElement>,
+  'x' | 'y' | 'width' | 'height' | 'ref' | 'children'
+>;
 
 // BarStack transforms its child series Datum into CombinedData<XScale, YScale>
 export type BarStackDatum<XScale extends AxisScale, YScale extends AxisScale> = SeriesPoint<

--- a/packages/visx-xychart/test/components/BarGroup.test.tsx
+++ b/packages/visx-xychart/test/components/BarGroup.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../src';
 import setupTooltipTest from '../mocks/setupTooltipTest';
 import { XYCHART_EVENT_SOURCE } from '../../src/constants';
+import { BarRounded } from '@visx/shape';
 
 const providerProps = {
   initialDimensions: { width: 100, height: 100 },
@@ -64,6 +65,20 @@ describe('<BarGroup />', () => {
       </DataProvider>,
     );
     expect(container.querySelectorAll('rect')).toHaveLength(4);
+  });
+
+  it('should render BarRounded if radius is set', () => {
+    const wrapper = mount(
+      <DataProvider {...providerProps}>
+        <svg>
+          <BarGroup>
+            <BarSeries dataKey={series1.key} radiusAll radius={4} {...series1} />
+            <BarSeries dataKey={series2.key} {...series2} />
+          </BarGroup>
+        </svg>
+      </DataProvider>,
+    );
+    expect(wrapper.find(BarRounded)).toHaveLength(2);
   });
 
   it('should use colorAccessor if passed', () => {

--- a/packages/visx-xychart/test/components/BarGroup.test.tsx
+++ b/packages/visx-xychart/test/components/BarGroup.test.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../src';
 import setupTooltipTest from '../mocks/setupTooltipTest';
 import { XYCHART_EVENT_SOURCE } from '../../src/constants';
-import { BarRounded } from '@visx/shape';
 
 const providerProps = {
   initialDimensions: { width: 100, height: 100 },
@@ -68,7 +67,7 @@ describe('<BarGroup />', () => {
   });
 
   it('should render BarRounded if radius is set', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarGroup>
@@ -78,7 +77,7 @@ describe('<BarGroup />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find(BarRounded)).toHaveLength(2);
+    expect(container.querySelectorAll('path')).toHaveLength(2);
   });
 
   it('should use colorAccessor if passed', () => {

--- a/packages/visx-xychart/test/components/BarSeries.test.tsx
+++ b/packages/visx-xychart/test/components/BarSeries.test.tsx
@@ -30,6 +30,17 @@ describe('<BarSeries />', () => {
     expect(container.querySelectorAll('rect')).toHaveLength(2);
   });
 
+  it('should render rounded rects if radius is set', () => {
+    const { container } = render(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <BarSeries dataKey={series.key} radiusAll radius={4} {...series} />
+        </svg>
+      </DataContext.Provider>,
+    );
+    expect(container.querySelectorAll('path')).toHaveLength(2);
+  });
+
   it('should use colorAccessor if passed', () => {
     const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>

--- a/packages/visx-xychart/test/components/BarStack.test.tsx
+++ b/packages/visx-xychart/test/components/BarStack.test.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../src';
 import setupTooltipTest from '../mocks/setupTooltipTest';
 import { XYCHART_EVENT_SOURCE } from '../../src/constants';
-import { BarRounded } from '@visx/shape';
 
 const providerProps = {
   initialDimensions: { width: 100, height: 100 },
@@ -68,7 +67,7 @@ describe('<BarStack />', () => {
   });
 
   it('should render BarRounded if radius is set', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarStack>
@@ -78,7 +77,7 @@ describe('<BarStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find(BarRounded)).toHaveLength(2);
+    expect('path').toHaveLength(2);
   });
 
   it('should use colorAccessor if passed', () => {

--- a/packages/visx-xychart/test/components/BarStack.test.tsx
+++ b/packages/visx-xychart/test/components/BarStack.test.tsx
@@ -77,7 +77,7 @@ describe('<BarStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect('path').toHaveLength(2);
+    expect(container.querySelectorAll('path')).toHaveLength(2);
   });
 
   it('should use colorAccessor if passed', () => {

--- a/packages/visx-xychart/test/components/BarStack.test.tsx
+++ b/packages/visx-xychart/test/components/BarStack.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../src';
 import setupTooltipTest from '../mocks/setupTooltipTest';
 import { XYCHART_EVENT_SOURCE } from '../../src/constants';
+import { BarRounded } from '@visx/shape';
 
 const providerProps = {
   initialDimensions: { width: 100, height: 100 },
@@ -64,6 +65,20 @@ describe('<BarStack />', () => {
     );
     const RectElements = container.querySelectorAll('rect');
     expect(RectElements).toHaveLength(4);
+  });
+
+  it('should render BarRounded if radius is set', () => {
+    const wrapper = mount(
+      <DataProvider {...providerProps}>
+        <svg>
+          <BarStack>
+            <BarSeries dataKey={series1.key} radiusAll radius={4} {...series1} />
+            <BarSeries dataKey={series2.key} {...series2} />
+          </BarStack>
+        </svg>
+      </DataProvider>,
+    );
+    expect(wrapper.find(BarRounded)).toHaveLength(2);
   });
 
   it('should use colorAccessor if passed', () => {


### PR DESCRIPTION
#### :rocket: Enhancements

This builds on #1097, and adds support for rounded `BarSeries` bars in `@visx/xychart` (including as children of `BarGroup`, `BarStack`) through the `radius`/`radiusAll`/`radiusTop`/`radiusBottom`/`radiusLeft`/`radiusRight` props. 

Note that when a `radius` is specified, the bar will be rendered with a `path` instead of a `rect`. I'm debating about **always** rendering a `BarRounded` (even if `radius=0`) for consistency, but I think 
- that would be a breaking change
- `path`s currently cannot animate on entrance `0 => value` (same for lines/areas right now) while `rect`s can. I think this is a limitation of `d3-interpolate-path`.

Closes #1092 and #1093.


Note that if users want full control over rendering bars (discussed in #1092), they can import `@visx/xychart/lib/components/series/private/BaseBarSeries` and specify a `BarsComponent`.


**BarSeries**
```tsx
<BarSeries radius={4} radiusRight {...} />
```
<img src="https://user-images.githubusercontent.com/4496521/110173757-f18b7a80-7db3-11eb-99cf-58432b11eaa2.png" width="500" />

**BarStack**
```tsx
<BarStack {...}>
   <BarSeries radius={6} radiusTop {...} />
   <BarSeries {...} />
   <BarSeries radius={6} radiusBottom {...} />
</BarStack>
```
<img src="https://user-images.githubusercontent.com/4496521/110174583-2c41e280-7db5-11eb-976f-3f3618d49c6e.png" width="500" />

**BarGroup**
```tsx
<BarGroup {...}>
   <BarSeries radius={4} radiusTop {...} />
</BarGroup>
```
<img src="https://user-images.githubusercontent.com/4496521/110173451-74600580-7db3-11eb-9f5c-b2fea63cd07d.png" width="500" />

@kristw @hshoff 
cc @tonyneel923 @goldenivan
