### PR TITLE
fix(xychart/Tooltip): don't render glyph for null data

### DIFF
--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -189,9 +189,12 @@ export default function Tooltip<Datum extends object>({
       });
     } else if (nearestDatum) {
       const { left, top } = getDatumLeftTop(nearestDatumKey, nearestDatum.datum);
+      // don't show glyphs if coords are unavailable
+      if (!isValidNumber(left) || !isValidNumber(top)) return;
+
       glyphProps.push({
-        left: (left ?? 0) - radius - strokeWidth,
-        top: (top ?? 0) - radius - strokeWidth,
+        left: left - radius - strokeWidth,
+        top: top - radius - strokeWidth,
         fill:
           (nearestDatumKey && colorScale?.(nearestDatumKey)) ??
           null ??

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -190,20 +190,20 @@ export default function Tooltip<Datum extends object>({
     } else if (nearestDatum) {
       const { left, top } = getDatumLeftTop(nearestDatumKey, nearestDatum.datum);
       // don't show glyphs if coords are unavailable
-      if (!isValidNumber(left) || !isValidNumber(top)) return;
-
-      glyphProps.push({
-        left: left - radius - strokeWidth,
-        top: top - radius - strokeWidth,
-        fill:
-          (nearestDatumKey && colorScale?.(nearestDatumKey)) ??
-          null ??
-          theme?.gridStyles?.stroke ??
-          theme?.htmlLabel?.color ??
-          '#222',
-        radius,
-        strokeWidth,
-      });
+      if (isValidNumber(left) && isValidNumber(top)) {
+        glyphProps.push({
+          left: left - radius - strokeWidth,
+          top: top - radius - strokeWidth,
+          fill:
+            (nearestDatumKey && colorScale?.(nearestDatumKey)) ??
+            null ??
+            theme?.gridStyles?.stroke ??
+            theme?.htmlLabel?.color ??
+            '#222',
+          radius,
+          strokeWidth,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
#### :bug: Bug Fix

This fixes an issue that was missed in #1068 when rendering tooltips for missing data. That PR fixed the case where tooltip circles are not rendered for shared tooltips (multiple series in the tooltip) but not the single-series tooltiip:

**Before**
<img src="https://user-images.githubusercontent.com/4496521/110874489-a926fd80-8288-11eb-9784-5d7865b9ac2d.png" width="300" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/110874687-0d49c180-8289-11eb-9f5e-151e0e535bb0.png" width="300" />

@kristw @etr2460