### PR TITLE
Export types in @visx/text

### DIFF
--- a/packages/visx-text/src/index.ts
+++ b/packages/visx-text/src/index.ts
@@ -1,3 +1,4 @@
 export { default as Text } from './Text';
 export { default as getStringWidth } from './util/getStringWidth';
 export { default as useText } from './hooks/useText';
+export * from './types';


### PR DESCRIPTION
Currently @visx/text does not export its types. So the following does not work:
`import { TextProps } from '@visx/text';`

This PR adds the exporting of those types.

Ugly work-around until then:
```
import { Text } from '@visx/text';
Parameters<typeof Text>[0]>
```