### PR TITLE
internal(workflows/release): add next dist-tag, fix lerna releases

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # checkout visx + this commit
+        with:
+        # pulls all commits (needed for lerna to correctly release only changed packages)
+        fetch-depth: '0'
       - uses: actions/setup-node@v2
         with:
           node-version: '12'

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -34,10 +34,13 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
       isMajor ? 'major' : isMinor ? 'minor' : 'patch'
     }`;
 
+    const distTag = isPreRelease ? 'next' : 'latest';
+
     console.log(`Attempting to publish a '${version}' release.`);
 
     const { stdout, stderr } = await exec(
-      `npx lerna publish ${version} --exact --yes --no-verify-access`,
+      // --no-verify-access is needed because the CI token isn't valid for that endpoint
+      `npx lerna publish ${version} --exact --yes --no-verify-access --dist-tag ${distTag}`,
     );
     if (stdout) {
       console.log('Lerna output', stdout);


### PR DESCRIPTION
#### :house: Internal

This attempts to fix a couple issues with the github actions push release workflow:

- Specifies a [`--dist-tag`](https://github.com/lerna/lerna/tree/main/commands/publish#--dist-tag-tag) for `lerna` releases. Currently this is always `latest`, which we don't want for alpha releases since it would make the alpha pre-release the default download
- Currently lerna is bumping/releasing **all** packages for each release, even if packages have not changed. I found [this issue](https://github.com/lerna/lerna/issues/2542) with a tip for why this happens, hoping it'll clear it up. 
  - **tl;dr** `actions/checkout@v2` only fetches the most recent commits by default, which makes lerna think it needs to publish all packages because it doesn't have the context of previous releases

**Issue before**
![image](https://user-images.githubusercontent.com/4496521/111050727-342c0300-8403-11eb-969c-23c85bf50594.png)


@kristw @hshoff 
