### PR TITLE
fix(brush/BrushHandle): prevent BrushHandle to trigger dragEnd onMouseLeave

### DIFF
--- a/packages/visx-brush/src/BrushHandle.tsx
+++ b/packages/visx-brush/src/BrushHandle.tsx
@@ -131,7 +131,6 @@ export default class BrushHandle extends React.Component<BrushHandleProps> {
                 style={{ cursor }}
                 onMouseMove={dragMove}
                 onMouseUp={dragEnd}
-                onMouseLeave={dragEnd}
               />
             )}
             <rect


### PR DESCRIPTION
#### :bug: Bug Fix

- This PR tries to solve https://github.com/airbnb/visx/issues/1109

I'm not sure if this `onMouseLeave` event is crucial for some other use case, but it looks like this new behavior is a bit more similar to the behavior in `BaseBrush`.