### PR TITLE
fix(xychart/TooltipProvider): handles NaNs in nearestDatum logic

### DIFF
--- a/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
@@ -51,6 +51,7 @@ describe('<TooltipProvider />', () => {
             key: 'far',
             index: 1,
             datum: { good: 'bye' },
+            distanceX: NaN,
             // no distance = Infinity
           });
         }


### PR DESCRIPTION
#### :bug: Bug Fix

This fixes an issue with `NaN` / missing data in the `TooltipProvider` layer. Previously if there were multiple series and one had a missing value, the `Tooltip` would get "stuck" in the missing data series regardless of mouse position. This fixes the logic and adds tests for it.

**Before**
Note: mouse is near the green line, but tooltip is stuck in the missing yellow / SF line.
![image](https://user-images.githubusercontent.com/4496521/111380604-cf221880-8661-11eb-86e1-92a0df218e5a.png)

**After**
Note: mouse is near the green line without missing data, and so is the tooltip
![image](https://user-images.githubusercontent.com/4496521/111380381-836f6f00-8661-11eb-862c-b3a0fa93c62e.png)

Also note that this is mostly for the overall `nearestDatum` calculation, the nearest datum for each series are still available in the tooltip callback
![image](https://user-images.githubusercontent.com/4496521/111380873-288a4780-8662-11eb-84de-287d008d9016.png)


@kristw @hshoff 