### PR TITLE
fix(scripts/performRelease): add comment, fix typo

### DIFF
--- a/scripts/performRelease/index.ts
+++ b/scripts/performRelease/index.ts
@@ -46,7 +46,7 @@ async function performRelease() {
     commitsSinceTag.map(commit => commit.sha),
   );
 
-  const isPrelease = await performLernaRelease(prsSinceLastTag);
+  const isPreRelease = await performLernaRelease(prsSinceLastTag);
 
   const newTagsRequest = await fetchTags(client);
   const newTag = newTagsRequest.data[0];
@@ -56,8 +56,8 @@ async function performRelease() {
     process.exit(0);
   }
 
-  // update changelog
-  if (!isPrelease) {
+  // update changelog only for non-pre-releases
+  if (!isPreRelease) {
     await updateChangelog(prsSinceLastTag, newTag.name);
   }
 

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -19,6 +19,9 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
 
   // run lerna based on the type of release
   const isPreRelease = releasePRsSinceLastTag.some(pr =>
+    // note that this logic requires that all alpha tags be removed from PRs
+    // in order to trigger a non-alpha release. git keeps tag history so
+    // preserving context should not be an issue
     pr.labels.some(label => label.name === ALPHA_RELEASE),
   );
   const isMinor = releasePRsSinceLastTag.some(pr =>


### PR DESCRIPTION
#### :house: Internal

This is mostly a PR to trigger a non-`alpha-release`, because of an implication of the release flow I hadn't fully internalized (and rather than committing something random, I added a comment about this implication to the release script 😄 ):

_If there are any PRs since the last tag which have an `alpha-release` label, the release will be an `alpha-release`_ 
(#1107 had this tag and thus the release was an alpha, I've since removed that tag). Here's an example

- `tag @ whatever` created
- Merge PR 1 tagged `alpha-release` + `patch-release` => triggers `alpha patch`
- Merge PR 2 tagged `minor-release` => triggers `alpha minor`
- Remove `alpha-release` from PR 1
- Merge PR 3 tagged `patch-release` => triggers `non-alpha minor` (`minor` required from PR 2)

The alternative I think is to perform a non-alpha release if there are PRs that are merged _after_ the `alpha-release`-tagged PR (in the example above, that would mean after PR 2 is merged, a `minor` release would be triggered). This seems like it could lead to unintentional non-`alpha-release`s if multiple people are merging things, so simply requiring the removal of `alpha-release` tags seems safer to me. Note in the example above, if you wanted PR 2 to trigger a `minor` release, you would just need to remove the alpha label from PR 1 prior to merging. 

Open to feedback tho!

@kristw @hshoff 
