### PR TITLE
fix(visx/annotation) Improve label positioning, add maxWidth

### DIFF
--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -101,10 +101,8 @@ export default function Label({
     padding.top + padding.bottom + (titleBounds.height ?? 0) + (subtitleBounds.height ?? 0),
   );
 
-  const measuredWidth = padding.right + padding.left + Math.max(
-    titleBounds.width ?? 0 ,
-    subtitleBounds.width ?? 0
-  );
+  const measuredWidth =
+    padding.right + padding.left + Math.max(titleBounds.width ?? 0, subtitleBounds.width ?? 0);
   const width = propWidth ?? measuredWidth;
   const innerWidth = (width ?? measuredWidth) - padding.left - padding.right;
 

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -128,16 +128,16 @@ export default function Label({
   });
 
   const titleMeasuredWidth = titleWordsByLine.reduce(
-    (maxWidth, line) => Math.max(maxWidth, line.width ?? 0),
+    (maxTitleWidth, line) => Math.max(maxTitleWidth, line.width ?? 0),
     0,
   );
 
   const subtitleMeasuredWidth = subtitleWordsByLine.reduce(
-    (maxWidth, line) => Math.max(maxWidth, line.width ?? 0),
+    (maxSubtitleWidth, line) => Math.max(maxSubtitleWidth, line.width ?? 0),
     0,
   );
 
-  const textMeasuredWidth = Math.max(titleMeasuredWidth, subtitleMeasuredWidth);
+  const textMeasuredWidth = Math.floor(Math.min(maxWidth, Math.max(titleMeasuredWidth, subtitleMeasuredWidth)));
   const measuredWidth = padding.right + padding.left + textMeasuredWidth;
   const width = propWidth ?? measuredWidth;
   const innerWidth = width - padding.left - padding.right;

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -137,7 +137,9 @@ export default function Label({
     0,
   );
 
-  const textMeasuredWidth = Math.floor(Math.min(maxWidth, Math.max(titleMeasuredWidth, subtitleMeasuredWidth)));
+  const textMeasuredWidth = Math.floor(
+    Math.min(maxWidth, Math.max(titleMeasuredWidth, subtitleMeasuredWidth)),
+  );
   const measuredWidth = padding.right + padding.left + textMeasuredWidth;
   const width = propWidth ?? measuredWidth;
   const innerWidth = width - padding.left - padding.right;

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -89,7 +89,7 @@ export default function Label({
   titleProps,
   verticalAnchor: propsVerticalAnchor,
   width: propWidth,
-  maxWidth = 120,
+  maxWidth = 125,
   x: propsX,
   y: propsY,
 }: LabelProps) {

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -96,7 +96,7 @@ export default function Label({
   // we must measure the rendered title + subtitle to compute container height
   const [titleRef, titleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
   const [subtitleRef, subtitleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
-  
+
   const padding = useMemo(() => getCompletePadding(backgroundPadding), [backgroundPadding]);
 
   // if props are provided, they take precedence over context
@@ -104,10 +104,10 @@ export default function Label({
   const height = Math.floor(
     padding.top + padding.bottom + (titleBounds.height ?? 0) + (subtitleBounds.height ?? 0),
   );
-  
+
   const { wordsByLines: titleWordsByLine } = useText({
     children: title,
-    verticalAnchor: "start",
+    verticalAnchor: 'start',
     capHeight: titleFontSize,
     fontSize: titleFontSize,
     fontWeight: titleFontWeight,
@@ -115,10 +115,10 @@ export default function Label({
     width: maxWidth,
     ...titleProps,
   });
-  
+
   const { wordsByLines: subtitleWordsByLine } = useText({
     children: subtitle,
-    verticalAnchor: "start",
+    verticalAnchor: 'start',
     capHeight: subtitleFontSize,
     fontSize: subtitleFontSize,
     fontWeight: subtitleFontWeight,
@@ -126,20 +126,18 @@ export default function Label({
     width: maxWidth,
     ...subtitleProps,
   });
-  
-  const titleMeasuredWidth = titleWordsByLine
-    .reduce(
-      (maxWidth, line) => Math.max(maxWidth, line.width ?? 0),
-      0
-    )
-  
-  const subtitleMeasuredWidth = subtitleWordsByLine
-    .reduce(
-      (maxWidth, line) => Math.max(maxWidth, line.width ?? 0),
-      0
-    )
-  
-  const textMeasuredWidth = Math.max(titleMeasuredWidth, subtitleMeasuredWidth)
+
+  const titleMeasuredWidth = titleWordsByLine.reduce(
+    (maxWidth, line) => Math.max(maxWidth, line.width ?? 0),
+    0,
+  );
+
+  const subtitleMeasuredWidth = subtitleWordsByLine.reduce(
+    (maxWidth, line) => Math.max(maxWidth, line.width ?? 0),
+    0,
+  );
+
+  const textMeasuredWidth = Math.max(titleMeasuredWidth, subtitleMeasuredWidth);
   const measuredWidth = padding.right + padding.left + textMeasuredWidth;
   const width = propWidth ?? measuredWidth;
   const innerWidth = width - padding.left - padding.right;

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -85,14 +85,14 @@ export default function Label({
   titleFontWeight = 600,
   titleProps,
   verticalAnchor: propsVerticalAnchor,
-  width = 125,
+  width: propWidth,
   x: propsX,
   y: propsY,
 }: LabelProps) {
   // we must measure the rendered title + subtitle to compute container height
   const [titleRef, titleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
   const [subtitleRef, subtitleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
-
+  
   const padding = useMemo(() => getCompletePadding(backgroundPadding), [backgroundPadding]);
 
   // if props are provided, they take precedence over context
@@ -100,14 +100,20 @@ export default function Label({
   const height = Math.floor(
     padding.top + padding.bottom + (titleBounds.height ?? 0) + (subtitleBounds.height ?? 0),
   );
-  const innerWidth = width - padding.left - padding.right;
+
+  const measuredWidth = padding.right + padding.left + Math.max(
+    titleBounds.width ?? 0 ,
+    subtitleBounds.width ?? 0
+  );
+  const width = propWidth ?? measuredWidth;
+  const innerWidth = (width ?? measuredWidth) - padding.left - padding.right;
 
   // offset container position based on horizontal + vertical anchor
   const horizontalAnchor =
     propsHorizontalAnchor || (Math.abs(dx) < Math.abs(dy) ? 'middle' : dx > 0 ? 'start' : 'end');
   const verticalAnchor =
     propsVerticalAnchor || (Math.abs(dx) > Math.abs(dy) ? 'middle' : dy > 0 ? 'start' : 'end');
-
+  
   const containerCoords = useMemo(() => {
     let adjustedX: number = propsX == null ? x + dx : propsX;
     let adjustedY: number = propsY == null ? y + dy : propsY;

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -92,7 +92,7 @@ export default function Label({
   // we must measure the rendered title + subtitle to compute container height
   const [titleRef, titleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
   const [subtitleRef, subtitleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
-  
+
   const padding = useMemo(() => getCompletePadding(backgroundPadding), [backgroundPadding]);
 
   // if props are provided, they take precedence over context
@@ -113,7 +113,7 @@ export default function Label({
     propsHorizontalAnchor || (Math.abs(dx) < Math.abs(dy) ? 'middle' : dx > 0 ? 'start' : 'end');
   const verticalAnchor =
     propsVerticalAnchor || (Math.abs(dx) > Math.abs(dy) ? 'middle' : dy > 0 ? 'start' : 'end');
-  
+
   const containerCoords = useMemo(() => {
     let adjustedX: number = propsX == null ? x + dx : propsX;
     let adjustedY: number = propsY == null ? y + dy : propsY;


### PR DESCRIPTION
#### :boom: Breaking Changes
- Possible breaking change (remove default value of width at label component from @visx/annotation)

#### :bug: Bug Fix
- Fixes https://github.com/airbnb/visx/issues/1126

This PR is trying to improve horizontal label positioning at @visx/annotation package.  

Info from https://github.com/airbnb/visx/issues/1126

> Label component from @visx/annotation is trying to calculate right position for text within component according x,y,dx and dy props. But this component does’t take into account real width of text element

TLDR; This fix has added real width measures by `useMeasures` hook and now label component does calculation according real width and paddings value as well.
**Examples**

Problem - Bad label positioning example
https://codesandbox.io/s/bold-antonelli-0v17h?file=/src/pie-chart.tsx
GitHub repo branch https://github.com/vovakulikov/chart-grid-sandbox/tree/bad-label-positioning-example

**Example with fix** label position  https://codesandbox.io/s/focused-https-mvvjn
Github repo branch https://github.com/vovakulikov/chart-grid-sandbox/tree/label-positioning-with-annotation-fix
