### PR TITLE
fix(xychart): onPointerUp fires twice

### DIFF
--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -159,7 +159,7 @@ export default function XYChart<
     );
   }
 
-// EventEmitterProvider should be the last wrapper so we do not duplicate handlers
+  // EventEmitterProvider should be the last wrapper so we do not duplicate handlers
   if (emit == null) {
     return (
       <EventEmitterProvider>

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -150,7 +150,7 @@ export default function XYChart<
       </ParentSize>
     );
   }
- 
+
   if (tooltipContext == null) {
     return (
       <TooltipProvider>

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -159,6 +159,7 @@ export default function XYChart<
     );
   }
 
+// EventEmitterProvider should be the last wrapper so we do not duplicate handlers
   if (emit == null) {
     return (
       <EventEmitterProvider>

--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -150,18 +150,20 @@ export default function XYChart<
       </ParentSize>
     );
   }
-  if (emit == null) {
-    return (
-      <EventEmitterProvider>
-        <XYChart {...props} />
-      </EventEmitterProvider>
-    );
-  }
+ 
   if (tooltipContext == null) {
     return (
       <TooltipProvider>
         <XYChart {...props} />
       </TooltipProvider>
+    );
+  }
+
+  if (emit == null) {
+    return (
+      <EventEmitterProvider>
+        <XYChart {...props} />
+      </EventEmitterProvider>
     );
   }
 


### PR DESCRIPTION
#### :bug: Bug Fix

- Fixes https://github.com/airbnb/visx/issues/1077

**Root cause of problem:**
Because xychart doesn't require from consumers wrap himself with all contexts (DataContext, EventEmmiterContext) xychart wraps himself recursively 

https://github.com/airbnb/visx/blob/c21e48bc2307557dc5560cd0f88014769d1ee5ac/packages/visx-xychart/src/components/XYChart.tsx#L153-L166

Which is good but here is a small problem. A bit early in this component we call `useEventHandlers` hook just to add consumer's handlers to our events from our EventEmmitter context emitter 

https://github.com/airbnb/visx/blob/c21e48bc2307557dc5560cd0f88014769d1ee5ac/packages/visx-xychart/src/components/XYChart.tsx#L112-L118


And this is a call tree how I understand that 

- call XYChart for the first time
  - call useEventHandlers (nothing happens because we don't have event emitter context for now)
  - XYChart wraps himself by EventEmmiterContext  (which leads to the second call of this component)
       - call XYChart a second time 
       - call useEventHandlers (write now we have context so we add some handlers to emitter context)
       - XYChart wraps himself by TooltipContext (which leads to the third call of this component)
           - call XYChart the third time  
           - **ROOT CAUSE OF PROBLEM** => call useEventHandlers (in this place we double our handlers from consumers )
  
  
So as a result if we what to be sure that we add consumer's handlers only once we have to put EventEmmiterContext wrap logic in XYChart component in the last order. 