### PR TITLE
new(shape/Polygon): add optional 'points' override

### DIFF
--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -6,8 +6,8 @@ import { AddSVGProps } from '../types';
 const DEFAULT_CENTER = { x: 0, y: 0 };
 
 export const getPoint = ({
-  sides,
-  size,
+  sides = 4,
+  size = 25,
   center = DEFAULT_CENTER,
   rotate = 0,
   side,
@@ -26,7 +26,7 @@ export const getPoints = ({
   size,
   center,
   rotate,
-}: Pick<PolygonProps, 'sides' | 'size' | 'center' | 'rotate'>) =>
+}: NonNullable<Pick<PolygonProps, 'sides' | 'size' | 'center' | 'rotate'>>) =>
   new Array(sides).fill(0).map((_, side) =>
     getPoint({
       sides,
@@ -78,7 +78,7 @@ export default function Polygon({
   }).map(({ x, y }) => [x, y]);
 
   // eslint-disable-next-line react/jsx-no-useless-fragment
-  if (children) return <>{children({ points })}</>;
+  if (children) return <>{children({ points: pointsToRender })}</>;
 
   return (
     <polygon

--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -11,7 +11,7 @@ export const getPoint = ({
   center = DEFAULT_CENTER,
   rotate = 0,
   side,
-}: { side: number } & Pick<PolygonProps, 'sides' | 'size' | 'center' | 'rotate'>) => {
+}: { side: number } & NonNullable<Pick<PolygonProps, 'sides' | 'size' | 'center' | 'rotate'>>) => {
   const degrees = (360 / sides) * side - rotate;
   const radians = degreesToRadians(degrees);
 

--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -67,7 +67,7 @@ export default function Polygon({
   className,
   children,
   innerRef,
-  points = null,
+  points,
   ...restProps
 }: AddSVGProps<PolygonProps, SVGPolygonElement>) {
   const pointsToRender: [number, number][] = points ? points : getPoints({

--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -60,14 +60,14 @@ export type PolygonProps = {
 };
 
 export default function Polygon({
-  sides,
+  sides = 4,
   size = 25,
   center = DEFAULT_CENTER,
   rotate = 0,
   className,
   children,
   innerRef,
-  points,
+  points = null,
   ...restProps
 }: AddSVGProps<PolygonProps, SVGPolygonElement>) {
   const pointsToRender: [number, number][] = points ? points : getPoints({

--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -39,10 +39,12 @@ export const getPoints = ({
 
 export type PolygonProps = {
   /** Number of polygon sides. */
-  sides: number;
+  sides?: number;
   /** Size of the shape. */
-  size: number;
+  size?: number;
   /** className to apply to polygon element. */
+  /** Points to use to render the polygon. If this is defined, `sides`, `size`, `rotate`, and `center` are ignored. */
+  points?: [number, number][];
   className?: string;
   /** Rotation transform to apply to polygon. */
   rotate?: number;
@@ -65,9 +67,10 @@ export default function Polygon({
   className,
   children,
   innerRef,
+  points,
   ...restProps
 }: AddSVGProps<PolygonProps, SVGPolygonElement>) {
-  const points: [number, number][] = getPoints({
+  const pointsToRender: [number, number][] = points ? points : getPoints({
     sides,
     size,
     center,
@@ -81,7 +84,7 @@ export default function Polygon({
     <polygon
       ref={innerRef}
       className={cx('visx-polygon', className)}
-      points={points.join(' ')}
+      points={pointsToRender.join(' ')}
       {...restProps}
     />
   );

--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -70,12 +70,14 @@ export default function Polygon({
   points,
   ...restProps
 }: AddSVGProps<PolygonProps, SVGPolygonElement>) {
-  const pointsToRender: [number, number][] = points ? points : getPoints({
-    sides,
-    size,
-    center,
-    rotate,
-  }).map(({ x, y }) => [x, y]);
+  const pointsToRender: [number, number][] =
+    points ||
+    getPoints({
+      sides,
+      size,
+      center,
+      rotate,
+    }).map(({ x, y }) => [x, y]);
 
   // eslint-disable-next-line react/jsx-no-useless-fragment
   if (children) return <>{children({ points: pointsToRender })}</>;

--- a/packages/visx-shape/src/shapes/Polygon.tsx
+++ b/packages/visx-shape/src/shapes/Polygon.tsx
@@ -42,9 +42,9 @@ export type PolygonProps = {
   sides?: number;
   /** Size of the shape. */
   size?: number;
-  /** className to apply to polygon element. */
   /** Points to use to render the polygon. If this is defined, `sides`, `size`, `rotate`, and `center` are ignored. */
   points?: [number, number][];
+  /** className to apply to polygon element. */
   className?: string;
   /** Rotation transform to apply to polygon. */
   rotate?: number;


### PR DESCRIPTION
#### :rocket: Enhancements

- The Polygon component can now accept `points` as a field to override its functionality for generating the points based on the `size`, `sides` and `center` props. This allows users of the library to leverage the underlying `polygon`'s flexibility while still making use of visx's styles and utilities.

Note: If a `points` prop is provided to a Polygon component, it's now used by the Polygon rather than being passed to the children.

#### :memo: Documentation

- I've introduced an additional prop to the `Polygon` component and provided a comment as documentation for it.
