### PR TITLE
development(contributing): update docs to rebuild single packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,19 +45,22 @@ yarn
 yarn build
 ```
 
-#### Rebuild one package
+#### Rebuild specific package(s)
 
-Upon modification of a single `package` you can run
+Upon modification of a single `package` you can run the following to rebuild it. Note that you can
+specify multiple packages to build this way, and optionally append `--watch` to continuously watch
+for changes.
 
 ```sh
-# build the package as cjs version
-yarn build-one --workspaces=@visx/package
+# build the specified package(s) as cjs version
+# example `yarn build:workspaces --workspaces=@visx/shape`
+yarn build:workspaces --workspaces=@visx/package[,@visx/package,...]
 
 # build the esm version (the @visx/demo next server sources these files)
-yarn build-one --workspaces=@visx/package --esm
+yarn build:workspaces --workspaces=@visx/package[,@visx/package,...] --esm
 
-# generate d.ts(definition files) for a lib
-yarn type-one --workspaces=@visx/package --esm
+# generate d.ts(definition files) the specified package(s)
+yarn type:workspaces --workspaces=@visx/package[,@visx/package,...]
 ```
 
 from the `visx` monorepo root to re-build the package with your changes.
@@ -67,7 +70,7 @@ from the `visx` monorepo root to re-build the package with your changes.
 You can use the local [`next.js`](https://nextjs.org) dev server within `packages/visx-demo` to view
 and iterate on your changes in the gallery. From the `packages/visx-demo` folder run `yarn dev` to
 start the next server which (if correctly sym-linked) will also watch for changes you make to other
-packages (upon re-building them).
+packages (upon re-building them, see above section).
 
 #### Config generation
 

--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
     "babel:cjs": "nimbus babel --clean --workspaces=\"@visx/!(demo)\"",
     "babel:esm": "nimbus babel --clean --workspaces=\"@visx/!(demo)\" --esm",
     "build": "yarn run babel && yarn run type",
-    "build-one": "echo 'build-one has been replaced with build:workspace' & exit 1",
     "build:sizes": "yarn run ts ./scripts/computeBuildSizes.ts",
     "build:release": "yarn run ts ./scripts/performRelease/index.ts",
-    "build:workspace": "nimbus babel --clean",
+    "build:workspaces": "nimbus babel --clean",
     "check:sizes": "yarn run ts ./scripts/compareBuildSizes.ts",
     "clean": "rm -rf ./packages/**/{lib,esm}",
     "format": "yarn run prettier --write",
@@ -51,9 +50,7 @@
     "test": "yarn run jest",
     "ts": "ts-node --project ./tsconfig.node.json",
     "type": "nimbus typescript --build --reference-workspaces",
-    "type-one": "echo 'type-one has been replaced with type:workspace' & exit 1",
-    "type:dts": "echo 'type:dts has been replaced with type' & exit 1",
-    "type:workspace": "nimbus typescript --build"
+    "type:workspaces": "nimbus typescript --build"
   },
   "devDependencies": {
     "@airbnb/config-babel": "^2.1.3",


### PR DESCRIPTION
#### :memo: Documentation

This fixes #1166 , it 
- updates `CONTRIBUTING.MD` to reflect the current scripts used to rebuild a specific package.
- removes the deprecated scripts (which should be fine now that this is documented).
- updates `build:workspace`/`type:workspace` to `workspaces` (with an `s`) since that better reflects the cli `--workspaces=` argument

@kristw @hshoff 
cc @jakeisnt  