### PR TITLE
fix(@visx/text) Bad size measurements in Firefox

### DIFF
--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -223,7 +223,7 @@ export default function Label({
       )}
       {title && (
         <Text
-          innerRef={titleRef}
+          innerTextRef={titleRef}
           fill={fontColor}
           verticalAnchor="start"
           x={padding.left + (titleProps?.textAnchor === 'middle' ? innerWidth / 2 : 0)}
@@ -238,7 +238,7 @@ export default function Label({
       )}
       {subtitle && (
         <Text
-          innerRef={subtitleRef}
+          innerTextRef={subtitleRef}
           fill={fontColor}
           verticalAnchor="start"
           x={padding.left + (subtitleProps?.textAnchor === 'middle' ? innerWidth / 2 : 0)}

--- a/packages/visx-text/src/Text.tsx
+++ b/packages/visx-text/src/Text.tsx
@@ -21,7 +21,7 @@ export default function Text(props: TextProps) {
     width,
     ...textProps
   } = props;
-  
+
   const { x = 0, fontSize } = textProps;
   const { wordsByLines, startDy, transform } = useText(props);
 

--- a/packages/visx-text/src/Text.tsx
+++ b/packages/visx-text/src/Text.tsx
@@ -21,14 +21,14 @@ export default function Text(props: TextProps) {
     width,
     ...textProps
   } = props;
-
+  
   const { x = 0, fontSize } = textProps;
   const { wordsByLines, startDy, transform } = useText(props);
 
   return (
-    <svg ref={innerRef} x={dx} y={dy} fontSize={fontSize} style={SVG_STYLE}>
+    <svg x={dx} y={dy} fontSize={fontSize} style={SVG_STYLE}>
       {wordsByLines.length > 0 ? (
-        <text transform={transform} {...textProps} textAnchor={textAnchor}>
+        <text ref={innerRef} transform={transform} {...textProps} textAnchor={textAnchor}>
           {wordsByLines.map((line, index) => (
             <tspan key={index} x={x} dy={index === 0 ? startDy : lineHeight}>
               {line.words.join(' ')}

--- a/packages/visx-text/src/Text.tsx
+++ b/packages/visx-text/src/Text.tsx
@@ -12,6 +12,7 @@ export default function Text(props: TextProps) {
     dy = 0,
     textAnchor = 'start',
     innerRef,
+    innerTextRef,
     verticalAnchor,
     angle,
     lineHeight = '1em',
@@ -26,9 +27,9 @@ export default function Text(props: TextProps) {
   const { wordsByLines, startDy, transform } = useText(props);
 
   return (
-    <svg x={dx} y={dy} fontSize={fontSize} style={SVG_STYLE}>
+    <svg ref={innerRef} x={dx} y={dy} fontSize={fontSize} style={SVG_STYLE}>
       {wordsByLines.length > 0 ? (
-        <text ref={innerRef} transform={transform} {...textProps} textAnchor={textAnchor}>
+        <text ref={innerTextRef} transform={transform} {...textProps} textAnchor={textAnchor}>
           {wordsByLines.map((line, index) => (
             <tspan key={index} x={x} dy={index === 0 ? startDy : lineHeight}>
               {line.words.join(' ')}

--- a/packages/visx-text/src/types.ts
+++ b/packages/visx-text/src/types.ts
@@ -15,7 +15,9 @@ type OwnProps = {
   /** Styles to be applied to the text (and used in computation of its size). */
   style?: React.CSSProperties;
   /** Ref passed to the Text SVG element. */
-  innerRef?: React.Ref<SVGTextElement>;
+  innerRef?: React.Ref<SVGSVGElement>;
+  /** Ref passed to the Text text element */
+  innerTextRef?: React.Ref<SVGTextElement>;
   /** x position of the text. */
   x?: string | number;
   /** y position of the text. */

--- a/packages/visx-text/src/types.ts
+++ b/packages/visx-text/src/types.ts
@@ -15,7 +15,7 @@ type OwnProps = {
   /** Styles to be applied to the text (and used in computation of its size). */
   style?: React.CSSProperties;
   /** Ref passed to the Text SVG element. */
-  innerRef?: React.Ref<SVGSVGElement>;
+  innerRef?: React.Ref<SVGTextElement>;
   /** x position of the text. */
   x?: string | number;
   /** y position of the text. */


### PR DESCRIPTION

#### :bug: Bug Fix
- Fixes: https://github.com/airbnb/visx/issues/1111


I don't have a clear understanding of this but it seems like `react-use-measure` hook doesn't work well with inner `svg` element within <Text />. 

I consider this problem came from how Firefox treats empty svg elements without width and height within another svg element with height and width - They usually have `width=100%` `height=100%` of parent size even if we put size value from CSS `width: 0px; height: 0px;` explicitly.

In the first render we're getting a really big value of Text svg height, so we're just stuck with this big initial height value here and therefore have this visual behaviour here.

Possible solution in this PR this is replace `innerRef` target from svg `<Text />` root element to `<text />` element which can be measured without this problem.

Only one concern here this is kind of breaking change in public API types (before we had i`nnerRef: Ref<SVGSvgElement>`, now we have `Ref<SVGTextElement>`). I see here two option how to avoid breaking change in types 
- Leave public types API as it is and add casting to text ref element `<text ref={innerRef as Ref<SVGTextElement>} />`
- Add new prop - `textInnerRef` with`Ref<SVGTextElement>` and use this prop to measure size at annotation `<Label />` instead of use old innerRef 
https://github.com/airbnb/visx/blob/d5fb82e42af56da4ee325ac5d2028fde52a48b01/packages/visx-annotation/src/components/Label.tsx#L225-L235
