### PR TITLE
new(@visx/zoom): adjust drag move to take optional offset

### DIFF
--- a/packages/visx-zoom/src/Zoom.tsx
+++ b/packages/visx-zoom/src/Zoom.tsx
@@ -212,14 +212,22 @@ class Zoom extends React.Component<ZoomProps, ZoomState> {
     this.setState({ isDragging: true });
   };
 
-  dragMove = (event: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent) => {
+  dragMove = (
+    event: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent,
+    options?: { offsetX?: number; offsetY?: number },
+  ) => {
     if (!this.state.isDragging || !this.startPoint || !this.startTranslate) return;
     const currentPoint = localPoint(event);
     const dx = currentPoint ? -(this.startPoint.x - currentPoint.x) : -this.startPoint.x;
     const dy = currentPoint ? -(this.startPoint.y - currentPoint.y) : -this.startPoint.y;
+
+    let translateX = this.startTranslate.translateX + dx;
+    if (options?.offsetX) translateX += options?.offsetX;
+    let translateY = this.startTranslate.translateY + dy;
+    if (options?.offsetY) translateY += options?.offsetY;
     this.setTranslate({
-      translateX: this.startTranslate.translateX + dx,
-      translateY: this.startTranslate.translateY + dy,
+      translateX,
+      translateY,
     });
   };
 


### PR DESCRIPTION
#### :rocket: Enhancements

- can provide optional offsetX and offsetY to `zoom.dragMove` 

#### :bug: Bug Fix

- Fixes #1172 / #1169 

I was trying to implement panning after the mouse leaves element/browser bounds. To achieve this I attached the mousemove listener directly to `window`. This resulted in the problem that `mousedown` has a different `event.target` than `mousemove`. As a result, there was a jump whenever it goes from `mousedown` to `mousemove`, resulting in a very bad ux.

I tried every solution I could think of and this is the only way I got it to work. If using `ParentSize`, I set the move offset to be `-x` and `-y` of `parent.ref.getBoundingClientRect`, which is the position of the zoom container relative to window.

~~This doesn't fix my problem 100%, because on the very first mousemove there is still a wrong coordinate. I'm not sure exactly why this happens though and I'm happy if someone knows more. Its not a huge dealbreaker for ux but definitely noticeable.~~

I realize this may not be a great solution, but its the only way I got it to work in my app, so I would be happy for any feedback and adjusting this so we can merge.