### PR TITLE
fix(grid,xychart): account for scale bandwidth in offsets

### DIFF
--- a/packages/visx-grid/src/grids/GridColumns.tsx
+++ b/packages/visx-grid/src/grids/GridColumns.tsx
@@ -5,6 +5,7 @@ import { Group } from '@visx/group';
 import { Point } from '@visx/point';
 import { getTicks, ScaleInput, coerceNumber } from '@visx/scale';
 import { CommonGridProps, GridScale } from '../types';
+import getScaleBandwidth from '../utils/getScaleBandwidth';
 
 export type GridColumnsProps<Scale extends GridScale> = CommonGridProps & {
   /** `@visx/scale` or `d3-scale` object used to convert value to position. */
@@ -41,8 +42,9 @@ export default function GridColumns<Scale extends GridScale>({
   ...restProps
 }: AllGridColumnsProps<Scale>) {
   const ticks = tickValues ?? getTicks(scale, numTicks);
+  const scaleOffset = (offset ?? 0) + getScaleBandwidth(scale) / 2;
   const tickLines = ticks.map(d => {
-    const x = offset ? (coerceNumber(scale(d)) || 0) + offset : coerceNumber(scale(d)) || 0;
+    const x = (coerceNumber(scale(d)) ?? 0) + scaleOffset;
     return {
       from: new Point({
         x,

--- a/packages/visx-grid/src/grids/GridRows.tsx
+++ b/packages/visx-grid/src/grids/GridRows.tsx
@@ -5,6 +5,7 @@ import { Group } from '@visx/group';
 import { Point } from '@visx/point';
 import { getTicks, ScaleInput, coerceNumber } from '@visx/scale';
 import { CommonGridProps, GridScale } from '../types';
+import getScaleBandwidth from '../utils/getScaleBandwidth';
 
 export type GridRowsProps<Scale extends GridScale> = CommonGridProps & {
   /** `@visx/scale` or `d3-scale` object used to convert value to position. */
@@ -41,8 +42,9 @@ export default function GridRows<Scale extends GridScale>({
   ...restProps
 }: AllGridRowsProps<Scale>) {
   const ticks = tickValues ?? getTicks(scale, numTicks);
+  const scaleOffset = (offset ?? 0) + getScaleBandwidth(scale) / 2;
   const tickLines = ticks.map(d => {
-    const y = offset ? (coerceNumber(scale(d)) || 0) + offset : coerceNumber(scale(d)) || 0;
+    const y = (coerceNumber(scale(d)) ?? 0) + scaleOffset;
     return {
       from: new Point({
         x: 0,

--- a/packages/visx-grid/src/utils/getScaleBandwidth.ts
+++ b/packages/visx-grid/src/utils/getScaleBandwidth.ts
@@ -1,0 +1,5 @@
+import { GridScale } from '../types';
+
+export default function getScaleBandwidth(scale: GridScale) {
+  return 'bandwidth' in scale ? scale.bandwidth() : 0;
+}

--- a/packages/visx-grid/test/utils.test.ts
+++ b/packages/visx-grid/test/utils.test.ts
@@ -1,6 +1,8 @@
+import { scaleLinear, scaleBand } from '@visx/scale';
 import polarToCartesian from '../src/utils/polarToCartesian';
+import getScaleBandwidth from '../src/utils/getScaleBandwidth';
 
-describe('GridUtils', () => {
+describe('grid utils', () => {
   describe('polarToCartesian', () => {
     const config = {
       radius: 20,
@@ -12,6 +14,31 @@ describe('GridUtils', () => {
         y: config.radius * Math.sin(config.angle),
       };
       expect(polarToCartesian(config)).toEqual(expected);
+    });
+  });
+
+  describe('getScaleBandwidth', () => {
+    it('should return 0 for non-band scales', () => {
+      expect(
+        getScaleBandwidth(
+          scaleLinear({
+            range: [0, 90],
+            domain: [0, 100],
+          }),
+        ),
+      ).toBe(0);
+    });
+
+    it('should return the size of the band for band scales', () => {
+      expect(
+        getScaleBandwidth(
+          scaleBand({
+            range: [0, 90],
+            domain: ['a', 'b', 'c'],
+            padding: 0,
+          }),
+        ),
+      ).toBe(30);
     });
   });
 });


### PR DESCRIPTION
#### :bug: Bug Fix

Fixes #1176. The offset differences between the grid + axis lines was due to `@visx/grid` not accounting for scale `bandwidth` in its offset.

Note the gaps on the side of the chart described in the issue can be controlled by setting the band scale `padding` config to `0`.

**Before**
<img src="https://user-images.githubusercontent.com/4496521/115492634-fd71b580-a216-11eb-91ec-59e8e5cecf27.png" width="700" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/115492475-bb487400-a216-11eb-957d-52cb378a230f.png" width="700" />

@kristw @hshoff 
cc @jimmy-e