### PR TITLE
fix(responsive): don't call resize.cancel if we never initialised

### DIFF
--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -77,7 +77,7 @@ export default function ParentSize({
     return () => {
       window.cancelAnimationFrame(animationFrameID.current);
       observer.disconnect();
-      resize.cancel();
+      if (resize && resize.cancel) resize.cancel();
     };
   }, [resize]);
 


### PR DESCRIPTION

#### :bug: Bug Fix

- If you mount visx within react-testing-library, you might've encountered the error:
```Error: Uncaught [TypeError: resize.cancel is not a function]```
  
  We no longer reference the resize callback if we haven't initialised it yet.