### PR TITLE
docs(shape): fix docs fror BarGroup, BarGroupHorizontal, and BarStack

### DIFF
--- a/packages/visx-shape/src/shapes/BarGroup.tsx
+++ b/packages/visx-shape/src/shapes/BarGroup.tsx
@@ -9,7 +9,7 @@ import {
   AnyScaleBand,
   AddSVGProps,
   BaseBarGroupProps,
-  BarGroup,
+  BarGroup as BarGroupType,
   GroupKey,
   Accessor,
 } from '../types';
@@ -32,7 +32,7 @@ export type BarGroupProps<
   /** Total height of the y-axis. */
   height: number;
   /** Override render function which is passed the computed BarGroups. */
-  children?: (barGroups: BarGroup<Key>[]) => React.ReactNode;
+  children?: (barGroups: BarGroupType<Key>[]) => React.ReactNode;
 };
 
 /**
@@ -73,7 +73,7 @@ export type BarGroupProps<
  *
  * Example: [https://airbnb.io/visx/bargroup](https://airbnb.io/visx/bargroup)
  */
-export default function BarGroupComponent<
+export default function BarGroup<
   Datum extends DatumObject,
   Key extends GroupKey = GroupKey,
   X0Scale extends AnyScaleBand = AnyScaleBand,
@@ -95,7 +95,7 @@ export default function BarGroupComponent<
 }: AddSVGProps<BarGroupProps<Datum, Key, X0Scale, X1Scale>, SVGRectElement>) {
   const barWidth = getBandwidth(x1Scale);
 
-  const barGroups: BarGroup<Key>[] = data.map((group, i) => ({
+  const barGroups: BarGroupType<Key>[] = data.map((group, i) => ({
     index: i,
     x0: x0Scale(x0(group))!,
     bars: keys.map((key, j) => {

--- a/packages/visx-shape/src/shapes/BarGroupHorizontal.tsx
+++ b/packages/visx-shape/src/shapes/BarGroupHorizontal.tsx
@@ -8,7 +8,7 @@ import {
   AnyScaleBand,
   DatumObject,
   AddSVGProps,
-  BarGroupHorizontal,
+  BarGroupHorizontal as BarGroupHorizontalType,
   BaseBarGroupProps,
   GroupKey,
   Accessor,
@@ -34,10 +34,10 @@ export type BarGroupHorizontalProps<
   /** Total width of the x-axis. */
   width: number;
   /** Override render function which is passed the computed Ba/rGroups. */
-  children?: (barGroups: BarGroupHorizontal<Key>[]) => React.ReactNode;
+  children?: (barGroups: BarGroupHorizontalType<Key>[]) => React.ReactNode;
 };
 
-export default function BarGroupHorizontalComponent<
+export default function BarGroupHorizontal<
   Datum extends DatumObject,
   Key extends GroupKey = GroupKey,
   Y0Scale extends AnyScaleBand = AnyScaleBand,
@@ -60,7 +60,7 @@ export default function BarGroupHorizontalComponent<
 }: AddSVGProps<BarGroupHorizontalProps<Datum, Key, Y0Scale, Y1Scale>, SVGRectElement>) {
   const barHeight = getBandwidth(y1Scale);
 
-  const barGroups: BarGroupHorizontal<Key>[] = data.map((group, i) => ({
+  const barGroups: BarGroupHorizontalType<Key>[] = data.map((group, i) => ({
     index: i,
     y0: y0Scale(y0(group)) || 0,
     bars: keys.map((key, j) => {

--- a/packages/visx-shape/src/shapes/BarStack.tsx
+++ b/packages/visx-shape/src/shapes/BarStack.tsx
@@ -6,7 +6,7 @@ import { ScaleInput } from '@visx/scale';
 import {
   PositionScale,
   AddSVGProps,
-  BarStack,
+  BarStack as BarStackType,
   BaseBarStackProps,
   StackKey,
   Accessor,
@@ -32,7 +32,7 @@ export type BarStackProps<
   y1?: Accessor<SeriesPoint<Datum>, ScaleInput<YScale>>;
 };
 
-export default function BarStackComponent<
+export default function BarStack<
   Datum,
   Key extends StackKey = StackKey,
   XScale extends PositionScale = PositionScale,
@@ -64,7 +64,7 @@ export default function BarStackComponent<
   const stacks = stack(data);
   const barWidth = getBandwidth(xScale);
 
-  const barStacks: BarStack<Datum, Key>[] = stacks.map((barStack, i) => {
+  const barStacks: BarStackType<Datum, Key>[] = stacks.map((barStack, i) => {
     const { key } = barStack;
     return {
       index: i,


### PR DESCRIPTION
Fixes #1217 

#### :memo: Documentation
#### :bug: Bug Fix

Fixes an issue with docs for `@visx/shape` where the component exports didn't match the file name, which breaks `react docgen`. I noticed this when there were some API [questions](https://github.com/airbnb/visx/discussions/1207#discussioncomment-734231) about `BarStack` vs `BarStackHorizontal` and couldn't find `BarStack` in the docs 😱 .

From `/docs/shape`
![image](https://user-images.githubusercontent.com/4496521/118172053-c8551f00-b3e0-11eb-8fc2-f06f9fe4272e.png)

@kristw @hshoff 
cc @jimmy-e