### PR TITLE
fix(xychart/Tooltip): bail early when tooltip is closed

### DIFF
--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -74,7 +74,21 @@ const INVISIBLE_STYLES: React.CSSProperties = {
   pointerEvents: 'none',
 };
 
-export default function Tooltip<Datum extends object>({
+/**
+ * This is a wrapper component which bails early if tooltip is not visible.
+ * If scroll detection is enabled in UseTooltipPortalOptions, this avoids re-rendering
+ * the component on every scroll. If many charts with Tooltips are rendered on a page,
+ * this also avoids creating many resize observers / hitting browser limits.
+ */
+export default function Tooltip<Datum extends object>(props: TooltipProps<Datum>) {
+  const tooltipContext = useContext(TooltipContext) as TooltipContextType<Datum>;
+
+  if (!tooltipContext?.tooltipOpen) return null;
+
+  return <TooltipInner {...props} />;
+}
+
+function TooltipInner<Datum extends object>({
   debounce,
   detectBounds,
   horizontalCrosshairStyle,


### PR DESCRIPTION
#### :bug: Bug Fix

This makes a perf improvement for how the `<Tooltip />` works in `@visx/xychart`. It's rendered inside a portal which requires using `react-use-measure` + `ResizeObserver` to update position upon resize and scroll. Currently this is all initialized even if `TooltipContext.tooltipOpen=false` which has two implications:

- on pages with dozens of charts, I've seen the chrome error `ResizeObserver loop limit exceeded` which [isn't critical](https://stackoverflow.com/a/50387233/1933266) but means that `ResizeObserver was not able to deliver all observations within a single animation frame.` which suggests perf isn't great
- if you enable scroll in the `UseMeasureOptions`, the `Tooltip` component (for every chart on the page) will rerender on every scroll which is rough. 

So I simply added a wrapper `Tooltip` component to bail early if `TooltipContext.tooltipOpen=false`.

Here're some render logs before the change 
![May-13-2021 16-53-58](https://user-images.githubusercontent.com/4496521/118201300-fbf96e80-b40b-11eb-8728-18f60ab1a40b.gif)

@kristw @hshoff 
