### PR TITLE
new(shape): support dynamic fill directly in Pie

### DIFF
--- a/packages/visx-shape/src/shapes/Pie.tsx
+++ b/packages/visx-shape/src/shapes/Pie.tsx
@@ -35,7 +35,7 @@ export type PieProps<Datum> = {
   pieSortValues?: PiePathConfig<Datum>['sortValues'];
   /** Render function override which is passed the configured arc generator as input. */
   children?: (provided: ProvidedProps<Datum>) => React.ReactNode;
-  /** Optional accessor function to return the fill string value of a given arc **/
+  /** Optional accessor function to return the fill string value of a given arc. **/
   fill?: string | StringAccessor<Datum>;
 } & Pick<PiePathConfig<Datum>, 'startAngle' | 'endAngle' | 'padAngle'> &
   Pick<
@@ -99,4 +99,3 @@ export default function Pie<Datum>({
     </Group>
   );
 }
-

--- a/packages/visx-shape/src/shapes/Pie.tsx
+++ b/packages/visx-shape/src/shapes/Pie.tsx
@@ -7,6 +7,8 @@ import { arc as arcPath, pie as piePath } from '../util/D3ShapeFactories';
 
 export type PieArcDatum<Datum> = PieArcDatumType<Datum>;
 
+type StringAccessor<Datum> = (arc: PieArcDatum<Datum>) => string;
+
 export type ProvidedProps<Datum> = {
   path: ArcType<$TSFIXME, PieArcDatum<Datum>>;
   arcs: PieArcDatum<Datum>[];
@@ -33,6 +35,8 @@ export type PieProps<Datum> = {
   pieSortValues?: PiePathConfig<Datum>['sortValues'];
   /** Render function override which is passed the configured arc generator as input. */
   children?: (provided: ProvidedProps<Datum>) => React.ReactNode;
+  /** Optional accessor function to return the fill string value of a given arc **/
+  fill?: string | StringAccessor<Datum>;
 } & Pick<PiePathConfig<Datum>, 'startAngle' | 'endAngle' | 'padAngle'> &
   Pick<
     ArcPathConfig<PieArcDatum<Datum>>,
@@ -56,6 +60,7 @@ export default function Pie<Datum>({
   pieSortValues,
   pieValue,
   children,
+  fill = '',
   ...restProps
 }: AddSVGProps<PieProps<Datum>, SVGPathElement>) {
   const path = arcPath<PieArcDatum<Datum>>({
@@ -78,14 +83,28 @@ export default function Pie<Datum>({
   // eslint-disable-next-line react/jsx-no-useless-fragment
   if (children) return <>{children({ arcs, path, pie })}</>;
 
+  const fillGenerator = getFillGenerator(fill);
   return (
     <Group className="visx-pie-arcs-group" top={top} left={left}>
       {arcs.map((arc, i) => (
         <g key={`pie-arc-${i}`}>
-          <path className={cx('visx-pie-arc', className)} d={path(arc) || ''} {...restProps} />
+          <path
+            className={cx('visx-pie-arc', className)}
+            d={path(arc) || ''}
+            fill={fillGenerator(arc)}
+            {...restProps}
+          />
           {centroid?.(path.centroid(arc), arc)}
         </g>
       ))}
     </Group>
   );
+}
+
+function getFillGenerator<Datum>(fill: string | StringAccessor<Datum>): StringAccessor<Datum> {
+  if (typeof fill === 'string') {
+    // Convert constant fill string to constant fill generator function
+    return (arc: PieArcDatum<Datum>) => fill;
+  }
+  return fill;
 }

--- a/packages/visx-shape/src/shapes/Pie.tsx
+++ b/packages/visx-shape/src/shapes/Pie.tsx
@@ -7,7 +7,7 @@ import { arc as arcPath, pie as piePath } from '../util/D3ShapeFactories';
 
 export type PieArcDatum<Datum> = PieArcDatumType<Datum>;
 
-type StringAccessor<Datum> = (arc: PieArcDatum<Datum>) => string;
+type StringAccessor<Datum> = (pieArcDatum: PieArcDatum<Datum>) => string;
 
 export type ProvidedProps<Datum> = {
   path: ArcType<$TSFIXME, PieArcDatum<Datum>>;
@@ -83,7 +83,6 @@ export default function Pie<Datum>({
   // eslint-disable-next-line react/jsx-no-useless-fragment
   if (children) return <>{children({ arcs, path, pie })}</>;
 
-  const fillGenerator = getFillGenerator(fill);
   return (
     <Group className="visx-pie-arcs-group" top={top} left={left}>
       {arcs.map((arc, i) => (
@@ -91,7 +90,7 @@ export default function Pie<Datum>({
           <path
             className={cx('visx-pie-arc', className)}
             d={path(arc) || ''}
-            fill={fillGenerator(arc)}
+            fill={fill == null || typeof fill === 'string' ? fill : fill(arc)}
             {...restProps}
           />
           {centroid?.(path.centroid(arc), arc)}
@@ -101,10 +100,3 @@ export default function Pie<Datum>({
   );
 }
 
-function getFillGenerator<Datum>(fill: string | StringAccessor<Datum>): StringAccessor<Datum> {
-  if (typeof fill === 'string') {
-    // Convert constant fill string to constant fill generator function
-    return (arc: PieArcDatum<Datum>) => fill;
-  }
-  return fill;
-}

--- a/packages/visx-shape/src/shapes/Pie.tsx
+++ b/packages/visx-shape/src/shapes/Pie.tsx
@@ -35,7 +35,7 @@ export type PieProps<Datum> = {
   pieSortValues?: PiePathConfig<Datum>['sortValues'];
   /** Render function override which is passed the configured arc generator as input. */
   children?: (provided: ProvidedProps<Datum>) => React.ReactNode;
-  /** Optional accessor function to return the fill string value of a given arc. **/
+  /** Optional accessor function to return the fill string value of a given arc. */
   fill?: string | StringAccessor<Datum>;
 } & Pick<PiePathConfig<Datum>, 'startAngle' | 'endAngle' | 'padAngle'> &
   Pick<

--- a/packages/visx-shape/test/Pie.test.tsx
+++ b/packages/visx-shape/test/Pie.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { Pie } from '../src';
-import { PieProps } from '../src/shapes/Pie';
+import { PieArcDatum, PieProps } from '../src/shapes/Pie';
 
 interface Datum {
   date: string;
@@ -14,6 +14,7 @@ interface Datum {
   Opera: string;
   Mozilla: string;
   'Other/Unknown': string;
+  color: string;
 }
 
 const browserUsage: Datum[] = [
@@ -27,6 +28,7 @@ const browserUsage: Datum[] = [
     Opera: '1.32',
     Mozilla: '0.12',
     'Other/Unknown': '0.01',
+    color: 'blue',
   },
   {
     date: '2015 Jun 16',
@@ -38,6 +40,7 @@ const browserUsage: Datum[] = [
     Opera: '1.32',
     Mozilla: '0.12',
     'Other/Unknown': '0.01',
+    color: 'red',
   },
 ];
 
@@ -100,6 +103,22 @@ describe('<Pie />', () => {
     const fn = jest.fn();
     PieChildren({ children: fn });
     expect(fn).toHaveBeenCalled();
+  });
+
+  test('it should accept a custom fill function', () => {
+    const paths = PieWrapper({
+      fill: (datum: PieArcDatum<Datum>) => datum.data.color,
+    }).find('path');
+    expect(paths.at(0).prop('fill')).toBe('blue');
+    expect(paths.at(1).prop('fill')).toBe('red');
+  });
+
+  test('it should accept a constant string fill value', () => {
+    const paths = PieWrapper({
+      fill: 'purple',
+    }).find('path');
+    expect(paths.at(0).prop('fill')).toBe('purple');
+    expect(paths.at(1).prop('fill')).toBe('purple');
   });
 
   test('it should call children function with { arcs, path, pie }', () => {


### PR DESCRIPTION
This is a PR for issue #1193 

#### :boom: Breaking Changes

- None. Previously the `fill` property supported only `string` value. It still accepts the `string` value (but can also accept a string accessor function). I added a test case for both.

#### :rocket: Enhancements

- This PR enables developers to create a Pie chart with custom colors per wedge by just using the `<Pie />` component. Prior, they had to add the `<path>` elements as children of the `<Pie>` in order to dynamic colors.

#### :memo: Documentation

- The `fill` function can now be a `string` or a function that receives an `PieArcDatum<Datum>` and returns a `string` fill value: `(arc: PieArcDatum<Datum>) => string`.

#### :bug: Bug Fix

- Wouldn't call this a bug fix....

#### :house: Internal

- Um... ?
