### PR TITLE
feat(animatedaxis): add tickComponent support (#977)

### DIFF
--- a/packages/visx-react-spring/src/axis/AnimatedAxis.tsx
+++ b/packages/visx-react-spring/src/axis/AnimatedAxis.tsx
@@ -11,14 +11,19 @@ export type AnimatedAxisProps<Scale extends AxisScale> = Omit<
 
 export default function AnimatedAxis<Scale extends AxisScale>({
   animationTrajectory,
+  tickComponent,
   ...axisProps
 }: AnimatedAxisProps<Scale>) {
   // wrap the ticksComponent so we can pass animationTrajectory
   const ticksComponent = useMemo(
     () => (ticks: TicksRendererProps<Scale>) => (
-      <AnimatedTicks {...ticks} animationTrajectory={animationTrajectory} />
+      <AnimatedTicks
+        {...ticks}
+        tickComponent={tickComponent}
+        animationTrajectory={animationTrajectory}
+      />
     ),
-    [animationTrajectory],
+    [animationTrajectory, tickComponent],
   );
   return <Axis {...axisProps} ticksComponent={ticksComponent} />;
 }

--- a/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
+++ b/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
@@ -14,6 +14,7 @@ export default function AnimatedTicks<Scale extends AxisScale>({
   orientation,
   scale,
   tickClassName,
+  tickComponent,
   tickLabelProps: allTickLabelProps,
   tickStroke = '#222',
   tickTransform,
@@ -71,7 +72,16 @@ export default function AnimatedTicks<Scale extends AxisScale>({
                 )}
                 opacity={opacity}
               >
-                <Text {...tickLabelProps}>{item?.formattedValue}</Text>
+                {tickComponent ? (
+                  tickComponent({
+                    ...tickLabelProps,
+                    x: toX,
+                    y: toY,
+                    formattedValue: item?.formattedValue,
+                  })
+                ) : (
+                  <Text {...tickLabelProps}>{item?.formattedValue}</Text>
+                )}
               </animated.g>
             </animated.g>
           );

--- a/packages/visx-react-spring/test/AnimatedTicks.test.tsx
+++ b/packages/visx-react-spring/test/AnimatedTicks.test.tsx
@@ -7,6 +7,31 @@ describe('AnimatedTicks', () => {
   it('should be defined', () => {
     expect(AnimatedTicks).toBeDefined();
   });
+
+  it('should render tickComponent defined', () => {
+    const wrapper = shallow(
+      <AnimatedTicks
+        hideTicks={false}
+        horizontal={false}
+        orientation="bottom"
+        tickComponent={() => <text>Test Component</text>}
+        scale={scaleLinear({ domain: [0, 10], range: [0, 10] })}
+        tickLabelProps={[]}
+        ticks={[
+          {
+            from: { x: 0, y: 0 },
+            to: { x: 0, y: 5 },
+            value: 0,
+            index: 0,
+            formattedValue: '0',
+          },
+        ]}
+      />,
+    );
+
+    expect(wrapper.text()).toEqual('Test Component');
+  });
+
   it('should not throw', () => {
     expect(() =>
       shallow(


### PR DESCRIPTION
#### :rocket: Enhancements

This adds support for the `tickComponent` prop on `AnimatedAxis`. It was already documented as being supported.

