### PR TITLE
build: skip release workflow when in forked repo

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,22 +35,24 @@ jobs:
         run: yarn build
 
       - name: 📐 Commit package sizes
+        if: github.repository_owner == 'airbnb'
         # note: `git diff-index --quiet HEAD`
         #       has exit code 0 if there are changes vs HEAD, else nothing to commit
         run: |
-          yarn build:sizes	
-          git config user.name github-actions	
-          git config user.email github-actions@github.com	
-          git add .	
-          git diff-index --quiet HEAD || git commit -m "build(${GITHUB_SHA}): auto-commit package sizes"	
+          yarn build:sizes
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git diff-index --quiet HEAD || git commit -m "build(${GITHUB_SHA}): auto-commit package sizes"
           git push
 
       - name: 🚀 Release
+        if: github.repository_owner == 'airbnb'
         # the following configurations are needed for lerna to
         #   - have git credentials for commiting tags
         #   - have correct npm credentials for publishing (yarn does not work)
         run: |
-          git config user.name github-actions	
+          git config user.name github-actions
           git config user.email github-actions@github.com
           yarn logout
           npm config set '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}'


### PR DESCRIPTION
#### :house: Internal

- pushing to `master` in forked repo triggers the `push.yml` github action workflow which include npm release. The release won't be successful (because fork doesn't have npm credentials) but it may bump the versions of `package.json` in the fork.

This PR add condition in the workflow to only run `commit size` and `release` steps from `airbnb/visx` but not from `some-fork/visx`.