### PR TITLE
feat(shape): add more segmentation for SplitLinePath

### DIFF
--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -81,6 +81,7 @@
     "d3-shape": "^1.0.6",
     "d3-time-format": "^2.0.5",
     "happo.io": "^6.4.0",
+    "lodash" : "^4.17.21",
     "markdown-loader": "^5.1.0",
     "next": "9.5.4",
     "nprogress": "^0.2.0",

--- a/packages/visx-demo/src/components/Gallery/SplitLinePathTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/SplitLinePathTile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import SplitLinePath, {
-  SplitLinePathProps,
+import SplitLinePathExample, {
+  SplitLinePathExampleProps,
   backgroundLight,
 } from '../../sandboxes/visx-shape-splitlinepath/Example';
 import GalleryTile from '../GalleryTile';
@@ -12,10 +12,10 @@ const detailsStyles = { color: 'white' };
 
 export default function SplitLinePathTile() {
   return (
-    <GalleryTile<SplitLinePathProps>
+    <GalleryTile<SplitLinePathExampleProps>
       title="SplitLinePath"
       description="<Shape.SplitLinePath />"
-      exampleRenderer={SplitLinePath}
+      exampleRenderer={SplitLinePathExample}
       exampleUrl="/splitlinepath"
       tileStyles={tileStyles}
       detailsStyles={detailsStyles}

--- a/packages/visx-demo/src/pages/splitlinepath.tsx
+++ b/packages/visx-demo/src/pages/splitlinepath.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import Show from '../components/Show';
-import SplitLinePath from '../sandboxes/visx-shape-splitlinepath/Example';
+import SplitLinePathExample from '../sandboxes/visx-shape-splitlinepath/Example';
 import StatsPlotSource from '!!raw-loader!../sandboxes/visx-shape-splitlinepath/Example';
 import packageJson from '../sandboxes/visx-shape-splitlinepath/package.json';
 
 const SplitLinePathPage = () => (
   <Show
     events
-    component={SplitLinePath}
+    component={SplitLinePathExample}
     title="SplitLinePath"
     codeSandboxDirectoryName="visx-shape-splitlinepath"
     packageJson={packageJson}

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -21,7 +21,20 @@ export type SplitLinePathExampleProps = {
   numberOfSegments?: number;
 };
 
-const CustomSegment: SplitLinePathChildren = ({ segment, styles }) => (
+const NumberSegment: SplitLinePathChildren = ({ segment, styles }) => (
+  <g>
+    {segment.map(({ x, y }, i) =>
+      i % 10 === 0 ? (
+        <text key={i} x={x} y={y} dy={3} fontSize={8} textAnchor="middle">
+          {i}
+        </text>
+      ) : null,
+    )}
+  </g>
+);
+
+/** Overlay growing circles instead of drawing a line */
+const CircleSegment: SplitLinePathChildren = ({ segment, styles }) => (
   <g>
     {segment.map(({ x, y }, i) =>
       i % 8 === 0 ? (
@@ -39,6 +52,8 @@ const CustomSegment: SplitLinePathChildren = ({ segment, styles }) => (
   </g>
 );
 
+const PADDING = 20;
+
 export default function SplitLinePathExample({
   width,
   height,
@@ -48,17 +63,31 @@ export default function SplitLinePathExample({
   const data = useMemo(
     () => ({
       leftToRight: generateSinSegments({
-        width: width / 2,
-        height: height / 2,
+        width: width / 2 - PADDING * 2,
+        height: height / 2 - PADDING * 2,
         numberOfWaves,
         pointsPerWave,
       }),
       rightToLeft: generateSinSegments({
-        width: width / 2,
-        height: height / 2,
+        width: width / 2 - PADDING * 2,
+        height: height / 2 - PADDING * 2,
         numberOfWaves,
         pointsPerWave,
         direction: 'right-to-left',
+      }),
+      topToBottom: generateSinSegments({
+        width: width / 2 - PADDING * 2,
+        height: height / 2 - PADDING * 2,
+        numberOfWaves,
+        pointsPerWave,
+        direction: 'top-to-bottom',
+      }),
+      bottomToTop: generateSinSegments({
+        width: width / 2 - PADDING * 2,
+        height: height / 2 - PADDING * 2,
+        numberOfWaves,
+        pointsPerWave,
+        direction: 'bottom-to-top',
       }),
     }),
     [width, height, numberOfWaves, pointsPerWave],
@@ -85,7 +114,8 @@ export default function SplitLinePathExample({
         />
 
         {/* left to right */}
-        <g transform={`translate(${width / 2}, ${height / 4})`}>
+        <g transform={`translate(${PADDING}, ${height / 4})`}>
+          {/* Render all segments as a single line for comparison */}
           <LinePath
             data={data.leftToRight.flat()}
             x={getX}
@@ -109,9 +139,8 @@ export default function SplitLinePathExample({
             ]}
           >
             {({ segment, styles, index }) =>
-              /** overlay circles to a couple of the segments */
               index === numberOfWaves - 1 || index === 2 ? (
-                <CustomSegment segment={segment} styles={styles} index={index} />
+                <CircleSegment segment={segment} styles={styles} index={index} />
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )
@@ -120,7 +149,8 @@ export default function SplitLinePathExample({
         </g>
 
         {/* right to left */}
-        <g transform={`translate(${width}, ${(height * 3) / 4})`}>
+        <g transform={`translate(${width / 2 - PADDING}, ${(height * 3) / 4})`}>
+          {/* Render all segments as a single line for comparison */}
           <LinePath
             data={data.rightToLeft.flat()}
             x={getX}
@@ -144,9 +174,80 @@ export default function SplitLinePathExample({
             ]}
           >
             {({ segment, styles, index }) =>
-              /** overlay circles to a couple of the segments */
               index === numberOfWaves - 1 || index === 2 ? (
-                <CustomSegment segment={segment} styles={styles} index={index} />
+                <NumberSegment segment={segment} styles={styles} index={index} />
+              ) : (
+                <LinePath data={segment} x={getX} y={getY} {...styles} />
+              )
+            }
+          </SplitLinePath>
+        </g>
+
+        {/* top to bottom */}
+        <g transform={`translate(${(width * 3) / 4}, ${PADDING})`}>
+          {/* Render all segments as a single line for comparison */}
+          <LinePath
+            data={data.topToBottom.flat()}
+            x={getX}
+            y={getY}
+            strokeWidth={8}
+            stroke="#fff"
+            strokeOpacity={0.15}
+            curve={curveCardinal}
+          />
+
+          <SplitLinePath
+            sampleRate={1}
+            segments={data.topToBottom}
+            segmentation="y"
+            x={getX}
+            y={getY}
+            curve={curveCardinal}
+            styles={[
+              { stroke: foreground, strokeWidth: 3 },
+              { stroke: '#fff', strokeWidth: 2, strokeDasharray: '9,5' },
+              { stroke: background, strokeWidth: 2 },
+            ]}
+          >
+            {({ segment, styles, index }) =>
+              index === numberOfWaves - 1 || index === 2 ? (
+                <CircleSegment segment={segment} styles={styles} index={index} />
+              ) : (
+                <LinePath data={segment} x={getX} y={getY} {...styles} />
+              )
+            }
+          </SplitLinePath>
+        </g>
+
+        {/* bottom to top */}
+        <g transform={`translate(${(width * 3) / 4}, ${height - PADDING})`}>
+          {/* Render all segments as a single line for comparison */}
+          <LinePath
+            data={data.bottomToTop.flat()}
+            x={getX}
+            y={getY}
+            strokeWidth={8}
+            stroke="#fff"
+            strokeOpacity={0.15}
+            curve={curveCardinal}
+          />
+
+          <SplitLinePath
+            sampleRate={1}
+            segments={data.bottomToTop}
+            segmentation="y"
+            x={getX}
+            y={getY}
+            curve={curveCardinal}
+            styles={[
+              { stroke: foreground, strokeWidth: 3 },
+              { stroke: '#fff', strokeWidth: 2, strokeDasharray: '9,5' },
+              { stroke: background, strokeWidth: 2 },
+            ]}
+          >
+            {({ segment, styles, index }) =>
+              index === numberOfWaves - 1 || index === 2 ? (
+                <CircleSegment segment={segment} styles={styles} index={index} />
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -25,9 +25,12 @@ const NumberSegment: SplitLinePathChildren = ({ segment, styles }) => (
   <g>
     {segment.map(({ x, y }, i) =>
       i % 25 === 0 ? (
-        <text key={i} x={x} y={y} dy={3} fontSize={8} textAnchor="middle">
-          {i}
-        </text>
+        <g transform={`translate(${x},${y})`}>
+          <circle r={2} fill="#222" />
+          <text key={i} dx={3} dy={3} fontSize={8}>
+            {i}
+          </text>
+        </g>
       ) : null,
     )}
   </g>
@@ -129,6 +132,7 @@ export default function SplitLinePathExample({
           <SplitLinePath
             sampleRate={2}
             segments={data.leftToRight}
+            segmentation="x"
             x={getX}
             y={getY}
             curve={curveCardinal}
@@ -146,6 +150,9 @@ export default function SplitLinePathExample({
               )
             }
           </SplitLinePath>
+          <text dy="0.3em" fontSize={10} fontWeight="bold" textAnchor="middle">
+            Start
+          </text>
         </g>
 
         {/* right to left */}
@@ -164,6 +171,7 @@ export default function SplitLinePathExample({
           <SplitLinePath
             sampleRate={1}
             segments={data.rightToLeft}
+            segmentation="x"
             x={getX}
             y={getY}
             curve={curveCardinal}
@@ -181,6 +189,9 @@ export default function SplitLinePathExample({
               )
             }
           </SplitLinePath>
+          <text dy="0.3em" fontSize={10} fontWeight="bold" textAnchor="middle">
+            Start
+          </text>
         </g>
 
         {/* top to bottom */}
@@ -217,6 +228,9 @@ export default function SplitLinePathExample({
               )
             }
           </SplitLinePath>
+          <text dy="0.3em" fontSize={10} fontWeight="bold" textAnchor="middle">
+            Start
+          </text>
         </g>
 
         {/* bottom to top */}
@@ -253,6 +267,9 @@ export default function SplitLinePathExample({
               )
             }
           </SplitLinePath>
+          <text dy="0.3em" fontSize={10} fontWeight="bold" textAnchor="middle">
+            Start
+          </text>
         </g>
       </svg>
     </div>

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -24,7 +24,7 @@ export type SplitLinePathExampleProps = {
 const NumberSegment: SplitLinePathChildren = ({ segment, styles }) => (
   <g>
     {segment.map(({ x, y }, i) =>
-      i % 10 === 0 ? (
+      i % 25 === 0 ? (
         <text key={i} x={x} y={y} dy={3} fontSize={8} textAnchor="middle">
           {i}
         </text>
@@ -211,7 +211,7 @@ export default function SplitLinePathExample({
           >
             {({ segment, styles, index }) =>
               index === numberOfWaves - 1 || index === 2 ? (
-                <CircleSegment segment={segment} styles={styles} index={index} />
+                <NumberSegment segment={segment} styles={styles} index={index} />
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from 'react';
+import { chunk } from 'lodash';
 import { curveCardinal } from '@visx/curve';
 import { LinePath, SplitLinePath } from '@visx/shape';
 import { LinearGradient } from '@visx/gradient';
 import { SplitLinePathRenderer } from '@visx/shape/lib/shapes/SplitLinePath';
 import generateSinSegments from './generateSinSegments';
+import generateSnakePath from './generateSnakePath';
 
 type Point = { x: number; y: number };
 const getX = (d: Point) => d.x;
@@ -55,7 +57,7 @@ const renderCircleSegment: SplitLinePathRenderer = ({ segment, styles }) => (
   </g>
 );
 
-const PADDING = 20;
+const PADDING = 30;
 
 export default function SplitLinePathExample({
   width,
@@ -81,20 +83,23 @@ export default function SplitLinePathExample({
       topToBottom: generateSinSegments({
         width: width / 2 - PADDING * 2,
         height: height / 2 - PADDING * 2,
-        numberOfWaves,
+        numberOfWaves: 5,
         pointsPerWave,
         direction: 'top-to-bottom',
       }),
       bottomToTop: generateSinSegments({
         width: width / 2 - PADDING * 2,
         height: height / 2 - PADDING * 2,
-        numberOfWaves,
+        numberOfWaves: 5,
         pointsPerWave,
         direction: 'bottom-to-top',
       }),
+      spiral: chunk(generateSnakePath({ width: width / 4, height: height / 4, step: 20 }), 8),
     }),
     [width, height, numberOfWaves, pointsPerWave],
   );
+
+  console.log('data.spiral', data.spiral);
 
   return width < 10 ? null : (
     <div>
@@ -268,6 +273,41 @@ export default function SplitLinePathExample({
             }
           </SplitLinePath>
           <text dy="0.3em" fontSize={10} fontWeight="bold" textAnchor="middle">
+            Start
+          </text>
+        </g>
+        {/* spiral */}
+        <g transform={`translate(${width / 2 - width / 8}, ${height / 2 - height / 8})`}>
+          {/* Render all segments as a single line for comparison */}
+          <LinePath
+            data={data.spiral.flat()}
+            x={getX}
+            y={getY}
+            strokeWidth={8}
+            stroke="#fff"
+            strokeOpacity={0.15}
+          />
+
+          <SplitLinePath
+            sampleRate={1}
+            segments={data.spiral}
+            segmentation="length"
+            x={getX}
+            y={getY}
+            styles={[
+              { stroke: foreground, strokeWidth: 3 },
+              { stroke: '#fff', strokeWidth: 2, strokeDasharray: '9,5' },
+              { stroke: background, strokeWidth: 2 },
+            ]}
+          />
+          <text
+            x={width / 8}
+            y={height / 8}
+            dy="0.3em"
+            fontSize={10}
+            fontWeight="bold"
+            textAnchor="middle"
+          >
             Start
           </text>
         </g>

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -99,8 +99,6 @@ export default function SplitLinePathExample({
     [width, height, numberOfWaves, pointsPerWave],
   );
 
-  console.log('data.spiral', data.spiral);
-
   return width < 10 ? null : (
     <div>
       <svg width={width} height={height}>

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { curveCardinal } from '@visx/curve';
 import { LinePath, SplitLinePath } from '@visx/shape';
 import { LinearGradient } from '@visx/gradient';
-import { SplitLinePathChildren } from '@visx/shape/lib/shapes/SplitLinePath';
+import { SplitLinePathRenderer } from '@visx/shape/lib/shapes/SplitLinePath';
 import generateSinSegments from './generateSinSegments';
 
 type Point = { x: number; y: number };
@@ -21,7 +21,7 @@ export type SplitLinePathExampleProps = {
   numberOfSegments?: number;
 };
 
-const NumberSegment: SplitLinePathChildren = ({ segment, styles }) => (
+const renderNumberSegment: SplitLinePathRenderer = ({ segment, styles }) => (
   <g>
     {segment.map(({ x, y }, i) =>
       i % 25 === 0 ? (
@@ -37,7 +37,7 @@ const NumberSegment: SplitLinePathChildren = ({ segment, styles }) => (
 );
 
 /** Overlay growing circles instead of drawing a line */
-const CircleSegment: SplitLinePathChildren = ({ segment, styles }) => (
+const renderCircleSegment: SplitLinePathRenderer = ({ segment, styles }) => (
   <g>
     {segment.map(({ x, y }, i) =>
       i % 8 === 0 ? (
@@ -144,7 +144,7 @@ export default function SplitLinePathExample({
           >
             {({ segment, styles, index }) =>
               index === numberOfWaves - 1 || index === 2 ? (
-                <CircleSegment segment={segment} styles={styles} index={index} />
+                renderCircleSegment({ segment, styles, index })
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )
@@ -183,7 +183,7 @@ export default function SplitLinePathExample({
           >
             {({ segment, styles, index }) =>
               index === numberOfWaves - 1 || index === 2 ? (
-                <NumberSegment segment={segment} styles={styles} index={index} />
+                renderNumberSegment({ segment, styles, index })
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )
@@ -222,7 +222,7 @@ export default function SplitLinePathExample({
           >
             {({ segment, styles, index }) =>
               index === numberOfWaves - 1 || index === 2 ? (
-                <NumberSegment segment={segment} styles={styles} index={index} />
+                renderNumberSegment({ segment, styles, index })
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )
@@ -261,7 +261,7 @@ export default function SplitLinePathExample({
           >
             {({ segment, styles, index }) =>
               index === numberOfWaves - 1 || index === 2 ? (
-                <CircleSegment segment={segment} styles={styles} index={index} />
+                renderCircleSegment({ segment, styles, index })
               ) : (
                 <LinePath data={segment} x={getX} y={getY} {...styles} />
               )

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -94,7 +94,7 @@ export default function SplitLinePathExample({
         pointsPerWave,
         direction: 'bottom-to-top',
       }),
-      spiral: chunk(generateSnakePath({ width: width / 4, height: height / 4, step: 20 }), 8),
+      snake: chunk(generateSnakePath({ width: width / 4, height: height / 4, step: 20 }), 8),
     }),
     [width, height, numberOfWaves, pointsPerWave],
   );
@@ -274,11 +274,11 @@ export default function SplitLinePathExample({
             Start
           </text>
         </g>
-        {/* spiral */}
+        {/* snake */}
         <g transform={`translate(${width / 2 - width / 8}, ${height / 2 - height / 8})`}>
           {/* Render all segments as a single line for comparison */}
           <LinePath
-            data={data.spiral.flat()}
+            data={data.snake.flat()}
             x={getX}
             y={getY}
             strokeWidth={8}
@@ -288,7 +288,7 @@ export default function SplitLinePathExample({
 
           <SplitLinePath
             sampleRate={1}
-            segments={data.spiral}
+            segments={data.snake}
             segmentation="length"
             x={getX}
             y={getY}

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSinPoints.ts
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSinPoints.ts
@@ -14,7 +14,7 @@ export default function generateSinPoints({
   const distanceBetweenPoints = waveLength / pointsPerWave;
   const sinPoints: { x: number; y: number }[] = [];
 
-  for (let waveIndex = 0; waveIndex <= numberOfWaves; waveIndex += 1) {
+  for (let waveIndex = 0; waveIndex < numberOfWaves; waveIndex += 1) {
     const waveDistFromStart = waveIndex * waveLength;
 
     for (let pointIndex = 0; pointIndex <= pointsPerWave; pointIndex += 1) {

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSinSegments.ts
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSinSegments.ts
@@ -1,0 +1,51 @@
+import generateSinPoints from './generateSinPoints';
+
+type Point = { x: number; y: number };
+
+export default function generateSinSegments({
+  width,
+  height,
+  numberOfWaves = 10,
+  pointsPerWave = 10,
+  direction = 'left-to-right',
+}: {
+  width: number;
+  height: number;
+  numberOfWaves?: number;
+  pointsPerWave?: number;
+  direction?: 'left-to-right' | 'right-to-left' | 'top-to-bottom' | 'bottom-to-top';
+}) {
+  const isHorizontal = direction === 'left-to-right' || direction === 'right-to-left';
+
+  // Generate points
+  const data = generateSinPoints({
+    width: isHorizontal ? width : height,
+    height: isHorizontal ? height : width,
+    numberOfWaves,
+    pointsPerWave,
+  });
+
+  // Create empty segments
+  const segments: Point[][] = [];
+  for (let i = 0; i < numberOfWaves; i += 1) {
+    segments.push([]);
+  }
+
+  // Split into equal width or height segments
+  const segmentSize = (isHorizontal ? width : height) / numberOfWaves;
+  data.forEach(d => {
+    segments[Math.min(Math.floor(d.x / segmentSize), segments.length - 1)].push(d);
+  });
+
+  switch (direction) {
+    case 'right-to-left':
+      return segments.map(segment => segment.map(({ x, y }) => ({ x: -x, y })));
+    case 'top-to-bottom':
+      return segments.map(segment => segment.map(({ x, y }) => ({ x: y, y: x })));
+    case 'bottom-to-top':
+      return segments.map(segment => segment.map(({ x, y }) => ({ x: y, y: -x })));
+    default:
+    case 'left-to-right':
+      return segments;
+  }
+}

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSnakePath.ts
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSnakePath.ts
@@ -9,6 +9,7 @@ function distance(a: Point, b: Point) {
   return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2);
 }
 
+/** generate a continuous path that fill rectangular space, similar to the classic Nokia snake game. */
 export default function generateSnakePath({
   width,
   height,

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSnakePath.ts
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/generateSnakePath.ts
@@ -1,0 +1,58 @@
+interface Point {
+  x: number;
+  y: number;
+}
+
+const pointKey = ({ x, y }: Point) => [x, y].join('_');
+
+function distance(a: Point, b: Point) {
+  return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2);
+}
+
+export default function generateSnakePath({
+  width,
+  height,
+  step,
+}: {
+  width: number;
+  height: number;
+  step: number;
+}) {
+  const points: Point[] = [];
+
+  const used = new Set();
+
+  function next(point: Point) {
+    const { x, y } = point;
+    return [
+      { x: x - step, y: y - step },
+      { x: x - step, y },
+      { x: x - step, y: y + step },
+      { x, y: y - step },
+      { x, y: y + step },
+      { x: x + step, y: y - step },
+      { x: x + step, y },
+      { x: x + step, y: y + step },
+    ]
+      .filter(p => p.x >= 0 && p.x <= width && p.y >= 0 && p.y <= height && !used.has(pointKey(p)))
+      .map(p => ({
+        point: p,
+        distance: distance(point, p),
+      }))
+      .sort((a, b) => a.distance - b.distance);
+  }
+
+  let currentPoint: Point | null = {
+    x: width / 2,
+    y: height / 2,
+  };
+
+  while (currentPoint) {
+    points.push(currentPoint);
+    used.add(pointKey(currentPoint));
+    const choices = next(currentPoint);
+    currentPoint = choices.length > 0 ? choices[0].point : null;
+  }
+
+  return points;
+}

--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/package.json
@@ -12,6 +12,7 @@
     "@visx/responsive": "latest",
     "@visx/scale": "latest",
     "@visx/shape": "latest",
+    "lodash": "^4.17.21",
     "react": "^16",
     "react-dom": "^16",
     "react-scripts-ts": "3.1.0",

--- a/packages/visx-shape/src/shapes/SplitLinePath.tsx
+++ b/packages/visx-shape/src/shapes/SplitLinePath.tsx
@@ -12,7 +12,7 @@ interface Point {
 const getX = (d: Point) => d.x || 0;
 const getY = (d: Point) => d.y || 0;
 
-export type SplitLinePathChildren = (renderProps: {
+export type SplitLinePathRenderer = (renderProps: {
   index: number;
   segment: { x: number; y: number }[];
   styles?: Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'children'>;
@@ -24,7 +24,7 @@ export type SplitLinePathProps<Datum> = {
   /** Styles to apply to each segment. If fewer styles are specified than the number of segments, they will be re-used. */
   styles: Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'children'>[];
   /** Override render function which is passed the configured path generator as input. */
-  children?: SplitLinePathChildren;
+  children?: SplitLinePathRenderer;
   /** className applied to path element. */
   className?: string;
 } & LinePathConfig<Datum> &
@@ -65,18 +65,22 @@ export default function SplitLinePath<Datum>({
     [pathString, segmentation, pointsInSegments, sampleRate],
   );
 
-  return splitLineSegments.map((segment, index) =>
-    children ? (
-      children({ index, segment, styles: styles[index] || styles[index % styles.length] })
-    ) : (
-      <LinePath
-        key={index}
-        className={className}
-        data={segment}
-        x={getX}
-        y={getY}
-        {...(styles[index] || styles[index % styles.length])}
-      />
-    ),
+  return (
+    <g>
+      {splitLineSegments.map((segment, index) =>
+        children ? (
+          children({ index, segment, styles: styles[index] || styles[index % styles.length] })
+        ) : (
+          <LinePath
+            key={index}
+            className={className}
+            data={segment}
+            x={getX}
+            y={getY}
+            {...(styles[index] || styles[index % styles.length])}
+          />
+        ),
+      )}
+    </g>
   );
 }

--- a/packages/visx-shape/src/shapes/SplitLinePath.tsx
+++ b/packages/visx-shape/src/shapes/SplitLinePath.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import getSplitLineSegments, { LineSegmentation } from '../util/getSplitLineSegments';
+import getSplitLineSegments, { GetLineSegmentsConfig } from '../util/getSplitLineSegments';
 import { line } from '../util/D3ShapeFactories';
 import { LinePathConfig } from '../types';
 import LinePath from './LinePath';
@@ -19,7 +19,6 @@ export type SplitLinePathChildren = (renderProps: {
 }) => React.ReactNode;
 
 export type SplitLinePathProps<Datum> = {
-  segmentation?: LineSegmentation;
   /** Array of data segments, where each segment will be a separate path in the rendered line. */
   segments: Datum[][];
   /** Styles to apply to each segment. If fewer styles are specified than the number of segments, they will be re-used. */
@@ -28,22 +27,22 @@ export type SplitLinePathProps<Datum> = {
   children?: SplitLinePathChildren;
   /** className applied to path element. */
   className?: string;
-  /** Optionally specify the sample rate for interpolating line segments. */
-  sampleRate?: number;
-} & LinePathConfig<Datum>;
+} & LinePathConfig<Datum> &
+  Pick<GetLineSegmentsConfig, 'segmentation' | 'sampleRate'>;
 
 export default function SplitLinePath<Datum>({
   children,
   className,
   curve,
   defined,
-  segmentation = 'x',
+  segmentation,
   sampleRate,
   segments,
   x,
   y,
   styles,
 }: SplitLinePathProps<Datum>) {
+  // Convert data in all segments to points.
   const pointsInSegments = useMemo(() => {
     const xFn = typeof x === 'number' || typeof x === 'undefined' ? () => x : x;
     const yFn = typeof y === 'number' || typeof y === 'undefined' ? () => y : y;
@@ -58,7 +57,6 @@ export default function SplitLinePath<Datum>({
   const splitLineSegments = useMemo(
     () =>
       getSplitLineSegments({
-        // use entire path to interpolate individual segments
         path: pathString,
         segmentation,
         pointsInSegments,

--- a/packages/visx-shape/src/util/getOrCreateMeasurementElement.ts
+++ b/packages/visx-shape/src/util/getOrCreateMeasurementElement.ts
@@ -1,0 +1,26 @@
+const SVG_NAMESPACE_URL = 'http://www.w3.org/2000/svg';
+
+export default function getOrCreateMeasurementElement(elementId: string) {
+  let pathElement = document.getElementById(elementId) as SVGPathElement | null;
+
+  // create a single path element if not done already
+  if (!pathElement) {
+    const svg = document.createElementNS(SVG_NAMESPACE_URL, 'svg');
+    // not visible
+    svg.style.opacity = '0';
+    svg.style.width = '0';
+    svg.style.height = '0';
+    // off screen
+    svg.style.position = 'absolute';
+    svg.style.top = '-100%';
+    svg.style.left = '-100%';
+    // no mouse events
+    svg.style.pointerEvents = 'none';
+    pathElement = document.createElementNS(SVG_NAMESPACE_URL, 'path');
+    pathElement.setAttribute('id', elementId);
+    svg.appendChild(pathElement);
+    document.body.appendChild(svg);
+  }
+
+  return pathElement;
+}

--- a/packages/visx-shape/src/util/getSplitLineSegments.ts
+++ b/packages/visx-shape/src/util/getSplitLineSegments.ts
@@ -50,14 +50,14 @@ export default function getSplitLineSegments({
     pathElement.setAttribute('d', path);
     const totalPathLength = pathElement.getTotalLength();
 
-    const samples = [];
-    for (let distance = 0; distance <= totalPathLength; distance += sampleRate) {
-      samples.push(pathElement.getPointAtLength(distance));
-    }
-
-    const numSegments = pointsInSegments.length;
-
     if (segmentation === 'x' || segmentation === 'y') {
+      const samples = [];
+      for (let distance = 0; distance <= totalPathLength; distance += sampleRate) {
+        samples.push(pathElement.getPointAtLength(distance));
+      }
+
+      const numSegments = pointsInSegments.length;
+
       const lineSegments: LineSegments = pointsInSegments.map(() => []);
       const segmentBegins = pointsInSegments.map(
         points => points.find(p => typeof p[segmentation] === 'number')?.[segmentation],
@@ -85,27 +85,25 @@ export default function getSplitLineSegments({
     }
 
     // segmentation === "length"
-    const totalPieces = pointsInSegments.reduce((sum, curr) => sum + curr.length, 0);
-    const pieceSize = totalPathLength / totalPieces;
+    const numPoints = pointsInSegments.reduce((sum, curr) => sum + curr.length, 0);
+    const pieceLength = totalPathLength / numPoints;
 
-    let cumulativeSize = 0;
+    let cumulativeCount = 0;
 
-    const lineSegments = pointsInSegments.map(segment => {
-      const segmentPointCount = segment.length;
+    return pointsInSegments.map(segment => {
+      const numPointsInSegment = segment.length;
       const coords: { x: number; y: number }[] = [];
 
-      for (let i = 0; i < segmentPointCount + sampleRate; i += sampleRate) {
-        const distance = (cumulativeSize + i) * pieceSize;
+      for (let i = 0; i < numPointsInSegment + sampleRate; i += sampleRate) {
+        const distance = (cumulativeCount + i) * pieceLength;
         const point = pathElement.getPointAtLength(distance);
         coords.push(point);
       }
 
-      cumulativeSize += segmentPointCount;
+      cumulativeCount += numPointsInSegment;
 
       return coords;
     });
-
-    return lineSegments;
   } catch (e) {
     return [];
   }

--- a/packages/visx-shape/src/util/getSplitLineSegments.ts
+++ b/packages/visx-shape/src/util/getSplitLineSegments.ts
@@ -82,7 +82,7 @@ export default function getSplitLineSegments({
       // segmentation === "length"
       const numPointsInSegment = pointsInSegments.map(points => points.length);
       const numPoints = numPointsInSegment.reduce((sum, curr) => sum + curr, 0);
-      const lengthBetweenPoints = totalLength / (numPoints - 1);
+      const lengthBetweenPoints = totalLength / Math.max(1, (numPoints - 1));
 
       const segmentBegins = numPointsInSegment.slice(0, numSegments - 1);
       segmentBegins.unshift(0);

--- a/packages/visx-shape/src/util/getSplitLineSegments.ts
+++ b/packages/visx-shape/src/util/getSplitLineSegments.ts
@@ -28,6 +28,8 @@ export interface GetLineSegmentsConfig {
    *  assuming y always increase only (segment[i].y > segment[i-1].y)
    *  or decrease only (segment[i].y < segment[i-1].y).
    * - `length`: Assuming the path length between consecutive points are equal.
+   *
+   * Default is `x`.
    */
   segmentation: LineSegmentation;
   /**

--- a/packages/visx-shape/src/util/getSplitLineSegments.ts
+++ b/packages/visx-shape/src/util/getSplitLineSegments.ts
@@ -22,11 +22,11 @@ export interface GetLineSegmentsConfig {
   /**
    * How to segment the line
    * - `x`: Split based on x-position,
-   *  assuming x always increase only (segment[i].x > segment[i-1].x)
-   *  or decrease only (segment[i].x < segment[i-1].x).
+   *  assuming x values increase only (`segment[i].x > segment[i-1].x`)
+   *  or decrease only (`segment[i].x < segment[i-1].x`).
    * - `y`: Split based on y-position,
-   *  assuming y always increase only (segment[i].y > segment[i-1].y)
-   *  or decrease only (segment[i].y < segment[i-1].y).
+   *  assuming y values increase only (`segment[i].y > segment[i-1].y`)
+   *  or decrease only (`segment[i].y < segment[i-1].y`).
    * - `length`: Assuming the path length between consecutive points are equal.
    *
    * Default is `x`.

--- a/packages/visx-shape/src/util/getSplitLineSegments.ts
+++ b/packages/visx-shape/src/util/getSplitLineSegments.ts
@@ -1,64 +1,115 @@
-import memoize from 'lodash/memoize';
-
 const MEASUREMENT_ELEMENT_ID = '__visx_splitpath_svg_path_measurement_id';
 const SVG_NAMESPACE_URL = 'http://www.w3.org/2000/svg';
 
-export interface GetLineSegmentsConfig<Datum> {
+function getOrCreateMeasurementElement() {
+  let pathElement = document.getElementById(MEASUREMENT_ELEMENT_ID) as SVGPathElement | null;
+
+  // create a single path element if not done already
+  if (!pathElement) {
+    const svg = document.createElementNS(SVG_NAMESPACE_URL, 'svg');
+    // not visible
+    svg.style.opacity = '0';
+    svg.style.width = '0';
+    svg.style.height = '0';
+    // off screen
+    svg.style.position = 'absolute';
+    svg.style.top = '-100%';
+    svg.style.left = '-100%';
+    // no mouse events
+    svg.style.pointerEvents = 'none';
+    pathElement = document.createElementNS(SVG_NAMESPACE_URL, 'path');
+    pathElement.setAttribute('id', MEASUREMENT_ELEMENT_ID);
+    svg.appendChild(pathElement);
+    document.body.appendChild(svg);
+  }
+
+  return pathElement;
+}
+
+interface PointInSegment {
+  x: number | undefined;
+  y: number | undefined;
+}
+
+/**
+ * Different methods to segment the line
+ * - `x`: Split based on x-position,
+ *  assuming x always increase only (segment[i].x > segment[i-1].x)
+ *  or decrease only (segment[i].x < segment[i-1].x).
+ * - `y`: Split based on y-position,
+ *  assuming y always increase only (segment[i].y > segment[i-1].y)
+ *  or decrease only (segment[i].y < segment[i-1].y).
+ * - `length`: Assuming the path length between consecutive points are equal.
+ */
+export type LineSegmentation = 'x' | 'y' | 'length';
+
+type LineSegments = { x: number; y: number }[][];
+
+export interface GetLineSegmentsConfig {
   /** Full path `d` attribute to be broken up into `n` segments. */
   path: string;
   /**
    * Array of length `n`, where `n` is the number of resulting line segments.
    * For each segment of length `m`, `m / sampleRate` evenly spaced points will be returned.
    */
-  segments: Datum[][];
+  pointsInSegments: PointInSegment[][];
+  /**
+   * How to segment the line
+   */
+  segmentation: LineSegmentation;
   /** For each segment of length `m`, `m / sampleRate` evenly spaced points will be returned. */
   sampleRate?: number;
 }
 
-type LineSegments = { x: number; y: number }[][];
-
-export function getSplitLineSegments<Datum>({
+export default function getSplitLineSegments({
   path,
-  segments,
-  sampleRate = 0.25,
-}: GetLineSegmentsConfig<Datum>): LineSegments {
+  pointsInSegments,
+  segmentation,
+  sampleRate = 1,
+}: GetLineSegmentsConfig): LineSegments {
   try {
-    let pathElement = document.getElementById(MEASUREMENT_ELEMENT_ID) as SVGPathElement | null;
-
-    // create a single path element if not done already
-    if (!pathElement) {
-      const svg = document.createElementNS(SVG_NAMESPACE_URL, 'svg');
-      // not visible
-      svg.style.opacity = '0';
-      svg.style.width = '0';
-      svg.style.height = '0';
-      // off screen
-      svg.style.position = 'absolute';
-      svg.style.top = '-100%';
-      svg.style.left = '-100%';
-      // no mouse events
-      svg.style.pointerEvents = 'none';
-      pathElement = document.createElementNS(SVG_NAMESPACE_URL, 'path');
-      pathElement.setAttribute('id', MEASUREMENT_ELEMENT_ID);
-      svg.appendChild(pathElement);
-      document.body.appendChild(svg);
-    }
-
+    const pathElement = getOrCreateMeasurementElement();
     pathElement.setAttribute('d', path);
 
     const totalPathLength = pathElement.getTotalLength();
-    const totalPieces = segments.reduce((sum, curr) => sum + curr.length, 0);
+
+    if (segmentation === 'x') {
+      const lineSegments: LineSegments = pointsInSegments.map(() => []);
+      const isIncreasing =
+        pathElement.getPointAtLength(totalPathLength).x > pathElement.getPointAtLength(0).x;
+      const segmentBegins = pointsInSegments.map(
+        s => s.find(p => typeof p.x === 'number')?.x ?? (isIncreasing ? -Infinity : Infinity),
+      );
+      let nextSegment = 1;
+      for (let distance = 0; distance <= totalPathLength; distance += sampleRate) {
+        const point = pathElement.getPointAtLength(distance);
+        if (isIncreasing) {
+          while (nextSegment < segmentBegins.length - 1 && point.x >= segmentBegins[nextSegment]) {
+            nextSegment += 1;
+          }
+        } else {
+          while (nextSegment < segmentBegins.length - 1 && point.x <= segmentBegins[nextSegment]) {
+            nextSegment += 1;
+          }
+        }
+        lineSegments[nextSegment].push(point);
+      }
+      return lineSegments;
+    }
+
+    // segmentation "length"
+    const totalPieces = pointsInSegments.reduce((sum, curr) => sum + curr.length, 0);
     const pieceSize = totalPathLength / totalPieces;
 
     let cumulativeSize = 0;
 
-    const lineSegments = segments.map(segment => {
+    const lineSegments = pointsInSegments.map(segment => {
       const segmentPointCount = segment.length;
       const coords: { x: number; y: number }[] = [];
 
       for (let i = 0; i < segmentPointCount + sampleRate; i += sampleRate) {
         const distance = (cumulativeSize + i) * pieceSize;
-        const point = pathElement!.getPointAtLength(distance);
+        const point = pathElement.getPointAtLength(distance);
         coords.push(point);
       }
 
@@ -72,9 +123,3 @@ export function getSplitLineSegments<Datum>({
     return [];
   }
 }
-
-export default memoize(
-  getSplitLineSegments,
-  ({ path, segments, sampleRate }: GetLineSegmentsConfig<any>) =>
-    `${path}_${segments.length}_${segments.map(segment => segment.length).join('-')}_${sampleRate}`,
-);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10275,6 +10275,11 @@ lodash@^4.17.19, lodash@^4.17.20:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"


### PR DESCRIPTION
#### :rocket: Enhancements

`SplitLinePath` can split line by multiple algorithms

```tsx
<SplitLinePath segmentation="x" />
```

- `x`: Split based on x-position, assuming x values increase only (`segment[i].x > segment[i-1].x`) or decrease only (`segment[i].x < segment[i-1].x`).
- `y`: Split based on y-position, assuming y values increase only (`segment[i].y > segment[i-1].y`) or decrease only (`segment[i].y < segment[i-1].y`).
- `length`: Assuming the path length between consecutive points are equal. (This was the original algorithm that led to #920.)

Default is set to `x`.


#### :memo: Documentation

- Update `SplitLinePath` example

#### :bug: Bug Fix

- Fix #920 

![image](https://user-images.githubusercontent.com/1659771/124072041-1b1c8180-d9f5-11eb-9cf4-a4fe1de118a7.png)
