### PR TITLE
fix(xychart): Add react-spring to xychart dependencies

### DIFF
--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -61,7 +61,8 @@
     "d3-shape": "^2.0.0",
     "lodash": "^4.17.10",
     "mitt": "^2.1.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.6.2",
+    "react-spring": "^9.2.3"
   },
   "devDependencies": {
     "resize-observer-polyfill": "1.5.1"


### PR DESCRIPTION
🐛 Bug Fix
Fixes [1265](https://github.com/airbnb/visx/issues/1265)

We already have `@visx/react-spring`, but some files import the actual `react-spring`, e.g.
https://github.com/airbnb/visx/blob/master/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx

A better fix might be to replace `react-spring` with `@visx/react-spring` everywhere?