### PR TITLE
fix: remove @types/classnames

### DIFF
--- a/packages/visx-annotation/package.json
+++ b/packages/visx-annotation/package.json
@@ -31,14 +31,13 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/drag": "1.15.0",
     "@visx/group": "1.7.0",
     "@visx/point": "1.7.0",
     "@visx/shape": "1.16.0",
     "@visx/text": "1.10.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.5.10",
     "react-use-measure": "^2.0.4"
   },

--- a/packages/visx-axis/package.json
+++ b/packages/visx-axis/package.json
@@ -28,14 +28,13 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/group": "1.7.0",
     "@visx/point": "1.7.0",
     "@visx/scale": "1.14.0",
     "@visx/shape": "1.16.0",
     "@visx/text": "1.10.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {

--- a/packages/visx-brush/package.json
+++ b/packages/visx-brush/package.json
@@ -37,7 +37,7 @@
     "@visx/event": "1.7.0",
     "@visx/group": "1.7.0",
     "@visx/shape": "1.16.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.1"
   },
   "devDependencies": {

--- a/packages/visx-chord/package.json
+++ b/packages/visx-chord/package.json
@@ -32,10 +32,9 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-chord": "^1.0.9",
     "@types/react": "*",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "d3-chord": "^1.0.4",
     "prop-types": "^15.6.1"
   },

--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -69,7 +69,7 @@
     "@visx/zoom": "1.14.1",
     "@zeit/next-css": "^1.0.1",
     "babel-loader": "^8.2.2",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-array": "^1.1.1",
     "d3-collection": "^1.0.4",
     "d3-format": "^1.2.0",

--- a/packages/visx-geo/package.json
+++ b/packages/visx-geo/package.json
@@ -29,12 +29,11 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-geo": "^1.11.1",
     "@types/geojson": "*",
     "@types/react": "*",
     "@visx/group": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-geo": "^1.11.3",
     "prop-types": "^15.5.10"
   },

--- a/packages/visx-glyph/package.json
+++ b/packages/visx-glyph/package.json
@@ -34,11 +34,10 @@
     "react": "^16.3.0-0"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-shape": "^1.3.1",
     "@types/react": "*",
     "@visx/group": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-shape": "^1.2.0",
     "prop-types": "^15.6.2"
   }

--- a/packages/visx-grid/package.json
+++ b/packages/visx-grid/package.json
@@ -31,14 +31,13 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/curve": "1.7.0",
     "@visx/group": "1.7.0",
     "@visx/point": "1.7.0",
     "@visx/scale": "1.14.0",
     "@visx/shape": "1.16.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.2"
   },
   "publishConfig": {

--- a/packages/visx-group/package.json
+++ b/packages/visx-group/package.json
@@ -32,9 +32,8 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.2"
   },
   "publishConfig": {

--- a/packages/visx-heatmap/package.json
+++ b/packages/visx-heatmap/package.json
@@ -34,10 +34,9 @@
     "react": "^16.3.0-0"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/group": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.1"
   }
 }

--- a/packages/visx-hierarchy/package.json
+++ b/packages/visx-hierarchy/package.json
@@ -31,11 +31,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-hierarchy": "^1.1.6",
     "@types/react": "*",
     "@visx/group": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-hierarchy": "^1.1.4",
     "prop-types": "^15.6.1"
   },

--- a/packages/visx-legend/package.json
+++ b/packages/visx-legend/package.json
@@ -34,11 +34,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/group": "1.7.0",
     "@visx/scale": "1.14.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.5.10"
   }
 }

--- a/packages/visx-marker/package.json
+++ b/packages/visx-marker/package.json
@@ -28,11 +28,10 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/group": "1.7.0",
     "@visx/shape": "1.16.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/packages/visx-network/package.json
+++ b/packages/visx-network/package.json
@@ -20,10 +20,9 @@
   "author": "@andyfang_dz",
   "license": "MIT",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/group": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/packages/visx-pattern/package.json
+++ b/packages/visx-pattern/package.json
@@ -28,9 +28,8 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/visx-react-spring/package.json
+++ b/packages/visx-react-spring/package.json
@@ -42,13 +42,12 @@
     "react-spring": "^8.0.27"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/axis": "1.17.0",
     "@visx/grid": "1.16.0",
     "@visx/scale": "1.14.0",
     "@visx/text": "1.10.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.6.2"
   }
 }

--- a/packages/visx-shape/package.json
+++ b/packages/visx-shape/package.json
@@ -21,7 +21,6 @@
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-path": "^1.0.8",
     "@types/d3-shape": "^1.3.1",
     "@types/lodash": "^4.14.146",
@@ -29,7 +28,7 @@
     "@visx/curve": "1.7.0",
     "@visx/group": "1.7.0",
     "@visx/scale": "1.14.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-path": "^1.0.5",
     "d3-shape": "^1.2.0",
     "lodash": "^4.17.15",

--- a/packages/visx-stats/package.json
+++ b/packages/visx-stats/package.json
@@ -28,12 +28,11 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-shape": "^1.3.2",
     "@types/react": "*",
     "@visx/group": "1.7.0",
     "@visx/scale": "1.14.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-shape": "^1.2.0",
     "prop-types": "^15.5.10"
   },

--- a/packages/visx-text/package.json
+++ b/packages/visx-text/package.json
@@ -28,10 +28,9 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/lodash": "^4.14.160",
     "@types/react": "*",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "lodash": "^4.17.20",
     "prop-types": "^15.7.2",
     "reduce-css-calc": "^1.3.0"

--- a/packages/visx-threshold/package.json
+++ b/packages/visx-threshold/package.json
@@ -24,11 +24,10 @@
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/clip-path": "1.7.0",
     "@visx/shape": "1.16.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/visx-tooltip/package.json
+++ b/packages/visx-tooltip/package.json
@@ -28,10 +28,9 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/react": "*",
     "@visx/bounds": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "prop-types": "^15.5.10",
     "react-use-measure": "^2.0.4"
   },

--- a/packages/visx-voronoi/package.json
+++ b/packages/visx-voronoi/package.json
@@ -31,10 +31,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/d3-voronoi": "^1.1.9",
     "@types/react": "*",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-voronoi": "^1.1.2",
     "prop-types": "^15.6.1"
   },

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -40,7 +40,6 @@
     "react-spring": "^8.0.27"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.9",
     "@types/lodash": "^4.14.146",
     "@types/react": "*",
     "@visx/annotation": "1.16.0",
@@ -55,7 +54,7 @@
     "@visx/text": "1.10.0",
     "@visx/tooltip": "1.7.2",
     "@visx/voronoi": "1.7.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.3.1",
     "d3-array": "^2.6.0",
     "d3-interpolate-path": "2.2.1",
     "d3-shape": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3565,11 +3565,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/classnames@^2.2.9":
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
-  integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -5583,10 +5578,15 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6, classnames@^2.2.5, classnames@^2.2.6:
+classnames@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-regexp@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### :rocket: Enhancements

noticed warnings during install

```
warning workspace-aggregator-d56295b5-e1bb-4287-aa1e-e72f5692b6cf > docs > @visx/xychart > @types/classnames@2.3.1: This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.
```

Looks like `classnames@>=2.3` comes with types

