### PR TITLE
fix(brush, drag): call start callbacks consistently, support mobile

### DIFF
--- a/packages/visx-brush/src/BrushCorner.tsx
+++ b/packages/visx-brush/src/BrushCorner.tsx
@@ -134,7 +134,7 @@ export default class BrushCorner extends React.Component<BrushCornerProps, Brush
   render() {
     const { type, brush, stageWidth, stageHeight, style: styleProp, corner } = this.props;
     const cursor =
-      (styleProp && styleProp.cursor) ||
+      styleProp?.cursor ||
       (type === 'topLeft' || type === 'bottomRight' ? 'nwse-resize' : 'nesw-resize');
     const pointerEvents = brush.activeHandle || brush.isBrushing ? 'none' : 'all';
 
@@ -154,15 +154,15 @@ export default class BrushCorner extends React.Component<BrushCornerProps, Brush
                 width={stageWidth}
                 height={stageHeight}
                 style={{ cursor }}
-                onMouseMove={dragMove}
-                onMouseUp={dragEnd}
+                onPointerMove={dragMove}
+                onPointerUp={dragEnd}
               />
             )}
             <rect
               fill="transparent"
-              onMouseDown={dragStart}
-              onMouseMove={dragMove}
-              onMouseUp={dragEnd}
+              onPointerDown={dragStart}
+              onPointerMove={dragMove}
+              onPointerUp={dragEnd}
               className={`visx-brush-corner-${type}`}
               style={{ cursor, pointerEvents, ...styleProp }}
               {...corner}

--- a/packages/visx-brush/src/BrushHandle.tsx
+++ b/packages/visx-brush/src/BrushHandle.tsx
@@ -10,6 +10,7 @@ export type BrushHandleProps = {
   stageHeight: number;
   brush: BrushState;
   updateBrush: (update: UpdateBrush) => void;
+  onBrushStart?: (brush: DragArgs) => void;
   onBrushEnd?: (brush: BrushState) => void;
   type: ResizeTriggerAreas;
   handle: { x: number; y: number; width: number; height: number };
@@ -21,10 +22,13 @@ export type BrushHandleProps = {
 /** BrushHandle's are placed along the bounds of the brush and handle Drag events which update the passed brush. */
 export default class BrushHandle extends React.Component<BrushHandleProps> {
   handleDragStart = (drag: DragArgs) => {
-    const { onBrushHandleChange, type } = this.props;
+    const { onBrushHandleChange, type, onBrushStart } = this.props;
 
     if (onBrushHandleChange) {
       onBrushHandleChange(type, getPageCoordinates(drag.event));
+    }
+    if (onBrushStart) {
+      onBrushStart(drag);
     }
   };
 
@@ -158,9 +162,9 @@ export default class BrushHandle extends React.Component<BrushHandleProps> {
                 width={stageWidth}
                 height={stageHeight}
                 style={{ cursor }}
-                onMouseMove={dragMove}
-                onMouseUp={isControlled ? undefined : dragEnd}
-                onMouseLeave={isControlled ? undefined : dragEnd}
+                onPointerMove={dragMove}
+                onPointerUp={isControlled ? undefined : dragEnd}
+                onPointerLeave={isControlled ? undefined : dragEnd}
               />
             )}
             <rect

--- a/packages/visx-brush/src/BrushSelection.tsx
+++ b/packages/visx-brush/src/BrushSelection.tsx
@@ -18,6 +18,7 @@ export type BrushSelectionProps = {
   brush: BrushState;
   updateBrush: (update: UpdateBrush) => void;
   onMoveSelectionChange?: (type?: BrushingType, options?: BrushPageOffset) => void;
+  onBrushStart?: (brush: DragArgs) => void;
   onBrushEnd?: (brush: BrushState) => void;
   disableDraggingSelection: boolean;
   onMouseLeave: PointerHandler;
@@ -40,10 +41,13 @@ export default class BrushSelection extends React.Component<
   };
 
   selectionDragStart = (drag: DragArgs) => {
-    const { onMoveSelectionChange } = this.props;
+    const { onMoveSelectionChange, onBrushStart } = this.props;
 
     if (onMoveSelectionChange) {
       onMoveSelectionChange('move', getPageCoordinates(drag.event));
+    }
+    if (onBrushStart) {
+      onBrushStart(drag);
     }
   };
 

--- a/packages/visx-drag/src/Drag.tsx
+++ b/packages/visx-drag/src/Drag.tsx
@@ -50,6 +50,7 @@ export default function Drag({
         <rect
           width={width}
           height={height}
+          onPointerDown={drag.dragStart}
           onPointerMove={drag.dragMove}
           onPointerUp={drag.dragEnd}
           fill="transparent"


### PR DESCRIPTION
#### :bug: Bug Fix

This should fix both 
- https://github.com/airbnb/visx/issues/1283 and
- https://github.com/airbnb/visx/issues/845

Demo of the start/end callback invocations for move/resize/fresh brush:

![start-end-brush](https://user-images.githubusercontent.com/4496521/126563829-dc4099eb-a55e-4294-81db-5010c5509202.gif)

@gazcn007 @kristw 
cc @JoeVanGundy
