### PR TITLE
new(xychart): distinguish nearestDatum in renderGlyph

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -8,10 +8,10 @@ import { AnimationTrajectory } from '@visx/react-spring/lib/types';
 import cityTemperature, { CityTemperature } from '@visx/mock-data/lib/mocks/cityTemperature';
 import { GlyphCross, GlyphDot, GlyphStar } from '@visx/glyph';
 import { curveLinear, curveStep, curveCardinal } from '@visx/curve';
+import { RenderTooltipGlypProps } from '@visx/xychart/src/components/Tooltip';
 import customTheme from './customTheme';
 import userPrefersReducedMotion from './userPrefersReducedMotion';
 import getAnimatedOrUnanimatedComponents from './getAnimatedOrUnanimatedComponents';
-import { RenderTooltipGlypProps } from '@visx/xychart/src/components/Tooltip';
 
 const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const temperatureScaleConfig = { type: 'linear' } as const;

--- a/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/ExampleControls.tsx
@@ -11,6 +11,7 @@ import { curveLinear, curveStep, curveCardinal } from '@visx/curve';
 import customTheme from './customTheme';
 import userPrefersReducedMotion from './userPrefersReducedMotion';
 import getAnimatedOrUnanimatedComponents from './getAnimatedOrUnanimatedComponents';
+import { RenderTooltipGlypProps } from '@visx/xychart/src/components/Tooltip';
 
 const dateScaleConfig = { type: 'band', paddingInner: 0.3 } as const;
 const temperatureScaleConfig = { type: 'linear' } as const;
@@ -74,7 +75,7 @@ type ProvidedProps = {
   renderGlyph: React.FC<GlyphProps<CityTemperature>>;
   renderGlyphSeries: boolean;
   enableTooltipGlyph: boolean;
-  renderTooltipGlyph: React.FC<GlyphProps<CityTemperature>>;
+  renderTooltipGlyph: React.FC<RenderTooltipGlypProps<CityTemperature>>;
   renderHorizontally: boolean;
   renderLineSeries: boolean;
   sharedTooltip: boolean;
@@ -166,7 +167,8 @@ export default function ExampleControls({ children }: ControlsProps) {
       onPointerMove,
       onPointerOut,
       onPointerUp,
-    }: GlyphProps<CityTemperature>) => {
+      isNearestDatum,
+    }: RenderTooltipGlypProps<CityTemperature>) => {
       const handlers = { onPointerMove, onPointerOut, onPointerUp };
       if (tooltipGlyphComponent === 'star') {
         return (
@@ -199,7 +201,7 @@ export default function ExampleControls({ children }: ControlsProps) {
       }
       return (
         <text x={x} y={y} dx="-0.75em" dy="0.25em" fontSize={14} {...handlers}>
-          🍍
+          {isNearestDatum ? '🍍' : '🍌'}
         </text>
       );
     },

--- a/packages/visx-xychart/src/components/Tooltip.tsx
+++ b/packages/visx-xychart/src/components/Tooltip.tsx
@@ -22,6 +22,11 @@ export type RenderTooltipParams<Datum extends object> = TooltipContextType<Datum
   colorScale?: PickD3Scale<'ordinal', string, string>;
 };
 
+export interface RenderTooltipGlypProps<Datum extends object> extends RenderGlyphProps<Datum> {
+  glyphStyle?: React.SVGProps<SVGCircleElement>;
+  isNearestDatum: boolean;
+}
+
 export type TooltipProps<Datum extends object> = {
   /**
    * When TooltipContext.tooltipOpen=true, this function is invoked and if the
@@ -30,7 +35,7 @@ export type TooltipProps<Datum extends object> = {
    */
   renderTooltip: (params: RenderTooltipParams<Datum>) => React.ReactNode;
   /** Function which handles rendering glyphs. */
-  renderGlyph?: (params: RenderGlyphProps<Datum>) => React.ReactNode;
+  renderGlyph?: (params: RenderTooltipGlypProps<Datum>) => React.ReactNode;
   /** Whether to snap tooltip + crosshair x-coord to the nearest Datum x-coord instead of the event x-coord. */
   snapTooltipToDatumX?: boolean;
   /** Whether to snap tooltip + crosshair y-coord to the nearest Datum y-coord instead of the event y-coord. */
@@ -66,10 +71,6 @@ const INVISIBLE_STYLES: React.CSSProperties = {
   height: 0,
   pointerEvents: 'none',
 };
-
-interface RenderTooltipGlypProps<Datum extends object> extends RenderGlyphProps<Datum> {
-  glyphStyle?: React.SVGProps<SVGCircleElement>;
-}
 
 function DefaultGlyph<Datum extends object>(props: RenderTooltipGlypProps<Datum>) {
   const { theme } = useContext(DataContext) || {};
@@ -220,6 +221,7 @@ function TooltipInner<Datum extends object>({
             x: left,
             y: top,
             glyphStyle,
+            isNearestDatum: nearestDatum ? nearestDatum.key === key : false,
           });
         },
       );
@@ -242,6 +244,7 @@ function TooltipInner<Datum extends object>({
           x: left,
           y: top,
           glyphStyle,
+          isNearestDatum: true,
         });
       }
     }


### PR DESCRIPTION
#### :rocket: Enhancements

Tooltip: Make it possible to distinguish between `nearestDatum` and other series in `renderGlyph`. Also correct the type of `renderGlyph`.

Alternatively we could go for different mechanisms, like passing the `nearestDatum` or `nearestDatumKey` so consumers can compare themselves with the `key` prop, or something like a `type: 'datum' | 'series'`. Also not sure if the naming of `isNearestDatum` is in the spirit of the library. Suggestions welcome.

_edit: Actually, looks like users are already able to achieve this behaviour by using the `TooltipContext` in their custom tooltip glyph, so I'm fine with discarding this PR altogether as well._