### PR TITLE
Refactor imports to not cause de-optimization for esm bundlers

### DIFF
--- a/packages/visx-grid/src/grids/GridAngle.tsx
+++ b/packages/visx-grid/src/grids/GridAngle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
-import Line, { LineProps } from '@visx/shape/lib/shapes/Line';
+import type { LineProps } from '@visx/shape/lib/shapes/Line';
+import { Line } from '@visx/shape';
 import { Group } from '@visx/group';
 import { ScaleInput, getTicks, coerceNumber } from '@visx/scale';
 import { Point } from '@visx/point';

--- a/packages/visx-grid/src/grids/GridColumns.tsx
+++ b/packages/visx-grid/src/grids/GridColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
-import Line, { LineProps } from '@visx/shape/lib/shapes/Line';
+import type { LineProps } from '@visx/shape/lib/shapes/Line';
+import { Line } from '@visx/shape';
 import { Group } from '@visx/group';
 import { Point } from '@visx/point';
 import { getTicks, ScaleInput, coerceNumber } from '@visx/scale';

--- a/packages/visx-grid/src/grids/GridPolar.tsx
+++ b/packages/visx-grid/src/grids/GridPolar.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from 'react';
 import cx from 'classnames';
 import { Group } from '@visx/group';
 import { ScaleInput } from '@visx/scale';
-import { LineProps } from '@visx/shape/lib/shapes/Line';
+import type { LineProps } from '@visx/shape/lib/shapes/Line';
 import GridAngle from './GridAngle';
 import GridRadial from './GridRadial';
 

--- a/packages/visx-grid/src/grids/GridRadial.tsx
+++ b/packages/visx-grid/src/grids/GridRadial.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
-import Arc, { ArcProps } from '@visx/shape/lib/shapes/Arc';
+import type { ArcProps } from '@visx/shape/lib/shapes/Arc';
+import { Arc } from '@visx/shape';
 import { Group } from '@visx/group';
 import { ScaleInput, getTicks } from '@visx/scale';
 

--- a/packages/visx-grid/src/grids/GridRows.tsx
+++ b/packages/visx-grid/src/grids/GridRows.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
-import Line, { LineProps } from '@visx/shape/lib/shapes/Line';
+import type { LineProps } from '@visx/shape/lib/shapes/Line';
+import  { Line } from '@visx/shape';
 import { Group } from '@visx/group';
 import { Point } from '@visx/point';
 import { getTicks, ScaleInput, coerceNumber } from '@visx/scale';


### PR DESCRIPTION
#### :rocket: Enhancements

When importing from `@visx/grid/lib/shapes/Line` it forces bundlers to use the CommonJS version instead of the ECMAScript Module version which leads to larger bundle sizes due to lacking tree-shaking capabilities (CommonJS uses `require` statements).

If the types are not exposed from the root barrel file they should reside in their own import as type imports will be omitted.