### PR TITLE
new(zoom): add pinch and zoom support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "release": "yarn run prepare-release && lerna publish --exact",
     "setup": "yarn run build",
     "test": "yarn run jest",
+    "test:watch": "yarn run jest --watch",
     "ts": "ts-node --project ./tsconfig.node.json",
     "type": "nimbus typescript --build --reference-workspaces",
     "type:workspaces": "nimbus typescript --build"

--- a/packages/visx-demo/src/sandboxes/visx-geo-custom/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-geo-custom/Example.tsx
@@ -75,14 +75,14 @@ export default function GeoCustom({ width, height, events = true }: GeoCustomPro
 
   return width < 10 ? null : (
     <>
-      <Zoom
+      <Zoom<SVGSVGElement>
         width={width}
         height={height}
         scaleXMin={100}
         scaleXMax={1000}
         scaleYMin={100}
         scaleYMax={1000}
-        transformMatrix={{
+        initialTransformMatrix={{
           scaleX: initialScale,
           scaleY: initialScale,
           translateX: centerX,
@@ -93,7 +93,13 @@ export default function GeoCustom({ width, height, events = true }: GeoCustomPro
       >
         {zoom => (
           <div className="container">
-            <svg width={width} height={height} className={zoom.isDragging ? 'dragging' : undefined}>
+            <svg
+              width={width}
+              height={height}
+              className={zoom.isDragging ? 'dragging' : undefined}
+              ref={zoom.containerRef}
+              style={{ touchAction: 'none' }}
+            >
               <rect x={0} y={0} width={width} height={height} fill={background} rx={14} />
               <CustomProjection<FeatureShape>
                 projection={PROJECTIONS[projection]}

--- a/packages/visx-demo/src/sandboxes/visx-zoom-i/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-zoom-i/Example.tsx
@@ -38,21 +38,22 @@ export default function ZoomI({ width, height }: ZoomIProps) {
 
   return (
     <>
-      <Zoom
+      <Zoom<SVGSVGElement>
         width={width}
         height={height}
         scaleXMin={1 / 2}
         scaleXMax={4}
         scaleYMin={1 / 2}
         scaleYMax={4}
-        transformMatrix={initialTransform}
+        initialTransformMatrix={initialTransform}
       >
         {zoom => (
           <div className="relative">
             <svg
               width={width}
               height={height}
-              style={{ cursor: zoom.isDragging ? 'grabbing' : 'grab' }}
+              style={{ cursor: zoom.isDragging ? 'grabbing' : 'grab', touchAction: 'none' }}
+              ref={zoom.containerRef}
             >
               <RectClipPath id="zoom-clip" width={width} height={height} />
               <rect width={width} height={height} rx={14} fill={bg} />

--- a/packages/visx-zoom/package.json
+++ b/packages/visx-zoom/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@types/react": "*",
+    "@use-gesture/react": "^10.0.0-beta.22",
     "@visx/event": "1.7.0",
     "prop-types": "^15.6.2"
   }

--- a/packages/visx-zoom/src/types.ts
+++ b/packages/visx-zoom/src/types.ts
@@ -1,4 +1,4 @@
-import { UserHandlers } from '@use-gesture/react';
+import { UserHandlers, WebKitGestureEvent, Handler } from '@use-gesture/react';
 
 export interface TransformMatrix {
   scaleX: number;
@@ -17,6 +17,12 @@ export interface Point {
 export type Translate = Pick<TransformMatrix, 'translateX' | 'translateY'>;
 
 export type Scale = Pick<TransformMatrix, 'scaleX' | 'scaleY'>;
+
+export type PinchDelta = (
+  params: Parameters<
+    Handler<'pinch', TouchEvent | PointerEvent | WheelEvent | WebKitGestureEvent>
+  >[0],
+) => Scale;
 
 export interface ScaleSignature {
   scaleX: TransformMatrix['scaleX'];

--- a/packages/visx-zoom/src/types.ts
+++ b/packages/visx-zoom/src/types.ts
@@ -1,4 +1,4 @@
-import { useGesture } from '@use-gesture/react';
+import { UserHandlers } from '@use-gesture/react';
 
 export interface TransformMatrix {
   scaleX: number;
@@ -46,8 +46,8 @@ export interface ProvidedZoom<ElementType> {
   reset: () => void;
   /** Callback for a wheel event, updating scale based on props.wheelDelta, relative to the mouse position. */
   handleWheel: (event: React.WheelEvent | WheelEvent) => void;
-  /** Callback for a react-use-gesture on pinch event, updating scale based on props.pinchDelta, relative to the pinch position */
-  handlePinch: Parameters<typeof useGesture>[0]['onPinch'];
+  /** Callback for a react-use-gesture on pinch event, updating scale based on props.pinchDelta, relative to the pinch position. */
+  handlePinch: UserHandlers['onPinch'];
   /** Callback for dragEnd, sets isDragging to false. */
   dragEnd: () => void;
   /** Callback for dragMove, results in a scale transform. */
@@ -73,6 +73,6 @@ export interface ProvidedZoom<ElementType> {
   applyToPoint: ({ x, y }: Point) => Point;
   /** Applies the inverse of the current transform matrix to the specified point. */
   applyInverseToPoint: ({ x, y }: Point) => Point;
-  /** Ref to stick on element to attach all handlers automatically */
+  /** Ref to stick on element to attach all handlers automatically. */
   containerRef: React.RefObject<ElementType>;
 }

--- a/packages/visx-zoom/src/types.ts
+++ b/packages/visx-zoom/src/types.ts
@@ -1,3 +1,5 @@
+import { useGesture } from '@use-gesture/react';
+
 export interface TransformMatrix {
   scaleX: number;
   scaleY: number;
@@ -22,7 +24,7 @@ export interface ScaleSignature {
   point?: Point;
 }
 
-export interface ProvidedZoom {
+export interface ProvidedZoom<ElementType> {
   /** Sets translateX/Y to the center defined by width and height. */
   center: () => void;
   /** Sets the transform matrix to the identity matrix. */
@@ -44,6 +46,8 @@ export interface ProvidedZoom {
   reset: () => void;
   /** Callback for a wheel event, updating scale based on props.wheelDelta, relative to the mouse position. */
   handleWheel: (event: React.WheelEvent | WheelEvent) => void;
+  /** Callback for a react-use-gesture on pinch event, updating scale based on props.pinchDelta, relative to the pinch position */
+  handlePinch: Parameters<typeof useGesture>[0]['onPinch'];
   /** Callback for dragEnd, sets isDragging to false. */
   dragEnd: () => void;
   /** Callback for dragMove, results in a scale transform. */
@@ -69,4 +73,6 @@ export interface ProvidedZoom {
   applyToPoint: ({ x, y }: Point) => Point;
   /** Applies the inverse of the current transform matrix to the specified point. */
   applyInverseToPoint: ({ x, y }: Point) => Point;
+  /** Ref to stick on element to attach all handlers automatically */
+  containerRef: React.RefObject<ElementType>;
 }

--- a/packages/visx-zoom/test/Zoom.test.tsx
+++ b/packages/visx-zoom/test/Zoom.test.tsx
@@ -24,7 +24,7 @@ describe('<Zoom />', () => {
         scaleXMax={4}
         scaleYMin={1 / 2}
         scaleYMax={4}
-        transformMatrix={initialTransform}
+        initialTransformMatrix={initialTransform}
       >
         {({ transformMatrix }) => {
           const { scaleX, scaleY, translateX, translateY } = transformMatrix;

--- a/packages/visx-zoom/test/Zoom.test.tsx
+++ b/packages/visx-zoom/test/Zoom.test.tsx
@@ -33,8 +33,7 @@ describe('<Zoom />', () => {
       </Zoom>,
     );
 
-    expect(wrapper.find('div')).toHaveLength(1);
-    expect(wrapper.find('div').text()).toEqual('1.27,1.27,-211.62,162.59');
+    expect(wrapper.html()).toEqual('1.27,1.27,-211.62,162.59');
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4063,6 +4063,18 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@use-gesture/core@^10.0.0-beta.22":
+  version "10.0.0-beta.22"
+  resolved "https://snapchat.jfrog.io/snapchat/api/npm/npm-virtual/@use-gesture/core/-/core-10.0.0-beta.22.tgz#5627dd00137462e306116942aedeadf249634353"
+  integrity sha1-VifdABN0YuMGEWlCrt6t8kljQ1M=
+
+"@use-gesture/react@^10.0.0-beta.22":
+  version "10.0.0-beta.22"
+  resolved "https://snapchat.jfrog.io/snapchat/api/npm/npm-virtual/@use-gesture/react/-/react-10.0.0-beta.22.tgz#e88da83d1eedde4f422d53a09fbc09522e823a67"
+  integrity sha1-6I2oPR7t3k9CLVOgn7wJUi6COmc=
+  dependencies:
+    "@use-gesture/core" "^10.0.0-beta.22"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4065,13 +4065,13 @@
 
 "@use-gesture/core@^10.0.0-beta.22":
   version "10.0.0-beta.22"
-  resolved "https://snapchat.jfrog.io/snapchat/api/npm/npm-virtual/@use-gesture/core/-/core-10.0.0-beta.22.tgz#5627dd00137462e306116942aedeadf249634353"
-  integrity sha1-VifdABN0YuMGEWlCrt6t8kljQ1M=
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.0.0-beta.22.tgz#5627dd00137462e306116942aedeadf249634353"
+  integrity sha512-nFPsMiHii99huDpeKjC9e5Ggagn4M/UAb3DFWw1/dEZl1fJSfFobrNdtB+5sPOTwyDBBsKpk4oS7Nde4coGDzA==
 
 "@use-gesture/react@^10.0.0-beta.22":
   version "10.0.0-beta.22"
-  resolved "https://snapchat.jfrog.io/snapchat/api/npm/npm-virtual/@use-gesture/react/-/react-10.0.0-beta.22.tgz#e88da83d1eedde4f422d53a09fbc09522e823a67"
-  integrity sha1-6I2oPR7t3k9CLVOgn7wJUi6COmc=
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.0.0-beta.22.tgz#e88da83d1eedde4f422d53a09fbc09522e823a67"
+  integrity sha512-6ZTpyK1XwL6xgzV0LArxE/rMBNueOiIp0LJoKHdX5/LSf33unMd/E7v9YGOf55NM7vl0tOevpa9f5gSlw4Pvhw==
   dependencies:
     "@use-gesture/core" "^10.0.0-beta.22"
 


### PR DESCRIPTION
#### :boom: Breaking Changes
- zoom.containerRef needs to be added to whatever element needs zoom functionality.
- props.transformMatrix was changed to => initialTransformMatrix
- passive/style/className were removed

#### :rocket: Enhancements
Zoom now supports mobile pinch.

#### :memo: Documentation
I consolidated the handlers all into react-use-gesture. A user can opt out by not adding the containerRef so it seems like passive was no longer necessary.

In order for mobile zoom to work fully users must add ```style={{ touchAction: 'none' }}``` to the element in order for the browser to allow js to handle pinch and zoom.

Also I had to use the newest version of use-gesture which is technically in beta because of bugs in version 9. By the author's own admission it is ready for production so I do not see an issue with it.

Discussion which prompted this PR: https://github.com/airbnb/visx/discussions/1292
