### PR TITLE
new(demo/geo-albers/usa): use all 4 colors in the map

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-geo-albers-usa/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-geo-albers-usa/Example.tsx
@@ -90,7 +90,7 @@ export default function GeoAlbersUsa({ width, height, fullSize = true }: GeoAlbe
                   <path
                     key={`map-feature-${i}`}
                     d={path || ''}
-                    fill={i % 2 === 0 ? colors[0] : colors[1]}
+                    fill={colors[i % 4]}
                     stroke={background}
                     strokeWidth={0.5}
                   />
@@ -102,7 +102,7 @@ export default function GeoAlbersUsa({ width, height, fullSize = true }: GeoAlbe
                   <path
                     key={`map-feature-${i}`}
                     d={path || ''}
-                    fill={i % 2 === 0 ? colors[0] : colors[1]}
+                    fill={colors[i % 4]}
                     stroke={background}
                     strokeWidth={0.5}
                   />


### PR DESCRIPTION
#### :memo: Documentation
Improve the USA map demo by making use of all 4 colors already defined in the example, rather than only the first two.
