### PR TITLE
Round up instead of down on text width within Label to avoid unnecessary wrapping

### DIFF
--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -137,7 +137,7 @@ export default function Label({
     0,
   );
 
-  const textMeasuredWidth = Math.floor(
+  const textMeasuredWidth = Math.ceil(
     Math.min(maxWidth, Math.max(titleMeasuredWidth, subtitleMeasuredWidth)),
   );
   const measuredWidth = padding.right + padding.left + textMeasuredWidth;


### PR DESCRIPTION
#### :boom: Breaking Changes

- Possibly will change certain labels that wrapped to no longer wrap, or to have fewer wrapped lines.

#### :rocket: Enhancements

-

#### :memo: Documentation

-

#### :bug: Bug Fix

- If you set `maxWidth` on `Label` to a large number, the text may still wrap. What I noticed is that the `wordsByLine` returned by `useText` within `Label` is fine (it just returns one line), but then `Label` rounds down the width value returned by `useText()`, and then sets that rounded down value as the width for `Text`. `Text` then calls `useText` again, but with that rounded down width as its restriction, and since the text length is just a fraction of a pixel larger, useText returns two lines instead of one.

#### :house: Internal

-
