### PR TITLE
new(tooltip): provide isFlippedVertically and isFlippedHorizontally context

### DIFF
--- a/packages/visx-tooltip/src/context/TooltipPositionContext.tsx
+++ b/packages/visx-tooltip/src/context/TooltipPositionContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export type TooltipPositionContextType = {
+  isFlippedVertically: boolean;
+  isFlippedHorizontally: boolean;
+};
+
+const TooltipPositionContext = createContext<TooltipPositionContextType>({
+  isFlippedVertically: false,
+  isFlippedHorizontally: false,
+});
+
+export const TooltipPositionProvider = TooltipPositionContext.Provider;
+export const TooltipPositionConsumer = TooltipPositionContext.Consumer;
+
+export const useTooltipPosition = () => useContext(TooltipPositionContext);

--- a/packages/visx-tooltip/src/index.ts
+++ b/packages/visx-tooltip/src/index.ts
@@ -1,6 +1,7 @@
 export { default as withTooltip } from './enhancers/withTooltip';
 export { default as useTooltip } from './hooks/useTooltip';
 export { default as useTooltipInPortal } from './hooks/useTooltipInPortal';
+export { useTooltipPosition, TooltipPositionConsumer } from './context/TooltipPositionContext';
 export { default as Tooltip, defaultStyles } from './tooltips/Tooltip';
 export { default as TooltipWithBounds } from './tooltips/TooltipWithBounds';
 export { default as Portal } from './Portal';

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { withBoundingRects, WithBoundingRectsProps } from "@visx/bounds";
+import React from 'react';
+import { withBoundingRects, WithBoundingRectsProps } from '@visx/bounds';
 
-import Tooltip, { TooltipProps, defaultStyles } from "./Tooltip";
+import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
 
 export type TooltipWithBoundsProps = TooltipProps &
   React.HTMLProps<HTMLDivElement> &

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withBoundingRects, WithBoundingRectsProps } from '@visx/bounds';
 
 import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
+import { TooltipPositionProvider } from '../context/TooltipPositionContext';
 
 export type TooltipWithBoundsProps = TooltipProps &
   React.HTMLProps<HTMLDivElement> &
@@ -21,13 +22,12 @@ function TooltipWithBounds({
   ...otherProps
 }: TooltipWithBoundsProps) {
   let transform: React.CSSProperties['transform'];
-  let childrenProps;
+  let placeTooltipLeft = false;
+  let placeTooltipUp = false;
 
   if (ownBounds && parentBounds) {
     let left = initialLeft;
     let top = initialTop;
-    let placeTooltipLeft = false;
-    let placeTooltipUp = false;
 
     if (parentBounds.width) {
       const rightPlacementClippedPx = left + offsetLeft + ownBounds.width - parentBounds.width;
@@ -57,13 +57,7 @@ function TooltipWithBounds({
     top = Math.round(top);
 
     transform = `translate(${left}px, ${top}px)`;
-    childrenProps = {
-      isFlippedVertically: !placeTooltipUp,
-      isFlippedHorizontally: !placeTooltipLeft,
-    };
   }
-
-  const childrenToRender = Array.isArray(children) ? (children as React.ReactNode[]) : [children];
 
   return (
     <Tooltip
@@ -75,9 +69,11 @@ function TooltipWithBounds({
       }}
       {...otherProps}
     >
-      {childrenToRender.map((child) =>
-        React.isValidElement(child) ? React.cloneElement(child, childrenProps) : child,
-      )}
+      <TooltipPositionProvider
+        value={{ isFlippedVertically: !placeTooltipUp, isFlippedHorizontally: !placeTooltipLeft }}
+      >
+        {children}
+      </TooltipPositionProvider>
     </Tooltip>
   );
 }

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { withBoundingRects, WithBoundingRectsProps } from '@visx/bounds';
+import React from "react";
+import { withBoundingRects, WithBoundingRectsProps } from "@visx/bounds";
 
-import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
+import Tooltip, { TooltipProps, defaultStyles } from "./Tooltip";
 
 export type TooltipWithBoundsProps = TooltipProps &
   React.HTMLProps<HTMLDivElement> &
@@ -21,6 +21,7 @@ function TooltipWithBounds({
   ...otherProps
 }: TooltipWithBoundsProps) {
   let transform: React.CSSProperties['transform'];
+  let childrenProps;
 
   if (ownBounds && parentBounds) {
     let left = initialLeft;
@@ -56,7 +57,15 @@ function TooltipWithBounds({
     top = Math.round(top);
 
     transform = `translate(${left}px, ${top}px)`;
+    childrenProps = {
+      isFlippedVertically: !placeTooltipUp,
+      isFlippedHorizontally: !placeTooltipLeft,
+    };
   }
+
+  const childrenToRender = Array.isArray(children)
+    ? (children as React.ReactNode[])
+    : [children];
 
   return (
     <Tooltip
@@ -68,7 +77,11 @@ function TooltipWithBounds({
       }}
       {...otherProps}
     >
-      {children}
+      {childrenToRender.map((child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, childrenProps)
+          : child
+      )}
     </Tooltip>
   );
 }

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -63,9 +63,7 @@ function TooltipWithBounds({
     };
   }
 
-  const childrenToRender = Array.isArray(children)
-    ? (children as React.ReactNode[])
-    : [children];
+  const childrenToRender = Array.isArray(children) ? (children as React.ReactNode[]) : [children];
 
   return (
     <Tooltip
@@ -78,9 +76,7 @@ function TooltipWithBounds({
       {...otherProps}
     >
       {childrenToRender.map((child) =>
-        React.isValidElement(child)
-          ? React.cloneElement(child, childrenProps)
-          : child
+        React.isValidElement(child) ? React.cloneElement(child, childrenProps) : child,
       )}
     </Tooltip>
   );


### PR DESCRIPTION
#### :rocket: Enhancements
resolves #1329 
- Adds `isFlippedVertically` and `isFlippedHorizontally` flags in tooltip renderer to render different tooltip based on it's position
