### PR TITLE
fix(zoom): better handling of simultaneous drag and scale

### DIFF
--- a/packages/visx-zoom/src/Zoom.tsx
+++ b/packages/visx-zoom/src/Zoom.tsx
@@ -188,7 +188,7 @@ function Zoom<ElementType extends Element>({
         setStartTranslate({ translateX, translateY });
       }
     },
-    [width, height, isDragging, setTransformMatrix],
+    [height, width, isDragging, setTransformMatrix],
   );
 
   const translate = useCallback(


### PR DESCRIPTION
#### :bug: Bug Fix

After scaling while dragging, `dragMove` continues to use the original `startPoint` and `startTranslate` set by `dragStart`, without accounting for the new scaled matrix:
![ScaleDuringDragBug](https://user-images.githubusercontent.com/826408/138412760-be4b4c12-2421-49cc-a4a0-8083714b41fe.gif)

Refreshing the `startPoint` and `startTranslate` from the `scale` handler seems to behave better:
![ScaleDuringDragFix](https://user-images.githubusercontent.com/826408/138412778-7165a9b0-5889-4bc4-a182-3585db132e08.gif)