### PR TITLE
docs(scale): Add note on scaleLog domain not containing 0

### DIFF
--- a/packages/visx-scale/Readme.md
+++ b/packages/visx-scale/Readme.md
@@ -110,6 +110,8 @@ const scale = Scale.scaleLog({
 });
 ```
 
+**Important note:** As log(0) = -∞, a log scale domain must be strictly-positive or strictly-negative; the domain must not include or cross zero.
+
 ### Radial scale
 
 [Original d3 docs](https://github.com/d3/d3-scale/blob/master/README.md#scaleRadial)


### PR DESCRIPTION
#### :memo: Documentation

Just a small quality of life improvement since I got stuck on this and I'm sure others will too. Not immediately apparent from using the library because if using with an `<Axis>` it just renders the line without any ticks and no console warnings.