### PR TITLE
docs(tooltip): remove incorrect handler from readme example

### DIFF
--- a/packages/visx-tooltip/Readme.md
+++ b/packages/visx-tooltip/Readme.md
@@ -222,7 +222,7 @@ const ChartWithTooltip = () => {
       <svg ref={containerRef} width={...} height={...}>
         // Chart here...
         <SomeChartElement
-          onMouseOver={this.handleMouseOver}
+          onMouseOver={handleMouseOver}
           onMouseOut={hideTooltip}
         />
       </svg>


### PR DESCRIPTION

#### :memo: Documentation

- Remove incorrect `this.` from README example