### PR TITLE
fix(tooltip): mount TooltipWithBounds before adding transform

### DIFF
--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -20,10 +20,11 @@ function TooltipWithBounds({
   unstyled = false,
   ...otherProps
 }: TooltipWithBoundsProps) {
-  let left = initialLeft;
-  let top = initialTop;
+  let transform: React.CSSProperties['transform'];
 
   if (ownBounds && parentBounds) {
+    let left = initialLeft;
+    let top = initialTop;
     let placeTooltipLeft = false;
     let placeTooltipUp = false;
 
@@ -50,17 +51,19 @@ function TooltipWithBounds({
 
     left = placeTooltipLeft ? left - ownBounds.width - offsetLeft : left + offsetLeft;
     top = placeTooltipUp ? top - ownBounds.height - offsetTop : top + offsetTop;
-  }
 
-  left = Math.round(left);
-  top = Math.round(top);
+    left = Math.round(left);
+    top = Math.round(top);
+
+    transform = `translate(${left}px, ${top}px)`;
+  }
 
   return (
     <Tooltip
       style={{
         left: 0,
         top: 0,
-        transform: `translate(${left}px, ${top}px)`,
+        transform,
         ...(!unstyled && style),
       }}
       {...otherProps}


### PR DESCRIPTION
#### :bug: Bug Fix

When `TooltipWithBounds` is first mounted near the bottom or right edge within a scrollable container/page, it can cause a flash of scroll bar(s) before it has a chance to measure and flip the tooltip up/left, and the available space lost to the scroll bar can cause barely-fitting content to wrap momentarily. To avoid/reduce those issues, don't apply the `transform` until the tooltip is mounted. i.e. wait until `ownBounds` and `parentBounds` are defined, since [they'll at least be `emptyRect`](https://github.com/airbnb/visx/blob/3fe8499/packages/visx-bounds/src/enhancers/withBoundingRects.tsx#L55-L59) once `ReactDOM.findDOMNode` succeeds.