### PR TITLE
new(drag): add options to restrict <Drag> area and control snapToPointer behaviour

### DIFF
--- a/packages/visx-drag/src/Drag.tsx
+++ b/packages/visx-drag/src/Drag.tsx
@@ -19,6 +19,7 @@ export type DragProps = UseDragOptions & {
 
 export default function Drag({
   captureDragArea = true,
+  snapToPointer = true,
   children,
   dx,
   dy,
@@ -34,6 +35,7 @@ export default function Drag({
 }: DragProps) {
   const drag = useDrag({
     resetOnStart,
+    snapToPointer,
     onDragEnd,
     onDragMove,
     onDragStart,

--- a/packages/visx-drag/src/Drag.tsx
+++ b/packages/visx-drag/src/Drag.tsx
@@ -32,6 +32,7 @@ export default function Drag({
   x,
   y,
   isDragging,
+  restrict,
 }: DragProps) {
   const drag = useDrag({
     resetOnStart,
@@ -44,6 +45,7 @@ export default function Drag({
     dx,
     dy,
     isDragging,
+    restrict,
   });
 
   return (

--- a/packages/visx-drag/src/useDrag.ts
+++ b/packages/visx-drag/src/useDrag.ts
@@ -29,9 +29,9 @@ export type UseDragOptions = {
   dy?: number;
   /** If defined, parent controls dragging state.  */
   isDragging?: boolean;
-  /** Snap element being dragged to middle of pointer */
+  /** Snap element being dragged to middle of pointer. */
   snapToPointer?: boolean;
-  /** Options for limiting dragging in the x and y plane */
+  /** Options for limiting dragging in the x and y plane. */
   restrict?: {
     xMin?: number;
     xMax?: number;

--- a/packages/visx-drag/src/useDrag.ts
+++ b/packages/visx-drag/src/useDrag.ts
@@ -1,11 +1,8 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { localPoint } from "@visx/event";
-import useStateWithCallback from "./util/useStateWithCallback";
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { localPoint } from '@visx/event';
+import useStateWithCallback from './util/useStateWithCallback';
 
-export type MouseTouchOrPointerEvent =
-  | React.MouseEvent
-  | React.TouchEvent
-  | React.PointerEvent;
+export type MouseTouchOrPointerEvent = React.MouseEvent | React.TouchEvent | React.PointerEvent;
 
 export type HandlerArgs = DragState & {
   /** Drag event. */
@@ -144,7 +141,7 @@ export default function useDrag({
           }),
       );
     },
-    [onDragStart, resetOnStart, setDragStateWithCallback, snapToPointer]
+    [onDragStart, resetOnStart, setDragStateWithCallback, snapToPointer],
   );
 
   const handleDragMove = useCallback(
@@ -179,7 +176,7 @@ export default function useDrag({
       snapToPointer,
       dragStartPointerOffset.x,
       dragStartPointerOffset.y,
-    ]
+    ],
   );
 
   const handleDragEnd = useCallback(
@@ -194,7 +191,7 @@ export default function useDrag({
           }),
       );
     },
-    [onDragEnd, setDragStateWithCallback]
+    [onDragEnd, setDragStateWithCallback],
   );
 
   return {

--- a/packages/visx-drag/src/useDrag.ts
+++ b/packages/visx-drag/src/useDrag.ts
@@ -79,13 +79,14 @@ export default function useDrag({
   // use ref to detect prop changes
   const positionPropsRef = useRef({ x, y, dx, dy });
 
+  const { xMin, xMax, yMin, yMax } = restrict;
   const clampX = useCallback(
-    (num: number) => clampNumber(num, restrict?.xMin ?? -Infinity, restrict?.xMax ?? Infinity),
-    [restrict.xMax, restrict.xMin],
+    (num: number) => clampNumber(num, xMin ?? -Infinity, xMax ?? Infinity),
+    [xMax, xMin],
   );
   const clampY = useCallback(
-    (num: number) => clampNumber(num, restrict?.yMin ?? -Infinity, restrict?.yMax ?? Infinity),
-    [restrict.yMax, restrict.yMin],
+    (num: number) => clampNumber(num, yMin ?? -Infinity, yMax ?? Infinity),
+    [yMax, yMin],
   );
 
   const [dragState, setDragStateWithCallback] = useStateWithCallback<DragState>({

--- a/packages/visx-drag/src/util/clampNumber.ts
+++ b/packages/visx-drag/src/util/clampNumber.ts
@@ -1,0 +1,4 @@
+/** Clamps number within the inclusive lower and upper bounds. */
+export default function clampNumber(number: number, lower: number, upper: number) {
+  return Math.min(Math.max(number, lower), upper);
+}


### PR DESCRIPTION
#### :rocket: Enhancements

- Restrict draggable area
- Option to disable snapping to centre of pointer on drag start.

Started from this discussion https://github.com/airbnb/visx/discussions/1365

`snapToCursor` (default behaviour):

https://user-images.githubusercontent.com/1286001/139196553-633e9a86-00b2-4391-bc4d-849489ff8e74.mov

`snapToCursor={false}`:

https://user-images.githubusercontent.com/1286001/139196579-6b81de6f-db42-499f-91f5-8b5d1eb9ebc0.mov

Restricted to chart area (draggable area extends beyond):

https://user-images.githubusercontent.com/1286001/139196632-19d10701-fb10-48e1-8d95-174697701fd7.mov
