### PR TITLE
fix(responsive): fix shallow equality check on default array value for ParentSize

### DIFF
--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -45,20 +45,19 @@ export default function ParentSize({
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
-  const [state, setState] = useState<ParentSizeState | null>(null);
+  const [state, setState] = useState<ParentSizeState>({
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+  });
 
   const resize = useMemo(() => {
     const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
-        setState((existingState) => {
-          const existing = existingState || {
-            width: 0,
-            height: 0,
-            top: 0,
-            left: 0,
-          };
+        setState((existing) => {
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
           const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
           const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
@@ -91,12 +90,11 @@ export default function ParentSize({
 
   return (
     <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
-      {state &&
-        children({
-          ...state,
-          ref: target.current,
-          resize,
-        })}
+      {children({
+        ...state,
+        ref: target.current,
+        resize,
+      })}
     </div>
   );
 }

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -1,6 +1,6 @@
-import debounce from "lodash/debounce";
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import ResizeObserver from "resize-observer-polyfill";
+import debounce from 'lodash/debounce';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
 
 export type ParentSizeProps = {
   /** Optional `className` to add to the parent `div` wrapper used for size measurement. */
@@ -18,7 +18,7 @@ export type ParentSizeProps = {
     args: {
       ref: HTMLDivElement | null;
       resize: (state: ParentSizeState) => void;
-    } & ParentSizeState
+    } & ParentSizeState,
   ) => React.ReactNode;
 };
 
@@ -31,27 +31,24 @@ type ParentSizeState = {
 
 export type ParentSizeProvidedProps = ParentSizeState;
 
-const defaultIgnoreDimensions: ParentSizeProps["ignoreDimensions"] = [];
+const defaultIgnoreDimensions: ParentSizeProps['ignoreDimensions'] = [];
 
 export default function ParentSize({
   className,
   children,
   debounceTime = 300,
   ignoreDimensions = defaultIgnoreDimensions,
-  parentSizeStyles = { width: "100%", height: "100%" },
+  parentSizeStyles = { width: '100%', height: '100%' },
   enableDebounceLeadingCall = true,
   ...restProps
-}: ParentSizeProps &
-  Omit<JSX.IntrinsicElements["div"], keyof ParentSizeProps>) {
+}: ParentSizeProps & Omit<JSX.IntrinsicElements['div'], keyof ParentSizeProps>) {
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
   const [state, setState] = useState<ParentSizeState | null>(null);
 
   const resize = useMemo(() => {
-    const normalized = Array.isArray(ignoreDimensions)
-      ? ignoreDimensions
-      : [ignoreDimensions];
+    const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
@@ -63,18 +60,14 @@ export default function ParentSize({
             left: 0,
           };
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
-          const keysWithChanges = stateKeys.filter(
-            (key) => existing[key] !== incoming[key]
-          );
-          const shouldBail = keysWithChanges.every((key) =>
-            normalized.includes(key)
-          );
+          const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
+          const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
 
           return shouldBail ? existing : incoming;
         });
       },
       debounceTime,
-      { leading: enableDebounceLeadingCall }
+      { leading: enableDebounceLeadingCall },
     );
   }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
@@ -97,12 +90,7 @@ export default function ParentSize({
   }, [resize]);
 
   return (
-    <div
-      style={parentSizeStyles}
-      ref={target}
-      className={className}
-      {...restProps}
-    >
+    <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
       {state &&
         children({
           ...state,

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -31,11 +31,13 @@ type ParentSizeState = {
 
 export type ParentSizeProvidedProps = ParentSizeState;
 
+const defaultIgnoreDimensions: ParentSizeProps['ignoreDimensions'] = [];
+
 export default function ParentSize({
   className,
   children,
   debounceTime = 300,
-  ignoreDimensions = [],
+  ignoreDimensions = defaultIgnoreDimensions,
   parentSizeStyles = { width: '100%', height: '100%' },
   enableDebounceLeadingCall = true,
   ...restProps
@@ -43,14 +45,20 @@ export default function ParentSize({
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
-  const [state, setState] = useState<ParentSizeState>({ width: 0, height: 0, top: 0, left: 0 });
+  const [state, setState] = useState<ParentSizeState | null>(null);
 
   const resize = useMemo(() => {
     const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
-        setState((existing) => {
+        setState((existingState) => {
+          const existing = existingState || {
+            width: 0,
+            height: 0,
+            top: 0,
+            left: 0,
+          };
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
           const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
           const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
@@ -83,7 +91,7 @@ export default function ParentSize({
 
   return (
     <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
-      {children({
+      {state && children({
         ...state,
         ref: target.current,
         resize,

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -1,6 +1,6 @@
-import debounce from 'lodash/debounce';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
+import debounce from "lodash/debounce";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import ResizeObserver from "resize-observer-polyfill";
 
 export type ParentSizeProps = {
   /** Optional `className` to add to the parent `div` wrapper used for size measurement. */
@@ -18,7 +18,7 @@ export type ParentSizeProps = {
     args: {
       ref: HTMLDivElement | null;
       resize: (state: ParentSizeState) => void;
-    } & ParentSizeState,
+    } & ParentSizeState
   ) => React.ReactNode;
 };
 
@@ -31,24 +31,27 @@ type ParentSizeState = {
 
 export type ParentSizeProvidedProps = ParentSizeState;
 
-const defaultIgnoreDimensions: ParentSizeProps['ignoreDimensions'] = [];
+const defaultIgnoreDimensions: ParentSizeProps["ignoreDimensions"] = [];
 
 export default function ParentSize({
   className,
   children,
   debounceTime = 300,
   ignoreDimensions = defaultIgnoreDimensions,
-  parentSizeStyles = { width: '100%', height: '100%' },
+  parentSizeStyles = { width: "100%", height: "100%" },
   enableDebounceLeadingCall = true,
   ...restProps
-}: ParentSizeProps & Omit<JSX.IntrinsicElements['div'], keyof ParentSizeProps>) {
+}: ParentSizeProps &
+  Omit<JSX.IntrinsicElements["div"], keyof ParentSizeProps>) {
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
   const [state, setState] = useState<ParentSizeState | null>(null);
 
   const resize = useMemo(() => {
-    const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
+    const normalized = Array.isArray(ignoreDimensions)
+      ? ignoreDimensions
+      : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
@@ -60,14 +63,18 @@ export default function ParentSize({
             left: 0,
           };
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
-          const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
-          const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
+          const keysWithChanges = stateKeys.filter(
+            (key) => existing[key] !== incoming[key]
+          );
+          const shouldBail = keysWithChanges.every((key) =>
+            normalized.includes(key)
+          );
 
           return shouldBail ? existing : incoming;
         });
       },
       debounceTime,
-      { leading: enableDebounceLeadingCall },
+      { leading: enableDebounceLeadingCall }
     );
   }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
@@ -90,12 +97,18 @@ export default function ParentSize({
   }, [resize]);
 
   return (
-    <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
-      {state && children({
-        ...state,
-        ref: target.current,
-        resize,
-      })}
+    <div
+      style={parentSizeStyles}
+      ref={target}
+      className={className}
+      {...restProps}
+    >
+      {state &&
+        children({
+          ...state,
+          ref: target.current,
+          resize,
+        })}
     </div>
   );
 }

--- a/packages/visx-responsive/src/components/ParentSizeModern.tsx
+++ b/packages/visx-responsive/src/components/ParentSizeModern.tsx
@@ -52,21 +52,19 @@ export default function ParentSize({
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
-  const [state, setState] = useState<ParentSizeState | null>(null);
+  const [state, setState] = useState<ParentSizeState>({
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+  });
 
   const resize = useMemo(() => {
     const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
-        setState((existingState) => {
-          const existing = existingState || {
-            width: 0,
-            height: 0,
-            top: 0,
-            left: 0,
-          };
-
+        setState((existing) => {
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
           const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
           const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
@@ -99,12 +97,11 @@ export default function ParentSize({
 
   return (
     <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
-      {state &&
-        children({
-          ...state,
-          ref: target.current,
-          resize,
-        })}
+      {children({
+        ...state,
+        ref: target.current,
+        resize,
+      })}
     </div>
   );
 }

--- a/packages/visx-responsive/src/components/ParentSizeModern.tsx
+++ b/packages/visx-responsive/src/components/ParentSizeModern.tsx
@@ -1,6 +1,6 @@
-import debounce from 'lodash/debounce';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ResizeObserver } from '../types';
+import debounce from "lodash/debounce";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { ResizeObserver } from "../types";
 
 // This can be deleted once https://git.io/Jk9FD lands in TypeScript
 declare global {
@@ -25,7 +25,7 @@ export type ParentSizeProps = {
     args: {
       ref: HTMLDivElement | null;
       resize: (state: ParentSizeState) => void;
-    } & ParentSizeState,
+    } & ParentSizeState
   ) => React.ReactNode;
 };
 
@@ -38,24 +38,27 @@ type ParentSizeState = {
 
 export type ParentSizeProvidedProps = ParentSizeState;
 
-const defaultIgnoreDimensions: ParentSizeProps['ignoreDimensions'] = [];
+const defaultIgnoreDimensions: ParentSizeProps["ignoreDimensions"] = [];
 
 export default function ParentSize({
   className,
   children,
   debounceTime = 300,
   ignoreDimensions = defaultIgnoreDimensions,
-  parentSizeStyles = { width: '100%', height: '100%' },
+  parentSizeStyles = { width: "100%", height: "100%" },
   enableDebounceLeadingCall = true,
   ...restProps
-}: ParentSizeProps & Omit<JSX.IntrinsicElements['div'], keyof ParentSizeProps>) {
+}: ParentSizeProps &
+  Omit<JSX.IntrinsicElements["div"], keyof ParentSizeProps>) {
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
   const [state, setState] = useState<ParentSizeState | null>(null);
 
   const resize = useMemo(() => {
-    const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
+    const normalized = Array.isArray(ignoreDimensions)
+      ? ignoreDimensions
+      : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
@@ -68,14 +71,18 @@ export default function ParentSize({
           };
 
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
-          const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
-          const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
+          const keysWithChanges = stateKeys.filter(
+            (key) => existing[key] !== incoming[key]
+          );
+          const shouldBail = keysWithChanges.every((key) =>
+            normalized.includes(key)
+          );
 
           return shouldBail ? existing : incoming;
         });
       },
       debounceTime,
-      { leading: enableDebounceLeadingCall },
+      { leading: enableDebounceLeadingCall }
     );
   }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
@@ -98,12 +105,18 @@ export default function ParentSize({
   }, [resize]);
 
   return (
-    <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
-      {state && children({
-        ...state,
-        ref: target.current,
-        resize,
-      })}
+    <div
+      style={parentSizeStyles}
+      ref={target}
+      className={className}
+      {...restProps}
+    >
+      {state &&
+        children({
+          ...state,
+          ref: target.current,
+          resize,
+        })}
     </div>
   );
 }

--- a/packages/visx-responsive/src/components/ParentSizeModern.tsx
+++ b/packages/visx-responsive/src/components/ParentSizeModern.tsx
@@ -1,6 +1,6 @@
-import debounce from "lodash/debounce";
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import { ResizeObserver } from "../types";
+import debounce from 'lodash/debounce';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ResizeObserver } from '../types';
 
 // This can be deleted once https://git.io/Jk9FD lands in TypeScript
 declare global {
@@ -25,7 +25,7 @@ export type ParentSizeProps = {
     args: {
       ref: HTMLDivElement | null;
       resize: (state: ParentSizeState) => void;
-    } & ParentSizeState
+    } & ParentSizeState,
   ) => React.ReactNode;
 };
 
@@ -38,27 +38,24 @@ type ParentSizeState = {
 
 export type ParentSizeProvidedProps = ParentSizeState;
 
-const defaultIgnoreDimensions: ParentSizeProps["ignoreDimensions"] = [];
+const defaultIgnoreDimensions: ParentSizeProps['ignoreDimensions'] = [];
 
 export default function ParentSize({
   className,
   children,
   debounceTime = 300,
   ignoreDimensions = defaultIgnoreDimensions,
-  parentSizeStyles = { width: "100%", height: "100%" },
+  parentSizeStyles = { width: '100%', height: '100%' },
   enableDebounceLeadingCall = true,
   ...restProps
-}: ParentSizeProps &
-  Omit<JSX.IntrinsicElements["div"], keyof ParentSizeProps>) {
+}: ParentSizeProps & Omit<JSX.IntrinsicElements['div'], keyof ParentSizeProps>) {
   const target = useRef<HTMLDivElement | null>(null);
   const animationFrameID = useRef(0);
 
   const [state, setState] = useState<ParentSizeState | null>(null);
 
   const resize = useMemo(() => {
-    const normalized = Array.isArray(ignoreDimensions)
-      ? ignoreDimensions
-      : [ignoreDimensions];
+    const normalized = Array.isArray(ignoreDimensions) ? ignoreDimensions : [ignoreDimensions];
 
     return debounce(
       (incoming: ParentSizeState) => {
@@ -71,18 +68,14 @@ export default function ParentSize({
           };
 
           const stateKeys = Object.keys(existing) as (keyof ParentSizeState)[];
-          const keysWithChanges = stateKeys.filter(
-            (key) => existing[key] !== incoming[key]
-          );
-          const shouldBail = keysWithChanges.every((key) =>
-            normalized.includes(key)
-          );
+          const keysWithChanges = stateKeys.filter((key) => existing[key] !== incoming[key]);
+          const shouldBail = keysWithChanges.every((key) => normalized.includes(key));
 
           return shouldBail ? existing : incoming;
         });
       },
       debounceTime,
-      { leading: enableDebounceLeadingCall }
+      { leading: enableDebounceLeadingCall },
     );
   }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
@@ -105,12 +98,7 @@ export default function ParentSize({
   }, [resize]);
 
   return (
-    <div
-      style={parentSizeStyles}
-      ref={target}
-      className={className}
-      {...restProps}
-    >
+    <div style={parentSizeStyles} ref={target} className={className} {...restProps}>
       {state &&
         children({
           ...state,


### PR DESCRIPTION
#### :boom: Breaking Changes

-

#### :rocket: Enhancements

-

#### :memo: Documentation

-

#### :bug: Bug Fix

I noticed that `debounceTime` wasn't being respected in ParentSize; the children function was being called many times a second. It ended up being because of the default value for `ignoreDimensions` triggering `useMemo` to reinstantiate the `resize` function, which makes the `useEffect` execute.

I also noticed that `children` always get's called initially with `width` 0. I changed that so a layout does not render until an initial width has been measured. We can remove this part of the PR if need be, but it will require users to add a `width === 0 ? null : renderContent()` type check anytime they use ParentSize to avoid rendering with that "incorrect" initial width.

#### :house: Internal

-
