### PR TITLE
Annotation label <foreignobject> render

### DIFF
--- a/packages/visx-annotation/src/components/HtmlLabel.tsx
+++ b/packages/visx-annotation/src/components/HtmlLabel.tsx
@@ -1,0 +1,87 @@
+import React, { useContext, useMemo } from 'react';
+import cx from 'classnames';
+import useMeasure from 'react-use-measure';
+import Group from '@visx/group/lib/Group';
+import AnnotationContext from '../context/AnnotationContext';
+import AnchorLine from './LabelAnchorLine';
+import { LabelProps } from './Label';
+
+const wrapperStyle = { display: 'inline-block' };
+
+export type HtmlLabelProps = Pick<
+  LabelProps,
+  | 'anchorLineStroke'
+  | 'className'
+  | 'horizontalAnchor'
+  | 'resizeObserverPolyfill'
+  | 'showAnchorLine'
+  | 'verticalAnchor'
+  | 'x'
+  | 'y'
+> & {
+  /** Pass in a custom element as the label to style as you like. Renders inside a <foreignObject>, be aware that most non-browser SVG renderers will not render HTML <foreignObject>s. See: https://github.com/airbnb/visx/issues/1173#issuecomment-1014380545.  */
+  children?: React.ReactNode;
+};
+export default function HtmlLabel({
+  anchorLineStroke = '#222',
+  children,
+  className,
+  horizontalAnchor: propsHorizontalAnchor,
+  resizeObserverPolyfill,
+  showAnchorLine = true,
+  verticalAnchor: propsVerticalAnchor,
+  x: propsX,
+  y: propsY,
+}: HtmlLabelProps) {
+  // we must measure the rendered title + subtitle to compute container height
+  const [labelRef, titleBounds] = useMeasure({
+    polyfill: resizeObserverPolyfill,
+  });
+  const { width, height } = titleBounds;
+
+  // if props are provided, they take precedence over context
+  const { x = 0, y = 0, dx = 0, dy = 0 } = useContext(AnnotationContext);
+
+  // offset container position based on horizontal + vertical anchor
+  const horizontalAnchor =
+    propsHorizontalAnchor || (Math.abs(dx) < Math.abs(dy) ? 'middle' : dx > 0 ? 'start' : 'end');
+  const verticalAnchor =
+    propsVerticalAnchor || (Math.abs(dx) > Math.abs(dy) ? 'middle' : dy > 0 ? 'start' : 'end');
+
+  const containerCoords = useMemo(() => {
+    let adjustedX: number = propsX == null ? x + dx : propsX;
+    let adjustedY: number = propsY == null ? y + dy : propsY;
+
+    if (horizontalAnchor === 'middle') adjustedX -= width / 2;
+    if (horizontalAnchor === 'end') adjustedX -= width;
+    if (verticalAnchor === 'middle') adjustedY -= height / 2;
+    if (verticalAnchor === 'end') adjustedY -= height;
+
+    return { x: adjustedX, y: adjustedY };
+  }, [propsX, x, dx, propsY, y, dy, horizontalAnchor, verticalAnchor, width, height]);
+
+  return (
+    <Group
+      top={containerCoords.y}
+      left={containerCoords.x}
+      pointerEvents="none"
+      className={cx('visx-annotationlabel', className)}
+    >
+      {showAnchorLine && (
+        <AnchorLine
+          anchorLineOrientation={Math.abs(dx) > Math.abs(dy) ? 'vertical' : 'horizontal'}
+          anchorLineStroke={anchorLineStroke}
+          verticalAnchor={verticalAnchor}
+          horizontalAnchor={horizontalAnchor}
+          width={width}
+          height={height}
+        />
+      )}
+      <foreignObject width={width} height={height} overflow="visible">
+        <div ref={labelRef} style={wrapperStyle}>
+          {children}
+        </div>
+      </foreignObject>
+    </Group>
+  );
+}

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -132,7 +132,7 @@ function ForeignObjectLabel({
           height={height}
         />
       )}
-      <foreignObject overflow="visible">
+      <foreignObject width={width} height={height} overflow="visible">
         <div ref={labelRef} style={{ display: 'inline-block' }}>
           {children}
         </div>

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -92,7 +92,6 @@ function ForeignObjectLabel({
     polyfill: resizeObserverPolyfill,
   });
   const { width, height } = titleBounds;
-  console.log(width, height);
 
   // if props are provided, they take precedence over context
   const { x = 0, y = 0, dx = 0, dy = 0 } = useContext(AnnotationContext);

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -15,6 +15,8 @@ export type LabelProps = {
   backgroundPadding?: number | { top?: number; right?: number; bottom?: number; left?: number };
   /** Additional props to be passed to background SVGRectElement. */
   backgroundProps?: React.SVGProps<SVGRectElement>;
+  /** Pass in a custom element as the label to style as you like. Renders inside a <foreignObject> */
+  children?: React.ReactNode;
   /** Optional className to apply to container in addition to 'visx-annotation-label'. */
   className?: string;
   /** Color of title and subtitle text. */
@@ -67,7 +69,79 @@ function getCompletePadding(padding: LabelProps['backgroundPadding']) {
   return { ...DEFAULT_PADDING, ...padding };
 }
 
-export default function Label({
+export default function Label({ ...props }: LabelProps) {
+  if (props.children) {
+    return <ForeignObjectLabel {...props} />;
+  }
+  return <SvgLabel {...props} />;
+}
+
+function ForeignObjectLabel({
+  anchorLineStroke = '#222',
+  children,
+  className,
+  horizontalAnchor: propsHorizontalAnchor,
+  resizeObserverPolyfill,
+  showAnchorLine = true,
+  verticalAnchor: propsVerticalAnchor,
+  x: propsX,
+  y: propsY,
+}: LabelProps) {
+  // we must measure the rendered title + subtitle to compute container height
+  const [labelRef, titleBounds] = useMeasure({
+    polyfill: resizeObserverPolyfill,
+  });
+  const { width, height } = titleBounds;
+  console.log(width, height);
+
+  // if props are provided, they take precedence over context
+  const { x = 0, y = 0, dx = 0, dy = 0 } = useContext(AnnotationContext);
+
+  // offset container position based on horizontal + vertical anchor
+  const horizontalAnchor =
+    propsHorizontalAnchor || (Math.abs(dx) < Math.abs(dy) ? 'middle' : dx > 0 ? 'start' : 'end');
+  const verticalAnchor =
+    propsVerticalAnchor || (Math.abs(dx) > Math.abs(dy) ? 'middle' : dy > 0 ? 'start' : 'end');
+
+  const containerCoords = useMemo(() => {
+    let adjustedX: number = propsX == null ? x + dx : propsX;
+    let adjustedY: number = propsY == null ? y + dy : propsY;
+
+    if (horizontalAnchor === 'middle') adjustedX -= width / 2;
+    if (horizontalAnchor === 'end') adjustedX -= width;
+    if (verticalAnchor === 'middle') adjustedY -= height / 2;
+    if (verticalAnchor === 'end') adjustedY -= height;
+
+    return { x: adjustedX, y: adjustedY };
+  }, [propsX, x, dx, propsY, y, dy, horizontalAnchor, verticalAnchor, width, height]);
+
+  return (
+    <Group
+      top={containerCoords.y}
+      left={containerCoords.x}
+      pointerEvents="none"
+      className={cx('visx-annotationlabel', className)}
+    >
+      {showAnchorLine && (
+        <AnchorLine
+          anchorLineOrientation={Math.abs(dx) > Math.abs(dy) ? 'vertical' : 'horizontal'}
+          anchorLineStroke={anchorLineStroke}
+          verticalAnchor={verticalAnchor}
+          horizontalAnchor={horizontalAnchor}
+          width={width}
+          height={height}
+        />
+      )}
+      <foreignObject overflow="visible">
+        <div ref={labelRef} style={{ display: 'inline-block' }}>
+          {children}
+        </div>
+      </foreignObject>
+    </Group>
+  );
+}
+
+function SvgLabel({
   anchorLineStroke = '#222',
   backgroundFill = '#eaeaea',
   backgroundPadding,
@@ -94,8 +168,12 @@ export default function Label({
   y: propsY,
 }: LabelProps) {
   // we must measure the rendered title + subtitle to compute container height
-  const [titleRef, titleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
-  const [subtitleRef, subtitleBounds] = useMeasure({ polyfill: resizeObserverPolyfill });
+  const [titleRef, titleBounds] = useMeasure({
+    polyfill: resizeObserverPolyfill,
+  });
+  const [subtitleRef, subtitleBounds] = useMeasure({
+    polyfill: resizeObserverPolyfill,
+  });
 
   const padding = useMemo(() => getCompletePadding(backgroundPadding), [backgroundPadding]);
 
@@ -182,10 +260,6 @@ export default function Label({
     [subtitleFontSize, subtitleFontWeight, subtitleFontFamily],
   ) as React.CSSProperties;
 
-  const anchorLineOrientation = Math.abs(dx) > Math.abs(dy) ? 'vertical' : 'horizontal';
-
-  const backgroundOutline = showAnchorLine ? { stroke: anchorLineStroke, strokeWidth: 2 } : null;
-
   return !title && !subtitle ? null : (
     <Group
       top={containerCoords.y}
@@ -206,20 +280,14 @@ export default function Label({
         />
       )}
       {showAnchorLine && (
-        <>
-          {anchorLineOrientation === 'horizontal' && verticalAnchor === 'start' && (
-            <line {...backgroundOutline} x1={0} x2={width} y1={0} y2={0} />
-          )}
-          {anchorLineOrientation === 'horizontal' && verticalAnchor === 'end' && (
-            <line {...backgroundOutline} x1={0} x2={width} y1={height} y2={height} />
-          )}
-          {anchorLineOrientation === 'vertical' && horizontalAnchor === 'start' && (
-            <line {...backgroundOutline} x1={0} x2={0} y1={0} y2={height} />
-          )}
-          {anchorLineOrientation === 'vertical' && horizontalAnchor === 'end' && (
-            <line {...backgroundOutline} x1={width} x2={width} y1={0} y2={height} />
-          )}
-        </>
+        <AnchorLine
+          anchorLineOrientation={Math.abs(dx) > Math.abs(dy) ? 'vertical' : 'horizontal'}
+          anchorLineStroke={anchorLineStroke}
+          verticalAnchor={verticalAnchor}
+          horizontalAnchor={horizontalAnchor}
+          width={width}
+          height={height}
+        />
       )}
       {title && (
         <Text
@@ -253,5 +321,41 @@ export default function Label({
         </Text>
       )}
     </Group>
+  );
+}
+
+interface AnchorLineProps {
+  anchorLineOrientation: 'horizontal' | 'vertical';
+  verticalAnchor: TextProps['verticalAnchor'];
+  horizontalAnchor: TextProps['textAnchor'];
+  anchorLineStroke: string;
+  width: number;
+  height: number;
+}
+function AnchorLine({
+  anchorLineOrientation,
+  anchorLineStroke,
+  verticalAnchor,
+  horizontalAnchor,
+  width,
+  height,
+}: AnchorLineProps) {
+  const backgroundOutline = { stroke: anchorLineStroke, strokeWidth: 2 };
+
+  return (
+    <>
+      {anchorLineOrientation === 'horizontal' && verticalAnchor === 'start' && (
+        <line {...backgroundOutline} x1={0} x2={width} y1={0} y2={0} />
+      )}
+      {anchorLineOrientation === 'horizontal' && verticalAnchor === 'end' && (
+        <line {...backgroundOutline} x1={0} x2={width} y1={height} y2={height} />
+      )}
+      {anchorLineOrientation === 'vertical' && horizontalAnchor === 'start' && (
+        <line {...backgroundOutline} x1={0} x2={0} y1={0} y2={height} />
+      )}
+      {anchorLineOrientation === 'vertical' && horizontalAnchor === 'end' && (
+        <line {...backgroundOutline} x1={width} x2={width} y1={0} y2={height} />
+      )}
+    </>
   );
 }

--- a/packages/visx-annotation/src/components/LabelAnchorLine.tsx
+++ b/packages/visx-annotation/src/components/LabelAnchorLine.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { TextProps } from '@visx/text';
+
+interface AnchorLineProps {
+  anchorLineOrientation: 'horizontal' | 'vertical';
+  verticalAnchor: TextProps['verticalAnchor'];
+  horizontalAnchor: TextProps['textAnchor'];
+  anchorLineStroke: string;
+  width: number;
+  height: number;
+}
+
+export default function AnchorLine({
+  anchorLineOrientation,
+  anchorLineStroke,
+  verticalAnchor,
+  horizontalAnchor,
+  width,
+  height,
+}: AnchorLineProps) {
+  const backgroundOutline = { stroke: anchorLineStroke, strokeWidth: 2 };
+
+  return (
+    <>
+      {anchorLineOrientation === 'horizontal' && verticalAnchor === 'start' && (
+        <line {...backgroundOutline} x1={0} x2={width} y1={0} y2={0} />
+      )}
+      {anchorLineOrientation === 'horizontal' && verticalAnchor === 'end' && (
+        <line {...backgroundOutline} x1={0} x2={width} y1={height} y2={height} />
+      )}
+      {anchorLineOrientation === 'vertical' && horizontalAnchor === 'start' && (
+        <line {...backgroundOutline} x1={0} x2={0} y1={0} y2={height} />
+      )}
+      {anchorLineOrientation === 'vertical' && horizontalAnchor === 'end' && (
+        <line {...backgroundOutline} x1={width} x2={width} y1={0} y2={height} />
+      )}
+    </>
+  );
+}

--- a/packages/visx-annotation/src/index.ts
+++ b/packages/visx-annotation/src/index.ts
@@ -1,5 +1,6 @@
 export { default as Connector } from './components/Connector';
 export { default as Label } from './components/Label';
+export { default as HtmlLabel } from './components/HtmlLabel';
 export { default as CircleSubject } from './components/CircleSubject';
 export { default as LineSubject } from './components/LineSubject';
 export { default as Annotation } from './components/Annotation';

--- a/packages/visx-annotation/test/Label.test.tsx
+++ b/packages/visx-annotation/test/Label.test.tsx
@@ -11,6 +11,7 @@ describe('<Label />', () => {
   it('should render title Text', () => {
     expect(
       shallow(<Label title="title test" resizeObserverPolyfill={ResizeObserver} />)
+        .dive()
         .children()
         .find(Text)
         .prop('children'),
@@ -25,6 +26,7 @@ describe('<Label />', () => {
           resizeObserverPolyfill={ResizeObserver}
         />,
       )
+        .dive()
         .children()
         .find(Text)
         .at(1)
@@ -33,16 +35,18 @@ describe('<Label />', () => {
   });
   it('should render a background', () => {
     expect(
-      shallow(
-        <Label title="title test" showBackground resizeObserverPolyfill={ResizeObserver} />,
-      ).find('rect'),
+      shallow(<Label title="title test" showBackground resizeObserverPolyfill={ResizeObserver} />)
+        .dive()
+        .find('rect'),
     ).toHaveLength(1);
   });
   it('should render an anchor line', () => {
     expect(
-      shallow(
-        <Label title="title test" showAnchorLine resizeObserverPolyfill={ResizeObserver} />,
-      ).find('line'),
+      shallow(<Label title="title test" showAnchorLine resizeObserverPolyfill={ResizeObserver} />)
+        .dive()
+        .find('AnchorLine')
+        .dive()
+        .find('line'),
     ).toHaveLength(1);
   });
 });

--- a/packages/visx-demo/src/pages/docs/annotation.tsx
+++ b/packages/visx-demo/src/pages/docs/annotation.tsx
@@ -6,6 +6,7 @@ import CircleSubject from '../../../../visx-annotation/src/components/CircleSubj
 import LineSubject from '../../../../visx-annotation/src/components/LineSubject';
 import Connector from '../../../../visx-annotation/src/components/Connector';
 import Label from '../../../../visx-annotation/src/components/Label';
+import HtmlLabel from '../../../../visx-annotation/src/components/HtmlLabel';
 import LinePathAnnotationDeprecated from '../../../../visx-annotation/src/deprecated/LinePathAnnotation';
 import DocPage from '../../components/DocPage';
 import AnnotationTile from '../../components/Gallery/AnnotationTile';
@@ -17,6 +18,7 @@ const components = [
   LineSubject,
   Connector,
   Label,
+  HtmlLabel,
   LinePathAnnotationDeprecated,
 ];
 


### PR DESCRIPTION
#### :rocket: Enhancements

Add option to pass in an element to render as a label as a child.
Uses <foreignObject> to allow user to pass in an HTML element.

Related to this discussion: https://github.com/airbnb/visx/issues/1173

This has the benefit of letting the element handle text reflow, with
the drawback being that the user need to manage min and max width of
the container element they render.

This approach seems much better imo, favouring composability over
configuration which is much more in line with the philosophy of d3.