### PR TITLE
fix(zoom): avoid 2x scale invocations on wheel end

### DIFF
--- a/packages/visx-zoom/src/Zoom.tsx
+++ b/packages/visx-zoom/src/Zoom.tsx
@@ -321,13 +321,7 @@ function Zoom<ElementType extends Element>({
       onDragStart: ({ event }) => {
         if (!(event instanceof KeyboardEvent)) dragStart(event);
       },
-      onDrag: (args) => {
-        console.log('onDrag args', args);
-        const { event, pinching, cancel, active } = args;
-        if (!active) {
-          console.log('onDrag !active, bailing');
-          return;
-        }
+      onDrag: ({ event, pinching, cancel }) => {
         if (pinching) {
           cancel();
           dragEnd();
@@ -340,7 +334,6 @@ function Zoom<ElementType extends Element>({
       onWheel: ({ event, active }) => {
         // currently onWheelEnd emits one final wheel event which causes 2x scale
         // updates for the last tick. ensuring that the gesture is active avoids this
-        // https://github.com/pmndrs/use-gesture/blob/374b87e043030c0927de9eb609149b3156b5bc5b/packages/core/src/engines/WheelEngine.ts#L33
         if (!active) return;
         handleWheel(event);
       },

--- a/packages/visx-zoom/src/Zoom.tsx
+++ b/packages/visx-zoom/src/Zoom.tsx
@@ -321,7 +321,13 @@ function Zoom<ElementType extends Element>({
       onDragStart: ({ event }) => {
         if (!(event instanceof KeyboardEvent)) dragStart(event);
       },
-      onDrag: ({ event, pinching, cancel }) => {
+      onDrag: (args) => {
+        console.log('onDrag args', args);
+        const { event, pinching, cancel, active } = args;
+        if (!active) {
+          console.log('onDrag !active, bailing');
+          return;
+        }
         if (pinching) {
           cancel();
           dragEnd();
@@ -331,7 +337,13 @@ function Zoom<ElementType extends Element>({
       },
       onDragEnd: dragEnd,
       onPinch: handlePinch,
-      onWheel: ({ event }) => handleWheel(event),
+      onWheel: ({ event, active }) => {
+        // currently onWheelEnd emits one final wheel event which causes 2x scale
+        // updates for the last tick. ensuring that the gesture is active avoids this
+        // https://github.com/pmndrs/use-gesture/blob/374b87e043030c0927de9eb609149b3156b5bc5b/packages/core/src/engines/WheelEngine.ts#L33
+        if (!active) return;
+        handleWheel(event);
+      },
     },
     { target: containerRef, eventOptions: { passive: false }, drag: { filterTaps: true } },
   );


### PR DESCRIPTION
#### :bug: Bug Fix

This fixes https://github.com/airbnb/visx/issues/1382 where the `useGesture` refactor of `@visx/zoom` led to 2x scale calls on the final `onWheel` invocation where the gesture is no longer active (see this [line](https://github.com/pmndrs/use-gesture/blob/374b87e043030c0927de9eb609149b3156b5bc5b/packages/core/src/engines/WheelEngine.ts#L29) where the `onWheel` event is emitted on "wheel end" causing it to get triggered one extra time at the end, thanks @nikostri for digging into this! 🙏 ).

Hard to capture the fix in a screenshot, but here you can see that we can detect the gesture is no longer `active` and bail before the second call to avoid the second scale.

<img src="https://user-images.githubusercontent.com/4496521/150243633-3e774207-1307-4bf2-819e-cabcfd7964a1.png" width="600" />

@gazcn007 @kristw @hshoff 
cc @ronlv10 @nikostri 