### PR TITLE
deps: replace resize-observer-polyfill with @juggle/resize-observer

### DIFF
--- a/packages/visx-annotation/package.json
+++ b/packages/visx-annotation/package.json
@@ -42,7 +42,7 @@
     "react-use-measure": "^2.0.4"
   },
   "devDependencies": {
-    "resize-observer-polyfill": "^1.5.1"
+    "@juggle/resize-observer": "^3.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/visx-annotation/test/Label.test.tsx
+++ b/packages/visx-annotation/test/Label.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from '@juggle/resize-observer';
 import Text from '@visx/text/lib/Text';
 import { shallow } from 'enzyme';
 import { Label } from '../src';

--- a/packages/visx-responsive/package.json
+++ b/packages/visx-responsive/package.json
@@ -32,7 +32,7 @@
     "@types/react": "*",
     "lodash": "^4.17.21",
     "prop-types": "^15.6.1",
-    "resize-observer-polyfill": "1.5.1"
+    "@juggle/resize-observer": "^3.3.1"
   },
   "peerDependencies": {
     "react": "^16.0.0-0 || ^17.0.0-0"

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -1,6 +1,6 @@
 import debounce from 'lodash/debounce';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from '@juggle/resize-observer';
 
 export type ParentSizeProps = {
   /** Optional `className` to add to the parent `div` wrapper used for size measurement. */

--- a/packages/visx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSize.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import debounce from 'lodash/debounce';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from '@juggle/resize-observer';
 
 const CONTAINER_STYLES = { width: '100%', height: '100%' };
 

--- a/packages/visx-tooltip/package.json
+++ b/packages/visx-tooltip/package.json
@@ -38,6 +38,9 @@
     "react": "^16.8.0-0 || ^17.0.0-0",
     "react-dom": "^16.8.0-0 || ^17.0.0-0"
   },
+  "devDependencies": {
+    "@juggle/resize-observer": "^3.3.1"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/visx-tooltip/test/useTooltipInPortal.test.tsx
+++ b/packages/visx-tooltip/test/useTooltipInPortal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from '@juggle/resize-observer';
 import { useTooltipInPortal } from '../src';
 import { UseTooltipPortalOptions } from '../src/hooks/useTooltipInPortal';
 

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -63,6 +63,6 @@
     "prop-types": "^15.6.2"
   },
   "devDependencies": {
-    "resize-observer-polyfill": "1.5.1"
+    "@juggle/resize-observer": "^3.3.1"
   }
 }

--- a/packages/visx-xychart/test/components/Tooltip.test.tsx
+++ b/packages/visx-xychart/test/components/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from '@juggle/resize-observer';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { AnyD3Scale } from '@visx/scale';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2883,6 +2883,11 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -13912,11 +13917,6 @@ reserved-words@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
   integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
-
-resize-observer-polyfill@1.5.1, resize-observer-polyfill@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### :house: Internal

Fixes #1325 . This refactors our usage of `resize-observer-polyfill` to `@juggle/resize-observer`. The former is no longer maintained and its `ResizeObserver` types will conflict with `typescript@^4`'s own type defs (see https://github.com/que-etc/resize-observer-polyfill/issues/83, thus this fixes one subtask of #1421). 

It makes the changes in the following packages:

- `@visx/responsive`: dependency
- `@visx/annotation`: devDependency
- `@visx/xychart`: devDependency
- `@visx/tooltip`: devDependency (this was actually missing previously)

@gazcn007 @kristw @hshoff
cc @gbiryukov