### PR TITLE
fix(responsive): remove global ResizeObserver type declaration

### DIFF
--- a/packages/visx-responsive/src/components/ParentSizeModern.tsx
+++ b/packages/visx-responsive/src/components/ParentSizeModern.tsx
@@ -2,11 +2,9 @@ import debounce from 'lodash/debounce';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ResizeObserver } from '../types';
 
-// This can be deleted once https://git.io/Jk9FD lands in TypeScript
-declare global {
-  interface Window {
-    ResizeObserver: ResizeObserver;
-  }
+// @TODO remove when upgraded to TS 4 which has its own declaration
+interface PrivateWindow {
+  ResizeObserver: ResizeObserver;
 }
 
 export type ParentSizeProps = {
@@ -78,7 +76,7 @@ export default function ParentSize({
   }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
   useEffect(() => {
-    const observer = new window.ResizeObserver((entries) => {
+    const observer = new (window as unknown as PrivateWindow).ResizeObserver((entries) => {
       entries.forEach((entry) => {
         const { left, top, width, height } = entry.contentRect;
         animationFrameID.current = window.requestAnimationFrame(() => {

--- a/packages/visx-responsive/src/enhancers/withParentSizeModern.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSizeModern.tsx
@@ -4,11 +4,9 @@ import { ResizeObserver } from '../types';
 
 const CONTAINER_STYLES = { width: '100%', height: '100%' };
 
-// This can be deleted once https://git.io/Jk9FD lands in TypeScript
-declare global {
-  interface Window {
-    ResizeObserver: ResizeObserver;
-  }
+// @TODO remove when upgraded to TS 4 which has its own declaration
+interface PrivateWindow {
+  ResizeObserver: ResizeObserver;
 }
 
 export type WithParentSizeProps = {
@@ -45,7 +43,7 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
     container: HTMLDivElement | null = null;
 
     componentDidMount() {
-      this.resizeObserver = new window.ResizeObserver((entries) => {
+      this.resizeObserver = new (window as unknown as PrivateWindow).ResizeObserver((entries) => {
         entries.forEach((entry) => {
           const { width, height } = entry.contentRect;
           this.animationFrameID = window.requestAnimationFrame(() => {

--- a/packages/visx-responsive/src/types/index.ts
+++ b/packages/visx-responsive/src/types/index.ts
@@ -1,4 +1,4 @@
-// This file can be deleted once https://git.io/Jk9FD lands in TypeScript
+// @TODO remove when upgraded to TS 4 which has its own declaration
 interface ResizeObserverEntry {
   contentRect: {
     left: number;

--- a/packages/visx-responsive/src/types/index.ts
+++ b/packages/visx-responsive/src/types/index.ts
@@ -8,6 +8,7 @@ interface ResizeObserverEntry {
   };
 }
 type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
+
 export interface ResizeObserver {
   // eslint-disable-next-line @typescript-eslint/no-misused-new
   new (callback: ResizeObserverCallback): ResizeObserver;


### PR DESCRIPTION
#### :bug: Bug Fix

This supersedes https://github.com/airbnb/visx/pull/1253 and fixes https://github.com/airbnb/visx/pull/1104. It removes the global declaration of `ResizeObserver` which breaks consumers ability to upgrade to `typescript@4` (which has its own `ResizeObserver` types).

Somewhat related to https://github.com/airbnb/visx/pull/1422

@gazcn007 @hshoff @kristw 
cc @MSiddharthReddy @HHK1