### PR TITLE
new(annotation): add HtmlLabel demo, add containterStyle prop

### DIFF
--- a/packages/visx-annotation/src/components/HtmlLabel.tsx
+++ b/packages/visx-annotation/src/components/HtmlLabel.tsx
@@ -21,11 +21,14 @@ export type HtmlLabelProps = Pick<
 > & {
   /** Pass in a custom element as the label to style as you like. Renders inside a <foreignObject>, be aware that most non-browser SVG renderers will not render HTML <foreignObject>s. See: https://github.com/airbnb/visx/issues/1173#issuecomment-1014380545.  */
   children?: React.ReactNode;
+  /** Optional styles to apply to the HTML container. */
+  containerStyle?: React.CSSProperties;
 };
 export default function HtmlLabel({
   anchorLineStroke = '#222',
   children,
   className,
+  containerStyle,
   horizontalAnchor: propsHorizontalAnchor,
   resizeObserverPolyfill,
   showAnchorLine = true,
@@ -67,6 +70,14 @@ export default function HtmlLabel({
       pointerEvents="none"
       className={cx('visx-annotationlabel', className)}
     >
+      <foreignObject width={width} height={height} overflow="visible">
+        <div
+          ref={labelRef}
+          style={containerStyle ? { ...wrapperStyle, ...containerStyle } : wrapperStyle}
+        >
+          {children}
+        </div>
+      </foreignObject>
       {showAnchorLine && (
         <AnchorLine
           anchorLineOrientation={Math.abs(dx) > Math.abs(dy) ? 'vertical' : 'horizontal'}
@@ -77,11 +88,6 @@ export default function HtmlLabel({
           height={height}
         />
       )}
-      <foreignObject width={width} height={height} overflow="visible">
-        <div ref={labelRef} style={wrapperStyle}>
-          {children}
-        </div>
-      </foreignObject>
     </Group>
   );
 }

--- a/packages/visx-annotation/test/HtmlLabel.test.tsx
+++ b/packages/visx-annotation/test/HtmlLabel.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+import { render } from '@testing-library/react';
+
+import { HtmlLabel } from '../src';
+
+describe('<HtmlLabel />', () => {
+  it('should render HTML content', () => {
+    const { container } = render(
+      <svg>
+        <HtmlLabel resizeObserverPolyfill={ResizeObserver}>
+          <h1>Hello, HTML</h1>
+        </HtmlLabel>
+      </svg>,
+    );
+    const h1Element = container.querySelector('h1');
+    expect(h1Element).not.toBeNull();
+  });
+});

--- a/packages/visx-annotation/test/HtmlLabel.test.tsx
+++ b/packages/visx-annotation/test/HtmlLabel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
+import { ResizeObserver } from '@juggle/resize-observer';
 import { render } from '@testing-library/react';
 
 import { HtmlLabel } from '../src';

--- a/packages/visx-demo/src/pages/annotation.tsx
+++ b/packages/visx-demo/src/pages/annotation.tsx
@@ -4,7 +4,7 @@ import Annotation from '../sandboxes/visx-annotation/Example';
 import AnnotationSource from '!!raw-loader!../sandboxes/visx-annotation/Example';
 import packageJson from '../sandboxes/visx-annotation/package.json';
 
-export default () => (
+const AnnotationPage = () => (
   <Show
     component={Annotation}
     title="Annotation"
@@ -14,3 +14,5 @@ export default () => (
     {AnnotationSource}
   </Show>
 );
+
+export default AnnotationPage;

--- a/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label, Connector, CircleSubject, LineSubject } from '@visx/annotation';
+import { HtmlLabel, Label, Connector, CircleSubject, LineSubject } from '@visx/annotation';
 import { LinePath } from '@visx/shape';
 
 import ExampleControls from './ExampleControls';
@@ -28,6 +28,7 @@ export default function Example({ width, height, compact = false }: AnnotationPr
         getDate,
         getStockValue,
         horizontalAnchor,
+        labelType,
         labelWidth,
         setAnnotationPosition,
         showAnchorLine,
@@ -83,18 +84,41 @@ export default function Example({ width, height, compact = false }: AnnotationPr
             }}
           >
             <Connector stroke={orange} type={connectorType} />
-            <Label
-              backgroundFill="white"
-              showAnchorLine={showAnchorLine}
-              anchorLineStroke={greens[2]}
-              backgroundProps={{ stroke: greens[1] }}
-              fontColor={greens[2]}
-              horizontalAnchor={horizontalAnchor}
-              subtitle={subtitle}
-              title={title}
-              verticalAnchor={verticalAnchor}
-              width={labelWidth}
-            />
+            {labelType === 'svg' ? (
+              <Label
+                backgroundFill="white"
+                showAnchorLine={showAnchorLine}
+                anchorLineStroke={greens[2]}
+                backgroundProps={{ stroke: greens[1] }}
+                fontColor={greens[2]}
+                horizontalAnchor={horizontalAnchor}
+                subtitle={subtitle}
+                title={title}
+                verticalAnchor={verticalAnchor}
+                width={labelWidth}
+              />
+            ) : (
+              <HtmlLabel
+                showAnchorLine={showAnchorLine}
+                anchorLineStroke={greens[2]}
+                horizontalAnchor={horizontalAnchor}
+                verticalAnchor={verticalAnchor}
+                containerStyle={{
+                  width: labelWidth,
+                  background: 'white',
+                  border: `1px solid ${greens[1]}`,
+                  borderRadius: 2,
+                  color: greens[2],
+                  fontSize: '0.55em',
+                  lineHeight: '1em',
+                  padding: '0 0.4em 0 1em',
+                  fontWeight: 200,
+                }}
+              >
+                <h3 style={{ margin: '1em 0 -0.5em' }}>{title}</h3>
+                <p>{subtitle}</p>
+              </HtmlLabel>
+            )}
             {subjectType === 'circle' && <CircleSubject stroke={orange} />}
             {subjectType !== 'circle' && (
               <LineSubject

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -24,6 +24,7 @@ type ProvidedProps = {
   getDate: (d: AppleStock) => number;
   getStockValue: (d: AppleStock) => number;
   horizontalAnchor?: 'start' | 'middle' | 'end';
+  labelType: 'svg' | 'html';
   labelWidth: number;
   setAnnotationPosition: (position: AnnotationPosition) => void;
   showAnchorLine: boolean;
@@ -73,6 +74,7 @@ export default function ExampleControls({
   const [connectorType, setConnectorType] = useState<ProvidedProps['connectorType']>('elbow');
   const [subjectType, setSubjectType] = useState<ProvidedProps['subjectType']>('circle');
   const [showAnchorLine, setShowAnchorLine] = useState(true);
+  const [labelType, setLabelType] = useState<ProvidedProps['labelType']>('svg');
   const [verticalAnchor, setVerticalAnchor] = useState<ProvidedProps['verticalAnchor'] | 'auto'>(
     'auto',
   );
@@ -109,6 +111,7 @@ export default function ExampleControls({
         getDate,
         getStockValue,
         horizontalAnchor: horizontalAnchor === 'auto' ? undefined : horizontalAnchor,
+        labelType,
         labelWidth,
         setAnnotationPosition,
         showAnchorLine,
@@ -148,6 +151,25 @@ export default function ExampleControls({
                 checked={editLabelPosition}
               />
               Edit label position
+            </label>
+          </div>
+          <div>
+            <strong>Label content type</strong>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setLabelType('svg')}
+                checked={labelType === 'svg'}
+              />
+              Svg
+            </label>
+            <label>
+              <input
+                type="radio"
+                onChange={() => setLabelType('html')}
+                checked={labelType === 'html'}
+              />
+              Html
             </label>
           </div>
           <div>


### PR DESCRIPTION
#### :rocket: Enhancements

These were called out as optional in  #1383 where `HtmlLabel` was added to `@visx/annotation`:
- render `AnnotationLine` **on top of** the html content so its not clipped
- add an optional `containerStyle` prop so that consumers don't have to add an extra wrapper `div` to apply styles (since `HtmlLabel` already renders one).

#### :memo: Documentation

Adds an `Annotation content type` control to the `/annotation` demo to enable toggling between the `SVG <> HTML` label types.

<img src="https://user-images.githubusercontent.com/4496521/150604415-3a377b8f-a6bd-4180-8f71-27c3fb372283.gif" width="600" />

#### :house: Internal

Adds a simple jest test for the new `HtmlLabel`


@valtism @hshoff @gazcn007 @kristw 