### PR TITLE
feat(xychart): add ssr to xychart

### DIFF
--- a/packages/visx-xychart/src/components/XYChart.tsx
+++ b/packages/visx-xychart/src/components/XYChart.tsx
@@ -1,11 +1,12 @@
 /* eslint jsx-a11y/mouse-events-have-key-events: 'off', @typescript-eslint/no-explicit-any: 'off' */
 import React, { useContext, useEffect } from 'react';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
-import { AxisScaleOutput } from '@visx/axis';
+import { AxisScale, AxisScaleOutput } from '@visx/axis';
 import { ScaleConfig } from '@visx/scale';
 
 import DataContext from '../context/DataContext';
 import { Margin, EventHandlerParams } from '../types';
+import { DataRegistryEntry } from '../types/data';
 import useEventEmitter from '../hooks/useEventEmitter';
 import EventEmitterProvider from '../providers/EventEmitterProvider';
 import TooltipContext from '../context/TooltipContext';
@@ -35,14 +36,18 @@ export type XYChartProps<
   height?: number;
   /** Margin to apply around the outside. */
   margin?: Margin;
+  /** XYChart data to be rendered in Series. */
+  data?:
+    | DataRegistryEntry<AxisScale, AxisScale, Datum>
+    | DataRegistryEntry<AxisScale, AxisScale, Datum>[];
   /** XYChart children (Series, Tooltip, etc.). */
   children: React.ReactNode;
   /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the theme. */
-  theme?: DataProviderProps<XScaleConfig, YScaleConfig>['theme'];
+  theme?: DataProviderProps<XScaleConfig, YScaleConfig, Datum>['theme'];
   /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the xScale config. */
-  xScale?: DataProviderProps<XScaleConfig, YScaleConfig>['xScale'];
+  xScale?: DataProviderProps<XScaleConfig, YScaleConfig, Datum>['xScale'];
   /** If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as the yScale config. */
-  yScale?: DataProviderProps<XScaleConfig, YScaleConfig>['yScale'];
+  yScale?: DataProviderProps<XScaleConfig, YScaleConfig, Datum>['yScale'];
   /* If DataContext is not available, XYChart will wrap itself in a DataProvider and set this as horizontal. Determines whether Series will be plotted horizontally (e.g., horizontal bars). By default this will try to be inferred based on scale types. */
   horizontal?: boolean | 'auto';
   /** Callback invoked for onPointerMove events for the nearest Datum to the PointerEvent _for each Series with pointerEvents={true}_. */
@@ -85,6 +90,7 @@ export default function XYChart<
     accessibilityLabel = 'XYChart',
     captureEvents = true,
     children,
+    data,
     height,
     horizontal,
     margin = DEFAULT_MARGIN,
@@ -127,6 +133,7 @@ export default function XYChart<
     }
     return (
       <DataProvider
+        data={data}
         xScale={xScale}
         yScale={yScale}
         theme={theme}

--- a/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
+++ b/packages/visx-xychart/src/enhancers/withRegisteredData.tsx
@@ -46,7 +46,7 @@ export default function withRegisteredData<
     >;
 
     useEffect(() => {
-      if (dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });
+      if (data && dataRegistry) dataRegistry.registerData({ key: dataKey, data, xAccessor, yAccessor });
       return () => dataRegistry?.unregisterData(dataKey);
     }, [dataRegistry, dataKey, data, xAccessor, yAccessor]);
 

--- a/packages/visx-xychart/src/providers/DataProvider.tsx
+++ b/packages/visx-xychart/src/providers/DataProvider.tsx
@@ -2,8 +2,9 @@
 import { ScaleConfig, ScaleConfigToD3Scale } from '@visx/scale';
 import React, { useContext, useMemo } from 'react';
 import createOrdinalScale from '@visx/scale/lib/scales/ordinal';
-import { AxisScaleOutput } from '@visx/axis';
+import { AxisScale, AxisScaleOutput } from '@visx/axis';
 import { XYChartTheme } from '../types';
+import { DataRegistryEntry } from '../types/data';
 import ThemeContext from '../context/ThemeContext';
 import DataContext from '../context/DataContext';
 import useDataRegistry from '../hooks/useDataRegistry';
@@ -15,6 +16,7 @@ import isDiscreteScale from '../utils/isDiscreteScale';
 export type DataProviderProps<
   XScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>,
   YScaleConfig extends ScaleConfig<AxisScaleOutput, any, any>,
+  Datum extends object,
 > = {
   /* Optionally define the initial dimensions. */
   initialDimensions?: Partial<Dimensions>;
@@ -24,6 +26,10 @@ export type DataProviderProps<
   xScale: XScaleConfig;
   /* y-scale configuration whose shape depends on scale type. */
   yScale: YScaleConfig;
+  /** XYChart data to be rendered in Series. */
+  data?:
+    | DataRegistryEntry<AxisScale, AxisScale, Datum>
+    | DataRegistryEntry<AxisScale, AxisScale, Datum>[];
   /* Any React children. */
   children: React.ReactNode;
   /* Determines whether Series will be plotted horizontally (e.g., horizontal bars). By default this will try to be inferred based on scale types. */
@@ -39,9 +45,10 @@ export default function DataProvider<
   theme: propsTheme,
   xScale: xScaleConfig,
   yScale: yScaleConfig,
+  data,
   children,
   horizontal: initialHorizontal = 'auto',
-}: DataProviderProps<XScaleConfig, YScaleConfig>) {
+}: DataProviderProps<XScaleConfig, YScaleConfig, Datum>) {
   // `DataProvider` provides a theme so that `ThemeProvider` is not strictly needed.
   // `props.theme` takes precedent over `context.theme`, which has a default even if
   // a ThemeProvider is not present.
@@ -55,6 +62,10 @@ export default function DataProvider<
   type YScale = ScaleConfigToD3Scale<YScaleConfig, AxisScaleOutput, any, any>;
 
   const dataRegistry = useDataRegistry<XScale, YScale, Datum>();
+
+  useMemo(() => {
+    if (data) dataRegistry.registerData(data)
+  }, [data]);
 
   const { xScale, yScale }: { xScale?: XScale; yScale?: YScale } = useScales({
     dataRegistry,

--- a/packages/visx-xychart/src/types/series.ts
+++ b/packages/visx-xychart/src/types/series.ts
@@ -29,11 +29,11 @@ export type SeriesProps<
   /** Required data key for the Series, should be unique across all series. */
   dataKey: string;
   /** Data for the Series. */
-  data: Datum[];
+  data?: Datum[];
   /** Given a Datum, returns the x-scale value. */
-  xAccessor: (d: Datum) => ScaleInput<XScale>;
+  xAccessor?: (d: Datum) => ScaleInput<XScale>;
   /** Given a Datum, returns the y-scale value. */
-  yAccessor: (d: Datum) => ScaleInput<YScale>;
+  yAccessor?: (d: Datum) => ScaleInput<YScale>;
   /**
    * Callback invoked for onPointerMove events for the nearest Datum to the PointerEvent.
    * By default XYChart will capture and emit PointerEvents, invoking this function for


### PR DESCRIPTION
#### :rocket: Enhancements

- Allows data to be set upfront in <XYChart> as well as in in child Series components.
- Fixes a chicken-and-egg issue where we delay rendering until data is passed into the children Series components.