### PR TITLE
fix(xychart, react-spring): fix duplicate key warning in Axis/Grid

### DIFF
--- a/packages/visx-grid/src/grids/GridColumns.tsx
+++ b/packages/visx-grid/src/grids/GridColumns.tsx
@@ -43,9 +43,10 @@ export default function GridColumns<Scale extends GridScale>({
 }: AllGridColumnsProps<Scale>) {
   const ticks = tickValues ?? getTicks(scale, numTicks);
   const scaleOffset = (offset ?? 0) + getScaleBandwidth(scale) / 2;
-  const tickLines = ticks.map((d) => {
+  const tickLines = ticks.map((d, index) => {
     const x = (coerceNumber(scale(d)) ?? 0) + scaleOffset;
     return {
+      index,
       from: new Point({
         x,
         y: 0,
@@ -60,9 +61,9 @@ export default function GridColumns<Scale extends GridScale>({
     <Group className={cx('visx-columns', className)} top={top} left={left}>
       {children
         ? children({ lines: tickLines })
-        : tickLines.map(({ from, to }, i) => (
+        : tickLines.map(({ from, to, index }) => (
             <Line
-              key={`column-line-${i}`}
+              key={`column-line-${index}`}
               from={from}
               to={to}
               stroke={stroke}

--- a/packages/visx-grid/src/grids/GridRows.tsx
+++ b/packages/visx-grid/src/grids/GridRows.tsx
@@ -43,9 +43,10 @@ export default function GridRows<Scale extends GridScale>({
 }: AllGridRowsProps<Scale>) {
   const ticks = tickValues ?? getTicks(scale, numTicks);
   const scaleOffset = (offset ?? 0) + getScaleBandwidth(scale) / 2;
-  const tickLines = ticks.map((d) => {
+  const tickLines = ticks.map((d, index) => {
     const y = (coerceNumber(scale(d)) ?? 0) + scaleOffset;
     return {
+      index,
       from: new Point({
         x: 0,
         y,
@@ -60,9 +61,9 @@ export default function GridRows<Scale extends GridScale>({
     <Group className={cx('visx-rows', className)} top={top} left={left}>
       {children
         ? children({ lines: tickLines })
-        : tickLines.map(({ from, to }, i) => (
+        : tickLines.map(({ from, to, index }) => (
             <Line
-              key={`row-line-${i}`}
+              key={`row-line-${index}`}
               from={from}
               to={to}
               stroke={stroke}

--- a/packages/visx-grid/src/types.ts
+++ b/packages/visx-grid/src/types.ts
@@ -10,7 +10,11 @@ export type GridScale<Output extends GridScaleOutput = GridScaleOutput> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   D3Scale<Output, any, any>;
 
-export type GridLines = { from: { x?: number; y?: number }; to: { x?: number; y?: number } }[];
+export type GridLines = {
+  from: { x?: number; y?: number };
+  to: { x?: number; y?: number };
+  index: number;
+}[];
 
 export type CommonGridProps = {
   /** classname to apply to line group element. */

--- a/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
+++ b/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
@@ -27,7 +27,7 @@ export default function AnimatedTicks<Scale extends AxisScale>({
       animateXOrY: horizontal ? 'x' : 'y',
       animationTrajectory,
     }),
-    keys: (tick: ComputedTick<Scale>) => `${tick.value}`,
+    keys: (tick: ComputedTick<Scale>) => `tick-${tick.value}-${tick.index}`,
   });
 
   return (

--- a/packages/visx-react-spring/src/grid/AnimatedGridColumns.tsx
+++ b/packages/visx-react-spring/src/grid/AnimatedGridColumns.tsx
@@ -32,7 +32,7 @@ export default function AnimatedGridColumns<Scale extends GridScale>({
           lines={lines}
           animationTrajectory={animationTrajectory}
           animateXOrY="x"
-          lineKey={(line) => String(line?.from?.x ?? '')}
+          lineKey={(line) => `column-${line?.from?.x ?? ''}-${line.index}`}
           {...lineProps}
         />
       )}

--- a/packages/visx-react-spring/src/grid/AnimatedGridRows.tsx
+++ b/packages/visx-react-spring/src/grid/AnimatedGridRows.tsx
@@ -32,7 +32,7 @@ export default function AnimatedGridRows<Scale extends GridScale>({
           lines={lines}
           animationTrajectory={animationTrajectory}
           animateXOrY="y"
-          lineKey={(line) => String(line?.from?.y ?? '')}
+          lineKey={(line) => `row-${line?.from?.y ?? ''}-${line.index}`}
           {...lineProps}
         />
       )}


### PR DESCRIPTION
#### :bug: Bug Fix

Fixes https://github.com/airbnb/visx/issues/1435 and possibly related to https://github.com/airbnb/visx/issues/1038, https://github.com/airbnb/visx/issues/969 (both closed)

Was able to reproduce @carlsverre 's issue by using a time scale where values only varied on the order of MS – as suggested the value is coerced to a date string which omits the MS and is therefore equal across children

<img width="1685" alt="image" src="https://user-images.githubusercontent.com/4496521/165852604-6afca6d7-3222-4c59-a6d3-a6b683226594.png">


I updated the logic to include the index of the tick (and made the same fix for animated grid columns/rows) and the warning disappeared 😎 

@kristw 
cc @carlsverre @mithi
