### PR TITLE
feat(xychart): add colorAccessor to LineSeries

### DIFF
--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -20,9 +20,12 @@ export type BaseLineSeriesProps<
   PathComponent?: React.FC<Omit<React.SVGProps<SVGPathElement>, 'ref'>> | 'path';
   /** Sets the curve factory (from @visx/curve or d3-curve) for the line generator. Defaults to curveLinear. */
   curve?: LinePathProps<Datum>['curve'];
+  /** Given a datakey, returns its color. Falls back to theme color if unspecified or if a null-ish value is returned. */
+  colorAccessor?: (dataKey: string) => string | undefined | null,
 } & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
 
 function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({
+  colorAccessor,
   curve,
   data,
   dataKey,
@@ -85,7 +88,7 @@ function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datu
       <LinePath x={getScaledX} y={getScaledY} defined={isDefined} curve={curve} {...lineProps}>
         {({ path }) => (
           <PathComponent
-            stroke={color}
+            stroke={colorAccessor?.(dataKey) ?? color}
             strokeWidth={2}
             fill="transparent"
             strokeLinecap="round" // without this a datum surrounded by nulls will not be visible

--- a/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseLineSeries.tsx
@@ -21,7 +21,7 @@ export type BaseLineSeriesProps<
   /** Sets the curve factory (from @visx/curve or d3-curve) for the line generator. Defaults to curveLinear. */
   curve?: LinePathProps<Datum>['curve'];
   /** Given a datakey, returns its color. Falls back to theme color if unspecified or if a null-ish value is returned. */
-  colorAccessor?: (dataKey: string) => string | undefined | null,
+  colorAccessor?: (dataKey: string) => string | undefined | null;
 } & Omit<React.SVGProps<SVGPathElement>, 'x' | 'y' | 'x0' | 'x1' | 'y0' | 'y1' | 'ref'>;
 
 function BaseLineSeries<XScale extends AxisScale, YScale extends AxisScale, Datum extends object>({

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -85,6 +85,21 @@ describe('<LineSeries />', () => {
       { showTooltip, hideTooltip },
     );
   });
+
+  it('should use colorAccessor if passed', () => {
+    const {container} = render(
+      <DataContext.Provider value={getDataContext(series)}>
+        <svg>
+          <LineSeries
+            dataKey={series.key}
+            {...series}
+            colorAccessor={(_) => 'banana'}
+          />
+        </svg>
+      </DataContext.Provider>,
+    );
+    expect(container.querySelector('path')).toHaveAttribute('stroke', 'banana')
+  });
 });
 
 describe('<AnimatedLineSeries />', () => {

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -87,18 +87,14 @@ describe('<LineSeries />', () => {
   });
 
   it('should use colorAccessor if passed', () => {
-    const {container} = render(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
-          <LineSeries
-            dataKey={series.key}
-            {...series}
-            colorAccessor={(_) => 'banana'}
-          />
+          <LineSeries dataKey={series.key} {...series} colorAccessor={(_) => 'banana'} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(container.querySelector('path')).toHaveAttribute('stroke', 'banana')
+    expect(container.querySelector('path')).toHaveAttribute('stroke', 'banana');
   });
 });
 


### PR DESCRIPTION
#### :rocket: Enhancements

- Add colorAccessor to XYChart LineSeries prop that accepts a function that takes the dataKey and returns a color, replacing the default theme color

resolves #1260

Based on #1005 