### PR TITLE
fix(brush): vertical brush with useWindowMoveEvents

### DIFF
--- a/packages/visx-brush/src/BaseBrush.tsx
+++ b/packages/visx-brush/src/BaseBrush.tsx
@@ -200,7 +200,7 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
                     ? Math.min(Math.max(x0 + offsetX, prevBrush.bounds.x0), prevBrush.bounds.x1)
                     : x0,
                 y:
-                  brushingType === 'bottom'
+                  brushingType === 'top'
                     ? Math.min(Math.max(y0 + offsetY, prevBrush.bounds.y0), prevBrush.bounds.y1)
                     : y0,
               },


### PR DESCRIPTION
#### :bug: Bug Fix

- Fix vertical resizing of a `Brush` with `useWindowMoveEvents` https://github.com/airbnb/visx/issues/1385

`handleWindowPointerMove` was checking `brushingType === 'bottom'` for both top and bottom, so dragging the top did nothing, and dragging the bottom moved the whole brush (since it was applying the offset to both `y0` and `y1`).