### PR TITLE
chore: Update deps for react-spring to specific target

### DIFF
--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -93,7 +93,7 @@
     "react-dom": "^18.0.0",
     "react-github-button": "^0.1.10",
     "react-markdown": "^4.3.1",
-    "react-spring": "^9.2.0",
+    "@react-spring/web": "^9.4.5",
     "react-tilt": "^0.1.4",
     "recompose": "^0.26.0",
     "topojson-client": "^3.0.0"

--- a/packages/visx-demo/src/sandboxes/visx-axis/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-axis/package.json
@@ -22,7 +22,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-scripts-ts": "3.1.0",
-    "react-spring": "^9.2.0",
+    "@react-spring/web": "^9.4.5",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/visx-demo/src/sandboxes/visx-shape-line-radial/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-line-radial/Example.tsx
@@ -11,7 +11,7 @@ import appleStock, { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
 import { LinearGradient } from '@visx/gradient';
 import { AxisLeft } from '@visx/axis';
 import { GridRadial, GridAngle } from '@visx/grid';
-import { animated, useSpring } from 'react-spring';
+import { animated, useSpring } from '@react-spring/web';
 
 const green = '#e5fd3d';
 export const blue = '#aeeef8';

--- a/packages/visx-demo/src/sandboxes/visx-shape-line-radial/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-shape-line-radial/package.json
@@ -19,7 +19,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-scripts-ts": "3.1.0",
-    "react-spring": "^9.2.0",
+    "@react-spring/web": "^9.4.5",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/visx-demo/src/sandboxes/visx-shape-pie/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-pie/Example.tsx
@@ -5,7 +5,7 @@ import { Group } from '@visx/group';
 import { GradientPinkBlue } from '@visx/gradient';
 import letterFrequency, { LetterFrequency } from '@visx/mock-data/lib/mocks/letterFrequency';
 import browserUsage, { BrowserUsage as Browsers } from '@visx/mock-data/lib/mocks/browserUsage';
-import { animated, useTransition, interpolate } from 'react-spring';
+import { animated, useTransition, interpolate } from '@react-spring/web';
 
 // data and types
 type BrowserNames = keyof Browsers;

--- a/packages/visx-demo/src/sandboxes/visx-shape-pie/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-shape-pie/package.json
@@ -16,7 +16,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-scripts-ts": "3.1.0",
-    "react-spring": "^9.2.0",
+    "@react-spring/web": "^9.4.5",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/visx-demo/src/sandboxes/visx-streamgraph/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-streamgraph/Example.tsx
@@ -8,7 +8,7 @@ import { Stack } from '@visx/shape';
 import { PatternCircles, PatternWaves } from '@visx/pattern';
 import { scaleLinear, scaleOrdinal } from '@visx/scale';
 import { transpose } from 'd3-array';
-import { animated, useSpring } from 'react-spring';
+import { animated, useSpring } from '@react-spring/web';
 
 import useForceUpdate from './useForceUpdate';
 import generateData from './generateData';

--- a/packages/visx-demo/src/sandboxes/visx-streamgraph/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-streamgraph/package.json
@@ -17,7 +17,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-scripts-ts": "3.1.0",
-    "react-spring": "^9.2.0",
+    "@react-spring/web": "^9.4.5",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/visx-demo/src/sandboxes/visx-xychart/package.json
+++ b/packages/visx-demo/src/sandboxes/visx-xychart/package.json
@@ -17,7 +17,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-scripts-ts": "3.1.0",
-    "react-spring": "^9.2.0",
+    "@react-spring/web": "^9.4.5",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/visx-react-spring/package.json
+++ b/packages/visx-react-spring/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0-0 || ^17.0.0 || ^18.0.0",
-    "react-spring": "^9.2.0"
+    "@react-spring/web": "^9.4.5"
   },
   "dependencies": {
     "@types/react": "*",

--- a/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
+++ b/packages/visx-react-spring/src/axis/AnimatedTicks.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { animated, useTransition, to, SpringValue } from 'react-spring';
+import { animated, useTransition, to, SpringValue } from '@react-spring/web';
 import cx from 'classnames';
 import Orientation from '@visx/axis/lib/constants/orientation';
 import { ComputedTick, TicksRendererProps, AxisScale } from '@visx/axis/lib/types';

--- a/packages/visx-react-spring/src/grid/AnimatedGridLines.tsx
+++ b/packages/visx-react-spring/src/grid/AnimatedGridLines.tsx
@@ -1,5 +1,5 @@
 import React, { SVGProps } from 'react';
-import { animated, useTransition } from 'react-spring';
+import { animated, useTransition } from '@react-spring/web';
 import { GridScale, GridLines, CommonGridProps } from '@visx/grid/lib/types';
 import useLineTransitionConfig, {
   TransitionConfig,

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^ 18.0.0",
-    "react-spring": "^9.2.0"
+    "@react-spring/web": "^9.4.5"
   },
   "dependencies": {
     "@types/lodash": "^4.14.172",

--- a/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
+++ b/packages/visx-xychart/src/components/annotation/AnimatedAnnotation.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { useSpring, animated, to } from 'react-spring';
+import { useSpring, animated, to } from '@react-spring/web';
 import {
   Annotation as VisxAnnotation,
   EditableAnnotation as VisxEditableAnnotation,

--- a/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedBars.tsx
@@ -1,7 +1,7 @@
 import { AxisScale } from '@visx/axis';
 import { BarRounded } from '@visx/shape';
 import React, { useMemo } from 'react';
-import { animated, useTransition } from 'react-spring';
+import { animated, useTransition } from '@react-spring/web';
 import { Bar, BarsProps } from '../../../types';
 import { cleanColor, colorHasUrl } from '../../../utils/cleanColorString';
 import getScaleBaseline from '../../../utils/getScaleBaseline';

--- a/packages/visx-xychart/src/components/series/private/AnimatedGlyphs.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedGlyphs.tsx
@@ -1,6 +1,6 @@
 import { AxisScale } from '@visx/axis';
 import React, { useMemo } from 'react';
-import { useTransition, animated, to } from 'react-spring';
+import { useTransition, animated, to } from '@react-spring/web';
 import getScaleBaseline from '../../../utils/getScaleBaseline';
 import { GlyphProps, GlyphsProps } from '../../../types';
 import { cleanColor, colorHasUrl } from '../../../utils/cleanColorString';

--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { animated, useSpring } from 'react-spring';
+import { animated, useSpring } from '@react-spring/web';
 // @ts-ignore no types
 import { interpolatePath } from 'd3-interpolate-path';
 import debounce from 'lodash/debounce';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,90 +3921,51 @@
   dependencies:
     "@octokit/openapi-types" "^9.3.0"
 
-"@react-spring/animated@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.2.4.tgz#062ecc0fdfef89f2541a42d8500428b70035f879"
-  integrity sha512-AfV6ZM8pCCAT29GY5C8/1bOPjZrv/7kD0vedjiE/tEYvNDwg9GlscrvsTViWR2XykJoYrDfdkYArrldWpsCJ5g==
+"@react-spring/animated@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.4.5.tgz#dd9921c716a4f4a3ed29491e0c0c9f8ca0eb1a54"
+  integrity sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==
   dependencies:
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
+    "@react-spring/shared" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
-"@react-spring/core@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.2.4.tgz#275a4a065e3a315a4f5fb28c9a6f62ce718c25d6"
-  integrity sha512-R+PwyfsjiuYCWqaTTfCpYpRmsP0h87RNm7uxC1Uxy7QAHUfHEm2sAHn+AdHPwq/MbVwDssVT8C5yf2WGcqiXGg==
+"@react-spring/core@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.4.5.tgz#4616e1adc18dd10f5731f100ebdbe9518b89ba3c"
+  integrity sha512-83u3FzfQmGMJFwZLAJSwF24/ZJctwUkWtyPD7KYtNagrFeQKUH1I05ZuhmCmqW+2w1KDW1SFWQ43RawqfXKiiQ==
   dependencies:
-    "@react-spring/animated" "~9.2.0"
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
+    "@react-spring/animated" "~9.4.5"
+    "@react-spring/rafz" "~9.4.5"
+    "@react-spring/shared" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
-"@react-spring/konva@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.2.4.tgz#e467b24b3b110ba496526c9001439ce561641e0d"
-  integrity sha512-19anDOIkfjcydDTfGgVIuZ3lruZxKubYGs9oHCswaP8SRLj7c1kkopJHUr/S4LXGxiIdqdF0XucWm0iTEPEq4w==
+"@react-spring/rafz@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.4.5.tgz#84f809f287f2a66bbfbc66195db340482f886bd7"
+  integrity sha512-swGsutMwvnoyTRxvqhfJBtGM8Ipx6ks0RkIpNX9F/U7XmyPvBMGd3GgX/mqxZUpdlsuI1zr/jiYw+GXZxAlLcQ==
+
+"@react-spring/shared@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.4.5.tgz#4c3ad817bca547984fb1539204d752a412a6d829"
+  integrity sha512-JhMh3nFKsqyag0KM5IIM8BQANGscTdd0mMv3BXsUiMZrcjQTskyfnv5qxEeGWbJGGar52qr5kHuBHtCjQOzniA==
   dependencies:
-    "@react-spring/animated" "~9.2.0"
-    "@react-spring/core" "~9.2.0"
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
+    "@react-spring/rafz" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
-"@react-spring/native@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.2.4.tgz#0fd335a44c05023f5428df444d8f1aa3da7abfc9"
-  integrity sha512-xKJWKh5qOhSclpL3iuGwJRLoZzTNvlBEnIrMs8yh8xvX6z9Lmnu4uGu5DpfrnM1GzBvRoktoCoLEx/VcEYFSng==
+"@react-spring/types@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.4.5.tgz#9c71e5ff866b5484a7ef3db822bf6c10e77bdd8c"
+  integrity sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg==
+
+"@react-spring/web@^9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.4.5.tgz#b92f05b87cdc0963a59ee149e677dcaff09f680e"
+  integrity sha512-NGAkOtKmOzDEctL7MzRlQGv24sRce++0xAY7KlcxmeVkR7LRSGkoXHaIfm9ObzxPMcPHQYQhf3+X9jepIFNHQA==
   dependencies:
-    "@react-spring/animated" "~9.2.0"
-    "@react-spring/core" "~9.2.0"
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
-
-"@react-spring/rafz@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.2.4.tgz#44793e9adc14dd0dcd1573d094368af11a89d73a"
-  integrity sha512-SOKf9eue+vAX+DGo7kWYNl9i9J3gPUlQjifIcV9Bzw9h3i30wPOOP0TjS7iMG/kLp2cdHQYDNFte6nt23VAZkQ==
-
-"@react-spring/shared@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.2.4.tgz#f9cc66ac5308a77293330a18518e34121f4008c1"
-  integrity sha512-ZEr4l2BxmyFRUvRA2VCkPfCJii4E7cGkwbjmTBx1EmcGrOnde/V2eF5dxqCTY3k35QuCegkrWe0coRJVkh8q2Q==
-  dependencies:
-    "@react-spring/rafz" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
-
-"@react-spring/three@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.2.4.tgz#849c97658a6e1410b6f823ad21e2ee33feada820"
-  integrity sha512-ljFig7XW099VWwRPKPUf+4yYLivp/sSWXN3oO5SJOF/9BSoV1quS/9chZ5Myl5J14od3CsHf89Tv4FdlX5kHlA==
-  dependencies:
-    "@react-spring/animated" "~9.2.0"
-    "@react-spring/core" "~9.2.0"
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
-
-"@react-spring/types@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.2.4.tgz#2365ce9d761f548a9adcb2cd68714bf26765a5de"
-  integrity sha512-zHUXrWO8nweUN/ISjrjqU7GgXXvoEbFca1CgiE0TY0H/dqJb3l+Rhx8ecPVNYimzFg3ZZ1/T0egpLop8SOv4aA==
-
-"@react-spring/web@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.2.4.tgz#c6d5464a954bfd0d7bc90117050f796a95ebfa08"
-  integrity sha512-vtPvOalLFvuju/MDBtoSnCyt0xXSL6Amyv82fljOuWPl1yGd4M1WteijnYL9Zlriljl0a3oXcPunAVYTD9dbDQ==
-  dependencies:
-    "@react-spring/animated" "~9.2.0"
-    "@react-spring/core" "~9.2.0"
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
-
-"@react-spring/zdog@~9.2.0":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.2.4.tgz#db1d1924fe9920e917d889c4d3bb138bd0885cf1"
-  integrity sha512-rv7ptedS37SHr6yuCbRkUErAzAhebdgt8f4KUtZWzseC+7qLNkaZWf+uujgsb881qAuX9b9yz8rre9UKeYepgw==
-  dependencies:
-    "@react-spring/animated" "~9.2.0"
-    "@react-spring/core" "~9.2.0"
-    "@react-spring/shared" "~9.2.0"
-    "@react-spring/types" "~9.2.0"
+    "@react-spring/animated" "~9.4.5"
+    "@react-spring/core" "~9.4.5"
+    "@react-spring/shared" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
@@ -4395,14 +4356,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-dom@*":
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.1.tgz#cb3cc10ea91141b12c71001fede1017acfbce4db"
-  integrity sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@^18.0.0":
   version "18.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.1.tgz#cb3cc10ea91141b12c71001fede1017acfbce4db"
   integrity sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==
@@ -13430,18 +13384,6 @@ react-shallow-renderer@^16.13.1:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
-
-react-spring@^9.2.0:
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.2.4.tgz#9d89b0321664d594f957dca9459b13d94b3dfa39"
-  integrity sha512-bMjbyTW0ZGd+/h9cjtohLqCwOGqX2OuaTvalOVfLCGmhzEg/u3GgopI3LAm4UD2Br3MNdVdGgNVoESg4MGqKFQ==
-  dependencies:
-    "@react-spring/core" "~9.2.0"
-    "@react-spring/konva" "~9.2.0"
-    "@react-spring/native" "~9.2.0"
-    "@react-spring/three" "~9.2.0"
-    "@react-spring/web" "~9.2.0"
-    "@react-spring/zdog" "~9.2.0"
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"


### PR DESCRIPTION
#### :house: Internal

- Updates all dependencies on react-spring to the specific web target (`@react-spring/web`)
- This follows recommended practice (see react-spring [Getting Started](https://github.com/pmndrs/react-spring#%EF%B8%8F-jump-start))
- This change also mitigates a critical vulnerability in the @react-spring/native dependency tree: 
```
└─┬ react-spring@9.4.5
  └─┬ @react-spring/native@9.4.5
    └─┬ react-native@0.69.0
      └── hermes-engine@0.11.0
```
- See the related [GitHub Advisory database entry](https://github.com/advisories/GHSA-327c-qx3v-h673) for hermes-engine