### PR TITLE
fix(demo,shape): fix SplitLinePath key

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-shape-splitlinepath/Example.tsx
@@ -27,7 +27,7 @@ const renderNumberSegment: SplitLinePathRenderer = ({ segment, styles }) => (
   <g>
     {segment.map(({ x, y }, i) =>
       i % 25 === 0 ? (
-        <g transform={`translate(${x},${y})`}>
+        <g key={i} transform={`translate(${x},${y})`}>
           <circle r={2} fill="#222" />
           <text key={i} dx={3} dy={3} fontSize={8}>
             {i}

--- a/packages/visx-shape/src/shapes/SplitLinePath.tsx
+++ b/packages/visx-shape/src/shapes/SplitLinePath.tsx
@@ -69,7 +69,9 @@ export default function SplitLinePath<Datum>({
     <g>
       {splitLineSegments.map((segment, index) =>
         children ? (
-          children({ index, segment, styles: styles[index] || styles[index % styles.length] })
+          <React.Fragment key={index}>
+            {children({ index, segment, styles: styles[index] || styles[index % styles.length] })}
+          </React.Fragment>
         ) : (
           <LinePath
             key={index}


### PR DESCRIPTION
#### :bug: Bug Fix

Fixes some key warnings I noticed in the splitline demo, one comes from the demo and the other from the component in `@visx/shape`

<img width="600" alt="image" src="https://user-images.githubusercontent.com/4496521/176256116-6d4f43f5-e216-47a5-ab29-e11129b15494.png">

@kristw 