### PR TITLE
fix(text, shape): Hide generated text element from assistive technologies

### DIFF
--- a/packages/visx-shape/src/util/getOrCreateMeasurementElement.ts
+++ b/packages/visx-shape/src/util/getOrCreateMeasurementElement.ts
@@ -6,7 +6,9 @@ export default function getOrCreateMeasurementElement(elementId: string) {
   // create a single path element if not done already
   if (!pathElement) {
     const svg = document.createElementNS(SVG_NAMESPACE_URL, 'svg');
+
     // not visible
+    svg.setAttribute('aria-hidden', 'true');
     svg.style.opacity = '0';
     svg.style.width = '0';
     svg.style.height = '0';

--- a/packages/visx-text/src/util/getStringWidth.ts
+++ b/packages/visx-text/src/util/getStringWidth.ts
@@ -8,6 +8,7 @@ function getStringWidth(str: string, style?: object) {
     let textEl = document.getElementById(MEASUREMENT_ELEMENT_ID) as SVGTextElement | null;
     if (!textEl) {
       const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('aria-hidden', 'true');
       svg.style.width = '0';
       svg.style.height = '0';
       svg.style.position = 'absolute';


### PR DESCRIPTION
Fixes: https://github.com/airbnb/visx/issues/1544

Currently the generated svg used to calculate text and shape size are being read by assitive technologies like screen readers.  This PR hides the generated element so it's now hidden for both screen reader and visual users. 

I tested using the demo app and verified the attribute was being added within Chrome dev tools. 
![image](https://user-images.githubusercontent.com/9698979/182695325-4535687f-bc94-426f-9a8e-8b2355364d8b.png)
