### PR TITLE
feat(axis): add an ability to specify different paddings for the start and the end of the axis

### DIFF
--- a/packages/visx-axis/src/axis/Axis.tsx
+++ b/packages/visx-axis/src/axis/Axis.tsx
@@ -8,6 +8,7 @@ import getTickPosition from '../utils/getTickPosition';
 import getTickFormatter from '../utils/getTickFormatter';
 import createPoint from '../utils/createPoint';
 import Orientation from '../constants/orientation';
+import getAxisRangePaddingConfig from '../utils/getAxisRangePaddingConfig';
 
 export type AxisProps<Scale extends AxisScale> = SharedAxisProps<Scale> & {
   orientation?: Orientation;
@@ -40,9 +41,14 @@ export default function Axis<Scale extends AxisScale>({
   const tickSign = isLeft || isTop ? -1 : 1;
 
   const range = scale.range();
-  const axisFromPoint = createPoint({ x: Number(range[0]) + 0.5 - rangePadding, y: 0 }, horizontal);
+  const rangePaddingConfig = getAxisRangePaddingConfig(rangePadding);
+
+  const axisFromPoint = createPoint(
+    { x: Number(range[0]) + 0.5 - rangePaddingConfig.start, y: 0 },
+    horizontal,
+  );
   const axisToPoint = createPoint(
-    { x: Number(range[range.length - 1]) + 0.5 + rangePadding, y: 0 },
+    { x: Number(range[range.length - 1]) + 0.5 + rangePaddingConfig.end, y: 0 },
     horizontal,
   );
 

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -70,8 +70,8 @@ export type CommonProps<Scale extends AxisScale> = {
   numTicks?: number;
   /** Placement of the axis */
   orientation?: Orientation;
-  /** Pixel padding to apply to both sides of the axis. */
-  rangePadding?: number;
+  /** Pixel padding to apply to axis sides. */
+  rangePadding?: number | { start?: number; end?: number };
   /** The color for the stroke of the lines. */
   stroke?: string;
   /** The pixel value for the width of the lines. */

--- a/packages/visx-axis/src/utils/getAxisRangePaddingConfig.ts
+++ b/packages/visx-axis/src/utils/getAxisRangePaddingConfig.ts
@@ -1,0 +1,11 @@
+import { SharedAxisProps } from '../types';
+
+export const defaultAxisRangePadding = 0;
+
+export default function getAxisRangePaddingConfig(
+  originalRangePadding: SharedAxisProps<never>['rangePadding'] = defaultAxisRangePadding,
+) {
+  return typeof originalRangePadding === 'number'
+    ? { start: originalRangePadding, end: originalRangePadding }
+    : { start: defaultAxisRangePadding, end: defaultAxisRangePadding, ...originalRangePadding };
+}

--- a/packages/visx-axis/test/utils/getAxisRangePaddingConfig.test.ts
+++ b/packages/visx-axis/test/utils/getAxisRangePaddingConfig.test.ts
@@ -1,0 +1,29 @@
+import getAxisRangePaddingConfig, {
+  defaultAxisRangePadding,
+} from '../../src/utils/getAxisRangePaddingConfig';
+
+describe('getAxisRangePaddingConfig(rangePadding)', () => {
+  it('should return default range padding config', () => {
+    const actualResult = getAxisRangePaddingConfig();
+    const expectedResult = { start: defaultAxisRangePadding, end: defaultAxisRangePadding };
+    expect(actualResult).toEqual(expectedResult);
+  });
+
+  it('should support range padding as a number', () => {
+    const actualResult = getAxisRangePaddingConfig(8);
+    const expectedResult = { start: 8, end: 8 };
+    expect(actualResult).toEqual(expectedResult);
+  });
+
+  it('should support range padding as a config object', () => {
+    const testCases = [
+      { input: { start: 5 }, expectedResult: { start: 5, end: defaultAxisRangePadding } },
+      { input: { end: 10 }, expectedResult: { start: defaultAxisRangePadding, end: 10 } },
+      { input: { start: 15, end: 5 }, expectedResult: { start: 15, end: 5 } },
+    ];
+    testCases.forEach(({ input, expectedResult }) => {
+      const actualResult = getAxisRangePaddingConfig(input);
+      expect(actualResult).toEqual(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
Hi, everyone! First of all, I want to say, that I'm impressed by the `visx` project, and I'm happy that I discovered it for myself! 

Currently, we are migrating our system from `recharts` to `visx` and found out that there is no way to specify different paddings for the start and the end of the axis. Such ability is present in `recharts` (https://recharts.org/en-US/api/XAxis#padding, https://recharts.org/en-US/api/YAxis#padding), and now we need to work around it using `hideAxisLine` option and our custom line. So it will be nice to have it also in `visx`.  

#### :rocket: Enhancements

- add an ability to specify different paddings for the start and the end of the axis

