### PR TITLE
fix(tooltip, bounds): replace findDOMNode with refs for TooltipWithBounds

### DIFF
--- a/packages/visx-bounds/src/enhancers/withBoundingRects.tsx
+++ b/packages/visx-bounds/src/enhancers/withBoundingRects.tsx
@@ -24,6 +24,7 @@ export type WithBoundingRectsProps = {
   getRects?: () => { rect: rectShape; parentRect: rectShape };
   rect?: rectShape;
   parentRect?: rectShape;
+  nodeRef?: React.RefObject<HTMLElement>;
 };
 
 export default function withBoundingRects<Props extends object = {}>(
@@ -32,17 +33,21 @@ export default function withBoundingRects<Props extends object = {}>(
   return class WrappedComponent extends React.PureComponent<Props> {
     static displayName = `withBoundingRects(${BaseComponent.displayName || ''})`;
     node: HTMLElement | undefined | null;
+    nodeRef: React.RefObject<HTMLElement>;
     constructor(props: Props) {
       super(props);
       this.state = {
         rect: undefined,
         parentRect: undefined,
       };
+      this.nodeRef = React.createRef();
       this.getRects = this.getRects.bind(this);
     }
 
     componentDidMount() {
-      this.node = ReactDOM.findDOMNode(this) as HTMLElement;
+      this.node = this.nodeRef?.current
+        ? this.nodeRef.current
+        : (ReactDOM.findDOMNode(this) as HTMLElement);
       this.setState(() => this.getRects());
     }
 
@@ -62,7 +67,14 @@ export default function withBoundingRects<Props extends object = {}>(
     }
 
     render() {
-      return <BaseComponent getRects={this.getRects} {...this.state} {...this.props} />;
+      return (
+        <BaseComponent
+          nodeRef={this.nodeRef}
+          getRects={this.getRects}
+          {...this.state}
+          {...this.props}
+        />
+      );
     }
   };
 }

--- a/packages/visx-tooltip/src/tooltips/Tooltip.tsx
+++ b/packages/visx-tooltip/src/tooltips/Tooltip.tsx
@@ -43,30 +43,42 @@ export const defaultStyles: React.CSSProperties = {
   pointerEvents: 'none',
 };
 
-export default function Tooltip({
-  className,
-  top,
-  left,
-  offsetLeft = 10,
-  offsetTop = 10,
-  style = defaultStyles,
-  children,
-  unstyled = false,
-  applyPositionStyle = false,
-  ...restProps
-}: TooltipProps & React.HTMLProps<HTMLDivElement>) {
-  return (
-    <div
-      className={cx('visx-tooltip', className)}
-      style={{
-        top: top == null || offsetTop == null ? top : top + offsetTop,
-        left: left == null || offsetLeft == null ? left : left + offsetLeft,
-        ...(applyPositionStyle && { position: 'absolute' }),
-        ...(!unstyled && style),
-      }}
-      {...restProps}
-    >
-      {children}
-    </div>
-  );
-}
+const Tooltip = React.forwardRef<
+  HTMLDivElement,
+  TooltipProps & React.HTMLAttributes<HTMLDivElement>
+>(
+  (
+    {
+      className,
+      top,
+      left,
+      offsetLeft = 10,
+      offsetTop = 10,
+      style = defaultStyles,
+      children,
+      unstyled = false,
+      applyPositionStyle = false,
+      ...restProps
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cx('visx-tooltip', className)}
+        style={{
+          top: top == null || offsetTop == null ? top : top + offsetTop,
+          left: left == null || offsetLeft == null ? left : left + offsetLeft,
+          ...(applyPositionStyle && { position: 'absolute' }),
+          ...(!unstyled && style),
+        }}
+        {...restProps}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+Tooltip.displayName = 'Tooltip';
+export default Tooltip;

--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -5,8 +5,8 @@ import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
 import { TooltipPositionProvider } from '../context/TooltipPositionContext';
 
 export type TooltipWithBoundsProps = TooltipProps &
-  React.HTMLProps<HTMLDivElement> &
-  WithBoundingRectsProps;
+  React.HTMLAttributes<HTMLDivElement> &
+  WithBoundingRectsProps & { nodeRef?: React.Ref<HTMLDivElement> };
 
 function TooltipWithBounds({
   children,
@@ -19,6 +19,7 @@ function TooltipWithBounds({
   style = defaultStyles,
   top: initialTop = 0,
   unstyled = false,
+  nodeRef,
   ...otherProps
 }: TooltipWithBoundsProps) {
   let transform: React.CSSProperties['transform'];
@@ -61,6 +62,7 @@ function TooltipWithBounds({
 
   return (
     <Tooltip
+      ref={nodeRef}
       style={{
         left: 0,
         top: 0,


### PR DESCRIPTION
#### :bug: Bug Fix
This pull request extends the withBoundingRects to use optional refs instead of findDomNode. This should solve the deprecation warning in R18 with strictMode as discussed [here](https://github.com/airbnb/visx/issues/737)
To check the fix please enable `reactStrictMode: true` in `next.config.js` in the demo package. 

This _should_ not introduce any breaking changes. If the res is not passed, withBoundingRects falls back to findDOMNode. I would appreaciate pointers on how to correctly type the `nodeRef` in `TooltipWithBounds.tsx`