### PR TITLE
internal(github-actions): add github release script

### DIFF
--- a/scripts/performRelease/createGithubRelease.ts
+++ b/scripts/performRelease/createGithubRelease.ts
@@ -1,0 +1,41 @@
+import { GithubClient } from '../utils/getGitHubClient';
+import getChangelogAddition from './updateChangelog/getChangelogAddition';
+import { PR } from './types';
+import getRepoContext from '../utils/getRepoContext';
+
+/**
+ * Posts a new Github release if prs is not empty.
+ * Release text matches changelog entry.
+ */
+export default async function createGithubRelease(
+  client: GithubClient,
+  prs: PR[],
+  tagName: string,
+) {
+  if (prs.length === 0) {
+    console.log('No PRs for which to create Github release. Exiting.');
+    return;
+  }
+
+  const { owner, repo } = getRepoContext();
+  const releaseDescription = getChangelogAddition(tagName, prs);
+
+  try {
+    await client.request('POST /repos/{owner}/{repo}/releases', {
+      owner,
+      repo,
+      tag_name: tagName,
+      target_commitish: 'master',
+      name: tagName,
+      body: releaseDescription,
+      draft: false,
+      prerelease: false,
+      generate_release_notes: false,
+    });
+  } catch (error) {
+    console.log(`Could not post new Github release. Aborting.`);
+    console.warn(error.message); // log but don't fail the job
+  }
+
+  return;
+}


### PR DESCRIPTION
#### :house: Internal

Currently we don't create a formal [Github release](https://github.com/airbnb/visx/releases) when we release new package versions, but ideally they are up-to-date with the changelog.

This adds a script to create a release anytime we update the changelog. Logic is based on the [Github release API docs](https://docs.github.com/en/rest/releases/releases#create-a-release). These are hard to test, so the next PR can be a test-case :)

@hshoff @kristw 