### PR TITLE
internal(nimbus): add babel ignore POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,9 @@
       "next": true
     },
     "babel": {
+      "ignore": [
+        "node_modules/(?!(d3-(array|color|format|interpolate|scale|time|time-format)|internmap)/)"
+      ],
       "plugins": [
         [
           "@babel/plugin-proposal-private-methods",


### PR DESCRIPTION
#### :house: Internal

explored adding an `ignore` entry to the nimbus babel config to support issues in https://github.com/airbnb/visx/pull/1578

verified that it was added to the generated `babel.config.js` by running `yarn nimbus create-config`
