### PR TITLE
docs(xychart): fix typo

### DIFF
--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -366,7 +366,7 @@ is visible (`tooltipOpen`), tooltlip position (`tooltipLeft`, `tooltipTop`),
 
 The `Tooltip` and `AnnotationLabel` components rely on
 [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)s. If your
-browswer target needs a polyfill, you can either polute the `window` object or inject it cleanly
+browser target needs a polyfill, you can either polute the `window` object or inject it cleanly
 using the `resizeObserverPolyfill` prop for these components.
 
 <details>


### PR DESCRIPTION
#### :memo: Documentation
![image](https://user-images.githubusercontent.com/21017157/198848824-6f27ba29-a90c-4f6a-bfe7-be4727c882e0.png)
