### PR TITLE
fix(demo/radar):  uneven data elements renders spokes and web out of sync

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-radar/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-radar/Example.tsx
@@ -17,7 +17,7 @@ const y = (d: LetterFrequency) => d.frequency;
 
 const genAngles = (length: number) =>
   [...new Array(length + 1)].map((_, i) => ({
-    angle: i * (degrees / length),
+    angle: i * (degrees / length) + (length % 2 === 0 ? 0 : degrees / length / 2),
   }));
 
 const genPoints = (length: number, radius: number) => {


### PR DESCRIPTION
#### :bug: Bug Fix

- Update example code

Before
<img width="244" alt="image" src="https://user-images.githubusercontent.com/70136261/201872991-da2703ef-f28a-4ba7-8d23-8e1f6a7f8b52.png">
After
<img width="137" alt="image" src="https://user-images.githubusercontent.com/70136261/201873124-1cff15b0-2834-4714-bea4-cb4afed80062.png">


