### PR TITLE
fix(brush): update brush start/end on window resize

### DIFF
--- a/packages/visx-brush/src/BaseBrush.tsx
+++ b/packages/visx-brush/src/BaseBrush.tsx
@@ -117,22 +117,28 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
     if (this.props.width !== prevProps.width || this.props.height !== prevProps.height) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState((prevBrush: BaseBrushState) => {
-        const widthRatio = this.props.width / prevProps.width;
-        const heightRatio = this.props.height / prevProps.height;
+        let { start, end, extent } = prevBrush;
 
-        const start = {
-          x: widthRatio * prevBrush.extent.x0,
-          y: heightRatio * prevBrush.extent.y0,
-        };
+        if (!(extent.x0 === -1 && extent.x1 === -1 && extent.y0 === -1 && extent.y1 === -1)) {
+          const widthRatio = this.props.width / prevProps.width;
+          const heightRatio = this.props.height / prevProps.height;
 
-        const end = {
-          x: widthRatio * prevBrush.extent.x1,
-          y: heightRatio * prevBrush.extent.y1,
-        };
+          start = {
+            x: widthRatio * extent.x0,
+            y: heightRatio * extent.y0,
+          };
 
-        const extent = this.getExtent(start, end);
+          end = {
+            x: widthRatio * extent.x1,
+            y: heightRatio * extent.y1,
+          };
+
+          extent = this.getExtent(start, end);
+        }
 
         return {
+          start,
+          end,
           extent,
           bounds: {
             x0: 0,


### PR DESCRIPTION
#### :bug: Bug Fix

Fixes two issues with brush updating on chart resize (see #1282 and #1436):

**1. When moving a brush that has been resized due to chart resize, it regresses to some old sizing**

Fixed by updating brush `start` and `end` when the chart resizes. Previously, only `extent` was updated.

_Repro steps:_
- Use the [Brush example](https://airbnb.io/visx/brush) from the Gallery
- Update the brush so that it is not the default size
- Resize the window width
- Move the brush by dragging

_Current behavior:_
It regresses to some of its old positioning.

<img width="650" alt="Screen Shot 2022-12-08 at 2 53 11 PM" src="https://user-images.githubusercontent.com/9322676/206584043-6d13a39d-25cd-4105-b3cc-346ac9d15555.png">

_New behavior:_
It moves as expected in its new coordinate space.

<img width="647" alt="Screen Shot 2022-12-08 at 2 53 50 PM" src="https://user-images.githubusercontent.com/9322676/206584118-833659cf-88e5-40cb-b4e9-8ee6f1067a03.png">

**2. Resizing when there is no brush selection, creates a phantom brush near 0,0**

Fixed by only updating brush `start`, `end`, and `extent` if there is a brush (i.e. `extent` coordinates are not all -1).

_Repro steps:_
- Use the [Brush example](https://airbnb.io/visx/brush) from the Gallery
- Clear the brush
- Resize the window width

_Current behavior:_
A phantom brush with handles is visible on the left side of the chart. The visx-brush-selection rect has non-zero height and is not positioned at -1,-1.

<img width="621" alt="Screen Shot 2022-12-08 at 2 57 21 PM" src="https://user-images.githubusercontent.com/9322676/206584574-e443c5fd-066b-4d29-a093-22e04458fa82.png">

_New behavior:_
No handles appear and the visx-brush-selection rect has attributes `x="-1" y="-1" width="0" height="0"` as expected

<img width="624" alt="Screen Shot 2022-12-08 at 3 01 50 PM" src="https://user-images.githubusercontent.com/9322676/206585365-10aed13f-11cc-48fd-bd27-8123c9f41acc.png">