### PR TITLE
internal(github/workflows): add tsconfig + demo site build checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,9 @@ jobs:
       - name: 📡 Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines
 
+      - name: 🤖 Ensure TS references are up to date
+        run: yarn type:update-refs && [-z "$(git status --porcelain)"]
+
       - name: 🛠 Build packages
         run: yarn build
 
@@ -43,6 +46,10 @@ jobs:
 
       - name: ❤️ Run lint
         run: yarn lint
+
+      - name: ✨ Build visx site without failure
+        run: yarn build
+        working-directory: './packages/visx-demo/'
 
       - name: 🦛 Run happo
         run: yarn run happo-ci-github-actions

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-engines
 
       - name: 🤖 Ensure TS references are up to date
-        run: yarn type:update-refs && [-z "$(git status --porcelain)"]
+        run: yarn type:update-refs && git diff --exit-code
 
       - name: 🛠 Build packages
         run: yarn build

--- a/packages/visx-annotation/tsconfig.json
+++ b/packages/visx-annotation/tsconfig.json
@@ -22,12 +22,6 @@
       "path": "../visx-group"
     },
     {
-      "path": "../visx-point"
-    },
-    {
-      "path": "../visx-shape"
-    },
-    {
       "path": "../visx-text"
     }
   ]

--- a/packages/visx-demo/tsconfig.json
+++ b/packages/visx-demo/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../visx-axis"
     },
     {
+      "path": "../visx-bounds"
+    },
+    {
       "path": "../visx-brush"
     },
     {
@@ -106,6 +109,9 @@
     },
     {
       "path": "../visx-tooltip"
+    },
+    {
+      "path": "../visx-visx"
     },
     {
       "path": "../visx-voronoi"


### PR DESCRIPTION
#### :house: Internal

This adds a couple new checks to our `pull_request` github workflow:
- Ensure `tsconfig` references are up to date. Without nimbus, we don't get this for free anymore. I added a script to do this locally but we should run it in CI too.
- Ensure that the `nextjs` demo site builds without error. https://github.com/airbnb/visx/pull/1578 silently broke this so I'd like to avoid it in the future