### PR TITLE
fix(zoom): prevent wheel interfering with pinch

### DIFF
--- a/packages/visx-zoom/src/Zoom.tsx
+++ b/packages/visx-zoom/src/Zoom.tsx
@@ -329,7 +329,7 @@ function Zoom<ElementType extends Element>({
       onPinch: handlePinch,
       onWheel: ({ event, active, pinching }) => {
         if (
-          // Outside of Safari, the wheel event is fired together with the pinch event.
+          // Outside of Safari, the wheel event is fired together with the pinch event
           pinching ||
           // currently onWheelEnd emits one final wheel event which causes 2x scale
           // updates for the last tick. ensuring that the gesture is active avoids this

--- a/packages/visx-zoom/src/Zoom.tsx
+++ b/packages/visx-zoom/src/Zoom.tsx
@@ -327,10 +327,16 @@ function Zoom<ElementType extends Element>({
       },
       onDragEnd: dragEnd,
       onPinch: handlePinch,
-      onWheel: ({ event, active }) => {
-        // currently onWheelEnd emits one final wheel event which causes 2x scale
-        // updates for the last tick. ensuring that the gesture is active avoids this
-        if (!active) return;
+      onWheel: ({ event, active, pinching }) => {
+        if (
+          // Outside of Safari, the wheel event is fired together with the pinch event.
+          pinching ||
+          // currently onWheelEnd emits one final wheel event which causes 2x scale
+          // updates for the last tick. ensuring that the gesture is active avoids this
+          !active
+        ) {
+          return;
+        }
         handleWheel(event);
       },
     },


### PR DESCRIPTION
#### :bug: Bug Fix

- Prevent wheel interfering with pinch 
  
  Using a macbook, a touchpad pinch gesture will trigger `useGesture`'s pinch event, as desired, but it will also trigger the wheel event. Except in Safari.

  With this change, the wheel event handler bails if a pinch gesture is ongoing.
  
  Tested in Firefox, Chrome and Safari on a macbook.

  Fixes: #1638
