### PR TITLE
fix(xychart): Tooltip snapping with AreaStack and BarStack

### DIFF
--- a/packages/visx-xychart/src/components/series/private/BaseAreaStack.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseAreaStack.tsx
@@ -152,12 +152,10 @@ function BaseAreaStack<XScale extends AxisScale, YScale extends AxisScale, Datum
 
   // custom logic to find the nearest AreaStackDatum (context) and return the original Datum (props)
   const findNearestDatum = useCallback(
-    (params: NearestDatumArgs<XScale, YScale, AreaStackDatum>): NearestDatumReturnType<Datum> => {
-      const childData = seriesChildren.find((child) => child.props.dataKey === params.dataKey)
-        ?.props?.data;
-      return childData ? findNearestStackDatum(params, childData, horizontal) : null;
-    },
-    [seriesChildren, horizontal],
+    (
+      params: NearestDatumArgs<XScale, YScale, AreaStackDatum>,
+    ): NearestDatumReturnType<AreaStackDatum> => findNearestStackDatum(params, horizontal),
+    [horizontal],
   );
 
   const ownEventSourceKey = `${AREASTACK_EVENT_SOURCE}-${dataKeys.join('-')}`;

--- a/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
+++ b/packages/visx-xychart/src/components/series/private/BaseBarStack.tsx
@@ -90,12 +90,9 @@ function BaseBarStack<
   const findNearestDatum = useCallback(
     (
       params: NearestDatumArgs<XScale, YScale, BarStackDatum<XScale, YScale>>,
-    ): NearestDatumReturnType<Datum> => {
-      const childData = seriesChildren.find((child) => child.props.dataKey === params.dataKey)
-        ?.props?.data;
-      return childData ? findNearestStackDatum(params, childData, horizontal) : null;
-    },
-    [seriesChildren, horizontal],
+    ): NearestDatumReturnType<BarStackDatum<XScale, YScale>> =>
+      findNearestStackDatum(params, horizontal),
+    [horizontal],
   );
 
   const ownEventSourceKey = `${BARSTACK_EVENT_SOURCE}-${dataKeys.join('-')}`;

--- a/packages/visx-xychart/src/utils/findNearestStackDatum.ts
+++ b/packages/visx-xychart/src/utils/findNearestStackDatum.ts
@@ -13,20 +13,17 @@ import { BarStackDatum, NearestDatumArgs } from '../types';
 export default function findNearestStackDatum<
   XScale extends AxisScale,
   YScale extends AxisScale,
-  Datum extends object,
 >(
   nearestDatumArgs: NearestDatumArgs<XScale, YScale, BarStackDatum<XScale, YScale>>,
-  seriesData: Datum[],
   horizontal?: boolean,
 ) {
   const { xScale, yScale, point } = nearestDatumArgs;
   const datum = (horizontal ? findNearestDatumY : findNearestDatumX)(nearestDatumArgs);
-  const seriesDatum = datum?.index == null ? null : seriesData[datum.index];
 
-  return datum && seriesDatum && point
+  return datum && point
     ? {
         index: datum.index,
-        datum: seriesDatum,
+        datum: datum.datum,
         distanceX: horizontal // if mouse is ON the stack series, set 0 distance
           ? point.x >= (xScale(getFirstItem(datum.datum)) ?? Infinity) &&
             point.x <= (xScale(getSecondItem(datum.datum)) ?? -Infinity)


### PR DESCRIPTION
#### :bug: Bug Fix

- fixes Tooltip snapping when using `AreaStack` and `BarStack` ( #1667 )