### PR TITLE
docs(icons): added svg icon

### DIFF
--- a/assets/visx-alt.svg
+++ b/assets/visx-alt.svg
@@ -1,0 +1,8 @@
+<svg width="200" height="200" viewBox="3 3 194 194" color="#EBEBEB" fill="#E7383C" xmlns="http://www.w3.org/2000/svg">
+    <title>visx</title>
+    <rect width="200" height="200" />
+    <path d="M3 3H49.5866L99.1681 52.2487L149.082 3H197L99.6664 96.1732L3 3Z" fill="currentColor" />
+    <path d="M3 197L95.8552 99.8336L3 3V50.5849L51.5832 99.8336L3 149.082V197Z" fill="currentColor" />
+    <path d="M197 197L103.814 99.8336L197 3V50.5849L147.751 99.8336L197 149.082V197Z" fill="currentColor" />
+    <path d="M197 197L99.6664 103.827L3 197H49.5866L99.1681 147.419L149.748 197H197Z" fill="currentColor" />
+</svg>

--- a/assets/visx-suggestion.svg
+++ b/assets/visx-suggestion.svg
@@ -1,0 +1,8 @@
+<svg width="200" height="200" viewBox="3 3 194 194" color="#E7383C" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>visx</title>
+    <rect width="200" height="200" />
+    <path d="M3 3H49.5866L99.1681 52.2487L149.082 3H197L99.6664 96.1732L3 3Z" fill="currentColor" />
+    <path d="M3 197L95.8552 99.8336L3 3V50.5849L51.5832 99.8336L3 149.082V197Z" fill="currentColor" />
+    <path d="M197 197L103.814 99.8336L197 3V50.5849L147.751 99.8336L197 149.082V197Z" fill="currentColor" />
+    <path d="M197 197L99.6664 103.827L3 197H49.5866L99.1681 147.419L149.748 197H197Z" fill="currentColor" />
+</svg>

--- a/assets/visx.svg
+++ b/assets/visx.svg
@@ -1,0 +1,8 @@
+<svg width="200" height="200" viewBox="0 0 200 200" color="#EBEBEB" fill="#E7383C" xmlns="http://www.w3.org/2000/svg">
+    <title>visx</title>
+    <rect width="200" height="200" />
+    <path d="M3 3H49.5866L99.1681 52.2487L149.082 3H197L99.6664 96.1732L3 3Z" fill="currentColor" />
+    <path d="M3 197L95.8552 99.8336L3 3V50.5849L51.5832 99.8336L3 149.082V197Z" fill="currentColor" />
+    <path d="M197 197L103.814 99.8336L197 3V50.5849L147.751 99.8336L197 149.082V197Z" fill="currentColor" />
+    <path d="M197 197L99.6664 103.827L3 197H49.5866L99.1681 147.419L149.748 197H197Z" fill="currentColor" />
+</svg>


### PR DESCRIPTION
#### :memo: Documentation

- created SVG icon based on the logo. Feel free to keep one or all of the options.
- monochrome setting; change svg's fill attribute to 'none' for a monochrome icon
- [open issue on simpleicons](https://github.com/simple-icons/simple-icons/issues/8623) to add it to their cdn for easy access