### PR TITLE
vendor: detect ESM-only packages

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,6 +30,9 @@ jobs:
       - name: 🤖 Ensure TS references are up to date
         run: yarn type:update-refs && git diff --exit-code
 
+      - name: 👀 Ensure we have no ESM-only dependencies
+        run: yarn vendor-check
+
       - name: 🛠 Build packages
         run: yarn build
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "ts": "ts-node --project ./tsconfig.node.json",
     "type": "lerna exec --parallel -- tsc --build",
     "type:pkg": "lerna exec --scope $PKG -- tsc --build --verbose",
-    "type:update-refs": "yarn run ts ./scripts/updateTsReferences.ts"
+    "type:update-refs": "yarn run ts ./scripts/updateTsReferences.ts",
+    "vendor-check": "yarn run ts ./packages/visx-vendor/scripts/flagVendorRequirements.ts"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/visx-vendor/scripts/flagVendorRequirements.ts
+++ b/packages/visx-vendor/scripts/flagVendorRequirements.ts
@@ -1,3 +1,4 @@
+/* eslint import/no-extraneous-dependencies: 'off' */
 import { compareVersions } from 'compare-versions';
 import chalk from 'chalk';
 import childProcess from 'child_process';
@@ -7,7 +8,7 @@ const exec = util.promisify(childProcess.exec);
 
 // based off of package.json history of packages in https://github.com/d3
 // it is not 100% comprehensive but includes all packages that might make
-// their way int visx
+// their way into visx
 const ESM_ONLY_MAP = {
   'd3-array': '3.0.0',
   'd3-chord': '3.0.0',
@@ -21,6 +22,7 @@ const ESM_ONLY_MAP = {
   'd3-hierarchy': '3.0.0',
   'd3-interpolate': '3.0.0',
   'd3-path': '3.0.0',
+  'd3-polygon': '3.0.0',
   'd3-quadtree': '3.0.0',
   'd3-random': '3.0.0',
   'd3-scale': '4.0.0',
@@ -30,7 +32,6 @@ const ESM_ONLY_MAP = {
   'd3-time-format': '4.0.0',
   'd3-voronoi': '3.0.0',
   internmap: '2.0.0',
-  'd3-polygon': '3.0.0',
 
   // unlikely to ever be in visx
   'd3-axis': '3.0.0',
@@ -40,7 +41,7 @@ const ESM_ONLY_MAP = {
   'd3-fetch': '3.0.0',
   'd3-zoom': '3.0.0',
 
-  // non-esm-only
+  // non-esm-only, here for completeness
   'd3-geo-polygon': '',
   'd3-hexbin': '',
   'd3-sankey': '',

--- a/packages/visx-vendor/scripts/flagVendorRequirements.ts
+++ b/packages/visx-vendor/scripts/flagVendorRequirements.ts
@@ -1,0 +1,117 @@
+import { compareVersions } from 'compare-versions';
+import chalk from 'chalk';
+import childProcess from 'child_process';
+import util from 'util';
+
+const exec = util.promisify(childProcess.exec);
+
+// based off of package.json history of packages in https://github.com/d3
+// it is not 100% comprehensive but includes all packages that might make
+// their way int visx
+const ESM_ONLY_MAP = {
+  'd3-array': '3.0.0',
+  'd3-chord': '3.0.0',
+  'd3-color': '3.0.0',
+  'd3-contour': '3.0.0',
+  'd3-delaunay': '6.0.0',
+  'd3-force': '3.0.0',
+  'd3-format': '3.0.0',
+  'd3-geo': '3.0.0',
+  'd3-geo-projection': '4.0.0',
+  'd3-hierarchy': '3.0.0',
+  'd3-interpolate': '3.0.0',
+  'd3-path': '3.0.0',
+  'd3-quadtree': '3.0.0',
+  'd3-random': '3.0.0',
+  'd3-scale': '4.0.0',
+  'd3-scale-chromatic': '3.0.0',
+  'd3-shape': '3.0.0',
+  'd3-time': '3.0.0',
+  'd3-time-format': '4.0.0',
+  'd3-voronoi': '3.0.0',
+  internmap: '2.0.0',
+  'd3-polygon': '3.0.0',
+
+  // unlikely to ever be in visx
+  'd3-axis': '3.0.0',
+  'd3-brush': '3.0.0',
+  'd3-drag': '3.0.0',
+  'd3-ease': '3.0.0',
+  'd3-fetch': '3.0.0',
+  'd3-zoom': '3.0.0',
+
+  // non-esm-only
+  'd3-geo-polygon': '',
+  'd3-hexbin': '',
+  'd3-sankey': '',
+  'd3-tile': '',
+};
+
+/**
+ * For each package in esmOnlyMap with a specified version, this identifies
+ * installed versions using `yarn why`. If any installed versions are ESM-only,
+ * it will eventually throw an error with the flagged versions.
+ */
+async function flagVendorRequirements(esmOnlyMap: { [pkg: string]: string }) {
+  const flaggedPackages: { [pkg: string]: string[] } = {};
+
+  // the map below does nothing, but is an easy way to await all calls
+  await Promise.all(
+    Object.entries(esmOnlyMap).map(async ([pkg, esmOnlyVersion]) => {
+      if (!esmOnlyVersion) return;
+
+      // find versions of this package in the tree
+      const command = `yarn why ${pkg} --recursive`;
+
+      const { stdout, stderr } = await exec(command);
+      if (stdout) {
+        const pkgVersionRegex = new RegExp(`${pkg}@([0-9\.]+)`, 'g');
+        const esmOnlyMatches = new Set<string>();
+
+        // find all matches/installed versions
+        while (true) {
+          const match = pkgVersionRegex.exec(stdout);
+
+          // if there's a match check if it's esm-only
+          if (match) {
+            const [, seenVersion] = match;
+            if (
+              // if seen is >= esmOnly, this returns 0 or 1 (not -1)
+              compareVersions(seenVersion, esmOnlyVersion) >= 0 &&
+              !esmOnlyMatches.has(seenVersion)
+            ) {
+              console.info(`${pkg}@${seenVersion} is ≥ the esm-only version ${esmOnlyVersion}`);
+              esmOnlyMatches.add(seenVersion);
+            }
+          } else {
+            break;
+          }
+        }
+
+        if (esmOnlyMatches.size > 0) {
+          flaggedPackages[pkg] = [...esmOnlyMatches].sort(compareVersions);
+        }
+      }
+      if (stderr) {
+        // pass (yarn why complains about invalid peer deps, etc)
+      }
+    }),
+  );
+
+  if (Object.keys(flaggedPackages).length > 0) {
+    console.error(
+      chalk.red(
+        'The following ESM-only should be vendored',
+        JSON.stringify(flaggedPackages, null, 2),
+      ),
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(chalk.green('No ESM-only packages detected ✨'));
+  }
+}
+
+flagVendorRequirements(ESM_ONLY_MAP).catch((error) => {
+  console.error(chalk.red(error.message));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
#### :house: Internal

After doing some manual work to parse through our `d3-` dependencies and flag those with versions that are ESM-only, or have transitive dependencies which are ESM-only, I decided it's not a great idea to do this manually. 

🫠
<img width="1374" alt="image" src="https://github.com/airbnb/visx/assets/4496521/435c7491-bcf0-47db-93e2-7bbf38e4a2a8">

We actually don't have a huge number of ESM-only dependencies at the moment, **but** if we were to version bump any number of `d3-` dependencies, we could pick up more ESM-only versions and we're back at having to figure out which are ESM-only. Ideally this detection can be automated.

This PR adds a script which we can use in CI to detect and throw errors if any ESM-only dependencies are detected. If any are detected, they can be added to our new/upcoming `@visx/vendor` package.

- [x] write script
- [x] validate
- [x] hook up to CI

Example output
![image](https://github.com/airbnb/visx/assets/4496521/e4ce5fa9-3817-44df-88f7-ac357823e6a9)


