### PR TITLE
add @visx/vendor

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,9 +111,10 @@
     "ts-node": "9.1.1",
     "typescript": "^3.8.3"
   },
-  "workspaces": [
-    "./packages/*"
-  ],
+  "workspaces": {
+    "packages": ["./packages/*"],
+    "nohoist": ["**/@visx/vendor/**"]
+  },
   "resolutions": {
     "@babel/parser": "^7.15.3",
     "handlebars": "4.5.3"

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
   ],
   "private": true,
   "scripts": {
+    "build:vendor": "yarn run ts ./packages/visx-vendor/scripts/buildVendor",
     "babel": "yarn run babel:cjs && yarn run babel:esm",
     "babel:cjs": "lerna exec --ignore @visx/demo --parallel -- babel --root-mode upward --delete-dir-on-start src/ --out-dir lib --extensions .ts,.tsx",
     "babel:esm": "ESM=true lerna exec --ignore @visx/demo --parallel -- babel --root-mode upward --delete-dir-on-start src/ --out-dir esm --extensions .ts,.tsx",
     "babel:pkg": "lerna exec --scope $PKG -- babel --root-mode upward --delete-dir-on-start src/ --out-dir lib --extensions .ts,.tsx && lerna exec --scope $PKG -- ESM=true babel --root-mode upward --delete-dir-on-start src/ --out-dir esm --extensions .ts,.tsx",
-    "build": "yarn run babel && yarn run type",
+    "build": "yarn run build:vendor && yarn run babel && yarn run type",
     "build:sizes": "yarn run ts ./scripts/computeBuildSizes.ts",
     "build:release": "yarn run ts ./scripts/performRelease/index.ts",
     "dev:demo": "yarn workspace @visx/demo dev",

--- a/packages/visx-scale/package.json
+++ b/packages/visx-scale/package.json
@@ -31,12 +31,7 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/d3-interpolate": "^3.0.1",
-    "@types/d3-scale": "^4.0.2",
-    "@types/d3-time": "^2.0.0",
-    "d3-interpolate": "^3.0.1",
-    "d3-scale": "^4.0.2",
-    "d3-time": "^2.1.1"
+    "@visx/vendor": "3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/visx-scale/src/operators/interpolate.ts
+++ b/packages/visx-scale/src/operators/interpolate.ts
@@ -1,4 +1,4 @@
-import { InterpolatorFactory } from 'd3-scale';
+import { InterpolatorFactory } from '@visx/vendor/d3-scale';
 import { StringLike } from '../types/Base';
 import { D3Scale, DefaultThresholdInput } from '../types/Scale';
 import createColorInterpolator from '../utils/createColorInterpolator';

--- a/packages/visx-vendor/.gitignore
+++ b/packages/visx-vendor/.gitignore
@@ -1,0 +1,4 @@
+# the following are built and should not be checked in
+lib/
+esm/
+vendor-cjs/

--- a/packages/visx-vendor/.gitignore
+++ b/packages/visx-vendor/.gitignore
@@ -2,3 +2,4 @@
 lib/
 esm/
 vendor-cjs/
+types/

--- a/packages/visx-vendor/.gitignore
+++ b/packages/visx-vendor/.gitignore
@@ -1,5 +1,7 @@
 # the following are built and should not be checked in
-lib/
-esm/
-vendor-cjs/
-types/
+/lib
+/esm
+/vendor-cjs
+/d3-*.js
+/internmap.js
+/*.d.ts

--- a/packages/visx-vendor/.gitignore
+++ b/packages/visx-vendor/.gitignore
@@ -2,6 +2,8 @@
 /lib
 /esm
 /vendor-cjs
+
+# root index and type files
 /d3-*.js
 /internmap.js
 /*.d.ts

--- a/packages/visx-vendor/Readme.md
+++ b/packages/visx-vendor/Readme.md
@@ -7,3 +7,51 @@ some transitive dependencies, which are ESM-only.
 This package is heavily based off of
 [`victory-vendor`](https://github.com/FormidableLabs/victory/tree/main/packages/victory-vendor)
 which aims to solve the same problem.
+
+## Vendored packages
+
+All vendored packages are listed as `dependencies` in the `package.json` of this package.
+
+## How it works
+
+We provide two alternate paths and behaviors -- for ESM and CommonJS
+
+### ESM
+
+When you use a module `import` syntax like the following, it will resolve to a re-exported version
+of `node_modules/d3-interpolate`, the unmodified ESM library from D3.
+
+```ts
+import { interpolate } from '@visx/vendor/d3-interpolate';
+```
+
+### CommonJS
+
+If you use a CJS `require` syntax like the following, it will resolve to an alternate path that
+contains the **transpiled** version of the underlying `d3-*` (or other) library to be found at
+`@visx/vendor/lib-vendor/d3-interpolate/**/*.js`.
+
+```ts
+const { interpolate } = require('victory-vendor/d3-interpolate');
+```
+
+Such transpiled versions have _internally consistent_ import references to other other
+`@visx/vendor/lib-vendor/<pkg-name>` paths that need to be transpiled.
+
+### TODO
+
+- [x] collect d3 requirements (manual) to inform design
+- [ ] automate dependency requirements
+  - yarn install packages
+  - script
+    - crawls packages from the root, finding those in the map
+      - yarn why <pgk> => extract <pgk>@XXX => compare XXX to map => if in map => add to dep
+      -
+  - bump d3-dep anywhere to version that needs vendor => CI should assert that the package.json diff
+    is clean
+  -
+- [ ] create @visx/vendor
+  - [ ]
+- [ ] write transpilation
+- [ ] update `d3-*` imports to reference `@visx/vendor/d3-*`
+  - [ ]

--- a/packages/visx-vendor/Readme.md
+++ b/packages/visx-vendor/Readme.md
@@ -17,9 +17,12 @@ versions of `d3` packages). For each (non-types) package `<pkg>`, we generate th
 - an ESM version of the package in `esm/<pkg>.js`
 - a CJS version of the package in `lib/<pkg>.js`
   - this points to the fully-transpiled version of the package in
-    `vendor-cjs/vendor-<pgk>/src/index.js`
-  - `vendor-cjs/vendor-<pgk>/LICENSE` contains the upstream license of the vendored package
-- TypeScript types from `@types/<pgk>` as root `<pkg>.d.ts` files
+    `vendor-cjs/vendor-<pkg>/src/index.js`
+  - `vendor-cjs/vendor-<pkg>/LICENSE` contains the upstream license of the vendored package
+  - other ESM-only packages (e.g., `<pkg2>`) that are referenced by `<pkg>` are updated to point to
+    `vendor-cjs/vendor-<pkg2>/src/index.js`
+- TypeScript types from `@types/<pkg>` as root `<pkg>.d.ts` files (when available as specified in
+  the `package.json` `dependencies`)
 - a root `<pkg>.js` file (pointing to the CJS version of the lib) for tooling that doesn't yet
   support `package.json:exports`
   ([conditional exports](https://nodejs.org/api/packages.html#conditional-exports))

--- a/packages/visx-vendor/Readme.md
+++ b/packages/visx-vendor/Readme.md
@@ -32,26 +32,8 @@ contains the **transpiled** version of the underlying `d3-*` (or other) library 
 `@visx/vendor/lib-vendor/d3-interpolate/**/*.js`.
 
 ```ts
-const { interpolate } = require('victory-vendor/d3-interpolate');
+const { interpolate } = require('@visx/vendor/d3-interpolate');
 ```
 
 Such transpiled versions have _internally consistent_ import references to other other
-`@visx/vendor/lib-vendor/<pkg-name>` paths that need to be transpiled.
-
-### TODO
-
-- [x] collect d3 requirements (manual) to inform design
-- [ ] automate dependency requirements
-  - yarn install packages
-  - script
-    - crawls packages from the root, finding those in the map
-      - yarn why <pgk> => extract <pgk>@XXX => compare XXX to map => if in map => add to dep
-      -
-  - bump d3-dep anywhere to version that needs vendor => CI should assert that the package.json diff
-    is clean
-  -
-- [ ] create @visx/vendor
-  - [ ]
-- [ ] write transpilation
-- [ ] update `d3-*` imports to reference `@visx/vendor/d3-*`
-  - [ ]
+`@visx/vendor/vendor-cjs/<pkg-name>` paths that need to be transpiled.

--- a/packages/visx-vendor/Readme.md
+++ b/packages/visx-vendor/Readme.md
@@ -10,7 +10,19 @@ which aims to solve the same problem.
 
 ## Vendored packages
 
-All vendored packages are listed as `dependencies` in the `package.json` of this package.
+All vendored packages are listed as `dependencies` in the `package.json` of this package (note that
+NPM aliases are used to guarantee version specificity in this large monorepo where we may have mixed
+versions of `d3` packages). For each (non-types) package `<pkg>`, we generate the following:
+
+- an ESM version of the package in `esm/<pkg>.js`
+- a CJS version of the package in `lib/<pkg>.js`
+  - this points to the fully-transpiled version of the package in
+    `vendor-cjs/vendor-<pgk>/src/index.js`
+  - `vendor-cjs/vendor-<pgk>/LICENSE` contains the upstream license of the vendored package
+- TypeScript types from `@types/<pgk>` as root `<pkg>.d.ts` files
+- a root `<pkg>.js` file (pointing to the CJS version of the lib) for tooling that doesn't yet
+  support `package.json:exports`
+  ([conditional exports](https://nodejs.org/api/packages.html#conditional-exports))
 
 ## How it works
 
@@ -37,3 +49,7 @@ const { interpolate } = require('@visx/vendor/d3-interpolate');
 
 Such transpiled versions have _internally consistent_ import references to other other
 `@visx/vendor/vendor-cjs/<pkg-name>` paths that need to be transpiled.
+
+### Root index files & types
+
+In addition to supporting

--- a/packages/visx-vendor/Readme.md
+++ b/packages/visx-vendor/Readme.md
@@ -11,8 +11,9 @@ which aims to solve the same problem.
 ## Vendored packages
 
 All vendored packages are listed as `dependencies` in the `package.json` of this package (note that
-NPM aliases are used to guarantee version specificity in this large monorepo where we may have mixed
-versions of `d3` packages). For each (non-types) package `<pkg>`, we generate the following:
+the `yarn` `nohoist` option is set for this package to guarantee version specificity in this large
+monorepo where we may have mixed versions of `d3` packages). For each (non-types) package `<pkg>`,
+we generate the following:
 
 - an ESM version of the package in `esm/<pkg>.js`
 - a CJS version of the package in `lib/<pkg>.js`
@@ -44,7 +45,7 @@ import { interpolate } from '@visx/vendor/d3-interpolate';
 
 If you use a CJS `require` syntax like the following, it will resolve to an alternate path that
 contains the **transpiled** version of the underlying `d3-*` (or other) library to be found at
-`@visx/vendor/lib-vendor/d3-interpolate/**/*.js`.
+`@visx/vendor/vendor-cjs/d3-interpolate/**/*.js`.
 
 ```ts
 const { interpolate } = require('@visx/vendor/d3-interpolate');
@@ -55,4 +56,9 @@ Such transpiled versions have _internally consistent_ import references to other
 
 ### Root index files & types
 
-In addition to supporting
+For tooling that doesn't yet support `package.json:exports`
+([conditional exports](https://nodejs.org/api/packages.html#conditional-exports)), we include root
+index files for all vendored packages, e.g., `@visx/vendor/d3-array.js`.
+
+Type declaration files are also included in the root, e.g., `@types/d3-array` is exported as
+`@visx/vendor/d3-array.d.ts`.

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -52,7 +52,13 @@
       "./package.json": "./package.json",
       "./d3-*": {
         "import": "./esm/d3-*.js",
-        "require": "./lib/d3-*.js"
+        "require": "./lib/d3-*.js",
+        "types": "./types/*.d.ts"
+      },
+      "internmap": {
+        "import": "./esm/internmap.js",
+        "require": "./lib/internmap.js",
+        "types": "./types/internmap.d.ts"
       }
     }
 }

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -11,11 +11,6 @@
       "charts"
     ],
     "author": "@williaster",
-<<<<<<< Updated upstream
-    "license": "MIT",
-    "dependencies": {},
-    "devDependencies": {},
-=======
     "license": "MIT and ISC",
     "dependencies": {
       "vendor-types-d3-array@npm:@types/d3-array": "^3.0.3",
@@ -30,7 +25,6 @@
       "esm": "^3.2.25",
       "rimraf": "^3.0.2"
     },
->>>>>>> Stashed changes
     "publishConfig": {
       "access": "public"
     },

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -13,28 +13,21 @@
     "author": "@williaster",
     "license": "MIT and ISC",
     "dependencies": {
-      "vendor-d3-array@npm:d3-array": "^3.2.1",
-      "vendor-types-d3-array@npm:@types/d3-array": "^3.0.3",
-
-      "vendor-internmap@npm:internmap": "^2.0.3",
-      
-      "vendor-d3-time-format@npm:d3-time-format": "^4.1.0",
-      "vendor-types-d3-time-format@npm:@types/d3-time-format": "^2.1.0",
-
-      "vendor-d3-scale@npm:d3-scale": "^4.0.2",
-      "vendor-types-d3-scale@npm:@types/d3-scale": "^4.0.2",
-
-      "vendor-d3-color@npm:d3-color": "^3.1.0",
-      "vendor-types-d3-color@npm:@types/d3-color": "^3.1.0",
-      
-      "vendor-d3-time@npm:d3-time": "^3.1.0",
-      "vendor-types-d3-time@npm:@types/d3-time": "^3.0.0",
-
-      "vendor-d3-format@npm:d3-format": "^3.1.0",
-      "vendor-types-d3-format@npm:@types/d3-format": "^3.0.1",
-      
-      "vendor-d3-interpolate@npm:d3-interpolate": "^3.0.1",
-      "vendor-types-d3-interpolate@npm:@types/d3-interpolate": "^3.0.1"
+      "@types/d3-array": "^3.0.3",
+      "@types/d3-color": "^3.1.0",
+      "@types/d3-format": "^3.0.1",
+      "@types/d3-interpolate": "^3.0.1",
+      "@types/d3-scale": "^4.0.2",
+      "@types/d3-time": "^3.0.0",
+      "@types/d3-time-format": "^2.1.0",
+      "d3-array": "^3.2.1",
+      "d3-color": "^3.1.0",
+      "d3-format": "^3.1.0",
+      "d3-interpolate": "^3.0.1",
+      "d3-scale": "^4.0.2",
+      "d3-time": "^3.1.0",
+      "d3-time-format": "^4.1.0",
+      "internmap": "^2.0.3"
     },
     "devDependencies": {
       "@babel/plugin-transform-modules-commonjs": "^7.22.5",

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -49,11 +49,11 @@
       "access": "public"
     },
     "exports": {
-      "./package.json": "./package.json",
-      "./d3-*": {
+      "package.json": "./package.json",
+      "d3-*": {
         "import": "./esm/d3-*.js",
         "require": "./lib/d3-*.js",
-        "types": "./types/*.d.ts"
+        "types": "./d3-*.d.ts"
       },
       "internmap": {
         "import": "./esm/internmap.js",

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@visx/vendor",
     "version": "3.0.0",
-    "description": "visx vendor",
+    "description": "vendored packages for visx",
     "sideEffects": false,
     "repository": "https://github.com/airbnb/visx",
     "keywords": [
@@ -11,11 +11,34 @@
       "charts"
     ],
     "author": "@williaster",
+<<<<<<< Updated upstream
     "license": "MIT",
     "dependencies": {},
     "devDependencies": {},
+=======
+    "license": "MIT and ISC",
+    "dependencies": {
+      "vendor-types-d3-array@npm:@types/d3-array": "^3.0.3",
+      "vendor-d3-array@npm:d3-array": "^3.2.1"
+    },
+    "devDependencies": {
+      "@babel/plugin-transform-modules-commonjs": "^7.22.5",
+      "babel-plugin-module-resolver": "^5.0.0",
+      "@types/rimraf": "^3.0.2",
+      "chalk": "4.1.0",
+      "compare-versions": "^5.0.0",
+      "esm": "^3.2.25",
+      "rimraf": "^3.0.2"
+    },
+>>>>>>> Stashed changes
     "publishConfig": {
       "access": "public"
+    },
+    "exports": {
+      "./package.json": "./package.json",
+      "./d3-*": {
+        "import": "./esm/d3-*.js",
+        "require": "./lib/d3-*.js"
+      }
     }
-  }
-  
+}

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -13,8 +13,28 @@
     "author": "@williaster",
     "license": "MIT and ISC",
     "dependencies": {
+      "vendor-d3-array@npm:d3-array": "^3.2.1",
       "vendor-types-d3-array@npm:@types/d3-array": "^3.0.3",
-      "vendor-d3-array@npm:d3-array": "^3.2.1"
+
+      "vendor-internmap@npm:internmap": "^2.0.3",
+      
+      "vendor-d3-time-format@npm:d3-time-format": "^4.1.0",
+      "vendor-types-d3-time-format@npm:@types/d3-time-format": "^2.1.0",
+
+      "vendor-d3-scale@npm:d3-scale": "^4.0.2",
+      "vendor-types-d3-scale@npm:@types/d3-scale": "^4.0.2",
+
+      "vendor-d3-color@npm:d3-color": "^3.1.0",
+      "vendor-types-d3-color@npm:@types/d3-color": "^3.1.0",
+      
+      "vendor-d3-time@npm:d3-time": "^3.1.0",
+      "vendor-types-d3-time@npm:@types/d3-time": "^3.0.0",
+
+      "vendor-d3-format@npm:d3-format": "^3.1.0",
+      "vendor-types-d3-format@npm:@types/d3-format": "^3.0.1",
+      
+      "vendor-d3-interpolate@npm:d3-interpolate": "^3.0.1",
+      "vendor-types-d3-interpolate@npm:@types/d3-interpolate": "^3.0.1"
     },
     "devDependencies": {
       "@babel/plugin-transform-modules-commonjs": "^7.22.5",

--- a/packages/visx-vendor/scripts/buildVendor/babel.config.js
+++ b/packages/visx-vendor/scripts/buildVendor/babel.config.js
@@ -1,0 +1,64 @@
+/**
+ * This file handles the logic of transpiling ESM-only modules, ensuring that
+ * any references to _other_ ESM-only modules also points to our vendored libs.
+ */
+const path = require('path');
+
+module.exports = {
+  plugins: [
+    [
+      '@babel/transform-modules-commonjs',
+      {
+        strict: false,
+        allowTopLevelThis: true,
+      },
+    ],
+    [
+      'module-resolver',
+      {
+        // Convert all imports for _other_ ESM-only dependencies to the relative
+        // path in our vendor package.
+        resolvePath(sourcePath, currentFile) {
+          // extract the pkg name and detect if there is a deep import path
+          const packagePattern = /^(?<pkg>([^/]))(?<path>.*)/;
+          const match = packagePattern.exec(sourcePath);
+
+          if (match) {
+            const pkgName = match.groups.pkg;
+
+            // this is the easies way to pass this map to this file :melt:
+            const vendorPkgMap = JSON.parse(process.env.VENDOR_PKG_MAP || '{}');
+
+            // if this pkg is one we vendor
+            if (pkgName in vendorPkgMap) {
+              // Throw if there is a path component like "d3-<whatever>/path/to.js"
+              if (match.groups.path) {
+                throw new Error(`Unable to process ${sourcePath} import in ${currentFile}`);
+              }
+              const parsedPkg = vendorPkgMap[pkgName];
+
+              // Derive relative path to vendor lib to have a file like move from:
+              // - 'node_modules/d3-interpolate/src/rgb.js'
+              // - 'lib-vendor/d3-interpolate/src/rgb.js'
+              const currentFileVendor = currentFile.replace(
+                /node_modules/,
+                process.env.VENDOR_CJS_DIR,
+              );
+
+              // and have an import transform like:
+              // - d3-color
+              // - ../../d3-color
+              const relPathToPkg = path
+                .relative(path.dirname(currentFileVendor), parsedPkg.vendorIndexPath)
+                .replace(/\\/g, '/');
+
+              return relPathToPkg;
+            }
+          }
+
+          return sourcePath;
+        },
+      },
+    ],
+  ],
+};

--- a/packages/visx-vendor/scripts/buildVendor/babel.config.js
+++ b/packages/visx-vendor/scripts/buildVendor/babel.config.js
@@ -22,8 +22,8 @@ module.exports = {
          * importing from `d3-time-format`.
          *
          * sourcePath: 'd3-time-format'
-         * currentFile: '/some/path/visx/node_modules/vendor-d3-scale/src/time.js'
-         * relativePath: '../../vendor-d3-time-format/src/index.js'
+         * currentFile: '/some/path/visx/node_modules/d3-scale/src/time.js'
+         * relativePath: '../../d3-time-format/src/index.js'
          */
         resolvePath(sourcePath, currentFile) {
           // extract the pkg name and detect if there is a deep import path
@@ -45,8 +45,8 @@ module.exports = {
               const sourcePkg = vendorPkgMap[pkgName];
 
               // convert from node_modules to the target vendored path, e.g.,
-              //    /path/visx/node_modules/vendor-d3-array/src/difference.js
-              //    /path/visx/packages/visx-vendor/lib/vendor-d3-array/src/difference.js
+              //    /path/visx/node_modules/d3-array/src/difference.js
+              //    /path/visx/packages/visx-vendor/lib/d3-array/src/difference.js
               const currentFileVendoredFilename = currentFile.replace(
                 process.env.ROOT_NODE_MODULES_PATH,
                 process.env.VENDOR_CJS_PATH,
@@ -54,9 +54,9 @@ module.exports = {
 
               // now create a *relative* path from the current vendor file to the
               // vendored source file being imported in the current file, e.g., the path from
-              //    /path/visx/packages/visx-vendor/lib/vendor-d3-array/src/difference.js
+              //    /path/visx/packages/visx-vendor/lib/d3-array/src/difference.js
               // to
-              //    /path/visx/packages/visx-vendor/lib/vendor-d3-XXX/src/index.js
+              //    /path/visx/packages/visx-vendor/lib/d3-XXX/src/index.js
               const relativePath = path.relative(
                 path.dirname(currentFileVendoredFilename),
                 sourcePkg.vendorIndexFileName,

--- a/packages/visx-vendor/scripts/buildVendor/index.ts
+++ b/packages/visx-vendor/scripts/buildVendor/index.ts
@@ -14,7 +14,7 @@ import {
   ESM_PATH,
   CJS_PATH,
   VENDOR_CJS_PATH,
-  ROOT_NODE_MODULES_PATH,
+  NODE_MODULES_PATH,
   getTSContent,
   TS_GLOB,
   INDEX_GLOB,
@@ -25,8 +25,10 @@ const exec = util.promisify(childProcess.exec);
 const rimraf = util.promisify(baseRimraf);
 
 /**
- * Handles building the entire package, assuming correct (aliased) vendor packages are included
- * in the package.json and yarn installed in the monorepo root.
+ * Handles building the entire package. Assumes all vendored packages are included
+ * in the package.json and yarn installed in `./packages/visx-vendor/node_modules`
+ * (i.e., they are not hoisted to the root, this helps guarantee specificity of
+ * vendored packages).
  */
 async function build() {
   // print out packages to be vendored
@@ -44,9 +46,7 @@ async function build() {
   Object.values(parsedVendorPkgsMap).forEach((pkg) => {
     const exists = fs.existsSync(pkg.nodeModulesPath);
     if (!exists) {
-      throw new Error(
-        `Module note found: ${pkg.packageName} (alias: ${pkg.vendorPath}, path: ${pkg.nodeModulesPath})`,
-      );
+      throw new Error(`Module note found: ${pkg.packageName} (looked for: ${pkg.nodeModulesPath})`);
     }
   });
   console.log(chalk.green('✅ Verified all packages are installed.'));
@@ -75,7 +75,7 @@ async function build() {
       --config-file ${BABEL_CONFIG_FILE} \
       --only ${transpileGlob} \
       --out-dir ${VENDOR_CJS_PATH} \
-      ${ROOT_NODE_MODULES_PATH}`,
+      ${NODE_MODULES_PATH}`,
   );
 
   if (stdout) {

--- a/packages/visx-vendor/scripts/buildVendor/index.ts
+++ b/packages/visx-vendor/scripts/buildVendor/index.ts
@@ -1,0 +1,120 @@
+/* eslint import/no-extraneous-dependencies: 'off' */
+import chalk from 'chalk';
+import childProcess from 'child_process';
+import fs, { promises as fsPromises } from 'fs';
+import path from 'path';
+import util from 'util';
+import baseRimraf from 'rimraf';
+
+import {
+  getESMContent,
+  getCJSContent,
+  BABEL_CONFIG,
+  ESM_PATH,
+  CJS_PATH,
+  VENDOR_CJS_PATH,
+  parsedVendorPkgsMap,
+  ROOT_NODE_MODULES_PATH,
+} from './utils';
+
+const exec = util.promisify(childProcess.exec);
+const rimraf = util.promisify(baseRimraf);
+
+async function build() {
+  console.log(
+    chalk.green(
+      'Vendoring the following packages',
+      JSON.stringify(
+        Object.values(parsedVendorPkgsMap).map((pkg) => pkg.packageName),
+        null,
+        2,
+      ),
+    ),
+  );
+
+  // validate that we can resolve all packages in (the root) node modules
+  // they are aliased so they are guaranteed to be in the root
+  Object.values(parsedVendorPkgsMap).forEach((pkg) => {
+    const exists = fs.existsSync(pkg.nodeModulesPath);
+    if (!exists) {
+      throw new Error(
+        `Module note found: ${pkg.packageName} (alias: ${pkg.vendorPath}, path: ${pkg.nodeModulesPath})`,
+      );
+    }
+  });
+  console.log(chalk.green('Verified all packages are installed.'));
+
+  // clean output directories
+  const paths = [ESM_PATH, CJS_PATH, VENDOR_CJS_PATH];
+
+  console.log(chalk.green('Cleaning old vendor directories.'));
+  await Promise.all(paths.map((glob) => rimraf(glob)));
+
+  console.log(chalk.green('Creating empty vendor directories.'));
+  await Promise.all(paths.map((libPath) => fsPromises.mkdir(libPath, { recursive: true })));
+
+  // transpile vendor packages to CJS
+  console.log(chalk.green('Transpiling vendor sources to CJS'));
+
+  const outDirPath = VENDOR_CJS_PATH;
+  const transpileGlob = Object.values(parsedVendorPkgsMap)
+    .filter((pkg) => !pkg.isTypeFile)
+    .map((pkg) => `"${pkg.nodeModulesPath}/src/**/*.js"`)
+    .join(', ');
+
+  const { stdout, stderr } = await exec(
+    `babel \
+      --config-file ${BABEL_CONFIG} \
+      --only ${transpileGlob} \
+      --out-dir ${outDirPath} \
+      ${ROOT_NODE_MODULES_PATH}`,
+  );
+
+  if (stdout) {
+    console.log(chalk.greenBright(`  ${stdout}`));
+  }
+  if (stderr) {
+    console.log(chalk.redBright(`  ${stderr}`));
+  }
+
+  // write files
+  console.log(chalk.green('Copying licenses and generating indexes.'));
+  await Promise.all(
+    Object.values(parsedVendorPkgsMap).map(async (pkg) => {
+      // type files are referenced in the ESM file
+      if (pkg.isTypeFile) return;
+
+      console.log(chalk.green(`  ${pkg.packageName}`));
+
+      // paths
+      const libVendorPath = pkg.vendorPath;
+      const pkgJsonPath = path.join(pkg.nodeModulesPath, 'package.json');
+      const srcLicencePath = path.join(pkg.nodeModulesPath, 'LICENSE');
+      const vendorLicencePath = path.join(libVendorPath, 'LICENSE');
+
+      const parsedPkgJson = await fsPromises
+        .readFile(pkgJsonPath)
+        .then((buf) => JSON.parse(buf.toString()));
+
+      await Promise.all([
+        // make vendored directory
+        fsPromises.mkdir(libVendorPath, { recursive: true }),
+
+        // write ESM version
+        fsPromises.writeFile(`${pkg.esmPath}.js`, getESMContent(parsedPkgJson, pkg)),
+
+        // write CJS version
+        fsPromises.writeFile(`${pkg.cjsPath}.js`, getCJSContent(parsedPkgJson, pkg)),
+
+        // copy licenses
+        fsPromises.copyFile(srcLicencePath, vendorLicencePath),
+      ]);
+    }),
+  );
+}
+
+// run build
+build().catch((error) => {
+  console.error(chalk.red(error.message));
+  process.exitCode = 1;
+});

--- a/packages/visx-vendor/scripts/buildVendor/utils.ts
+++ b/packages/visx-vendor/scripts/buildVendor/utils.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import packageJson from '../../package.json';
 
 // types
@@ -39,11 +40,10 @@ export const VENDOR_CJS_DIR = 'vendor-cjs/';
 export const ESM_PATH = path.resolve(DIRNAME, `../../${ESM_DIR}`);
 export const CJS_PATH = path.resolve(DIRNAME, `../../${CJS_DIR}`);
 export const VENDOR_CJS_PATH = path.resolve(DIRNAME, `../../${VENDOR_CJS_DIR}`);
-export const BABEL_CONFIG = path.resolve(DIRNAME, './babel.config.js');
+export const BABEL_CONFIG_PATH = path.resolve(DIRNAME, './babel.config.js');
 export const ROOT_NODE_MODULES_PATH = path.resolve(DIRNAME, '../../../../node_modules/');
 
-// parsed packages
-
+// vendor package metadata
 const parseVendorPkgs = (pkgJsonDeps: {
   [dep: string]: string;
 }): { [pkg: string]: VendoredPkg } => {
@@ -55,13 +55,14 @@ const parseVendorPkgs = (pkgJsonDeps: {
     pkgDependencies.map((pkgJsonName) => {
       /**
        * Vendored packages are added as dependencies with aliases
-       * to guarantee that we reference the correct version within the monorepo
+       * to guarantee that we reference the correct version within the monorepo.
+       * This parses these dependencies into the alias source path
+       * and the actual package name.
+       *
        * examples (note aliases cannot include `@` or `/`):
        *   d3-array        => vendor-d3-array@npm:d3-array
        *   @types/d3-array => vendor-types-d3-array@npm:@types/d3-array
        *
-       * This parses these dependencies into the alias source path
-       * and the actual package name.
        */
       const [npmAlias, packageName] = pkgJsonName.split('@npm:');
       if (!npmAlias || !packageName) {
@@ -127,6 +128,6 @@ module.exports = require("../${VENDOR_CJS_DIR}${pkg.npmAlias}/src/index.js");`;
 
 // note: this is how we pass these dynamic variables into the
 // babel config. it's not great but babel config files can't easily
-// import from TS modules like this
+// import from TS module files like this
 process.env.VENDOR_CJS_DIR = VENDOR_CJS_DIR;
 process.env.VENDOR_PKG_MAP = JSON.stringify(parsedVendorPkgsMap);

--- a/packages/visx-vendor/scripts/buildVendor/utils.ts
+++ b/packages/visx-vendor/scripts/buildVendor/utils.ts
@@ -133,7 +133,7 @@ export function getCJSContent(pkgJson: PackageJson, pkg: VendoredPkg) {
 module.exports = require('../${VENDOR_CJS_DIR}${pkg.npmAlias}/src/index.js');`;
 }
 
-/**  */
+/** Generates the content of the root index file which points to CJS. */
 export function getIndexContent(pkgJson: PackageJson, pkg: VendoredPkg) {
   return `/**
  * \`@visx/vendor/${pkg.packageName}\` (CommonJS)
@@ -157,5 +157,6 @@ export * from '${pkg.npmAlias}';`;
 // note: this is how we pass these dynamic variables into the
 // babel config. it's not great but babel config files can't easily
 // import from TS module files like this
-process.env.VENDOR_CJS_DIR = VENDOR_CJS_DIR;
+process.env.VENDOR_CJS_PATH = VENDOR_CJS_PATH;
+process.env.ROOT_NODE_MODULES_PATH = ROOT_NODE_MODULES_PATH;
 process.env.VENDOR_PKG_MAP = JSON.stringify(parsedVendorPkgsMap);

--- a/packages/visx-vendor/scripts/buildVendor/utils.ts
+++ b/packages/visx-vendor/scripts/buildVendor/utils.ts
@@ -1,0 +1,132 @@
+import path from 'path';
+import packageJson from '../../package.json';
+
+// types
+/** Parsed representation of a vendored package */
+export type VendoredPkg = {
+  /** Name of the root node_modules/ package alias, e.g., vendor-d3-array. */
+  npmAlias: string;
+  /** Canonical name of the package, e.g., d3-array. */
+  packageName: string;
+  /** Whether this package is a types file. */
+  isTypeFile: boolean;
+  /** Name of the corresponding types file, if any. */
+  typesPackageName: string | null;
+  /** Fully-resolved path to transpiled vendor source in @visx/vendor. */
+  vendorPath: string;
+  /** Vendor path with src/index.js */
+  vendorIndexPath: string;
+  /** Path of the vendored CJS package. This points to the transpiled vendor path. */
+  cjsPath: string;
+  /** Path of the vendored ESM package. */
+  esmPath: string;
+  /** Fully-resolved path to root node_modules/ source. */
+  nodeModulesPath: string;
+};
+
+/** Minimal representation of a package.json */
+type PackageJson = {
+  name: string;
+  repository: { url: string };
+};
+
+// constants
+export const DIRNAME = __dirname; // eslint-disable-line no-undef
+export const ESM_DIR = 'esm/';
+export const CJS_DIR = 'lib/';
+export const VENDOR_CJS_DIR = 'vendor-cjs/';
+
+export const ESM_PATH = path.resolve(DIRNAME, `../../${ESM_DIR}`);
+export const CJS_PATH = path.resolve(DIRNAME, `../../${CJS_DIR}`);
+export const VENDOR_CJS_PATH = path.resolve(DIRNAME, `../../${VENDOR_CJS_DIR}`);
+export const BABEL_CONFIG = path.resolve(DIRNAME, './babel.config.js');
+export const ROOT_NODE_MODULES_PATH = path.resolve(DIRNAME, '../../../../node_modules/');
+
+// parsed packages
+
+const parseVendorPkgs = (pkgJsonDeps: {
+  [dep: string]: string;
+}): { [pkg: string]: VendoredPkg } => {
+  // e.g. ['vendor-d3-array@npm:d3-array', ...]
+  const pkgDependencies = Object.keys(pkgJsonDeps);
+
+  // e.g., { 'd3-array': 'vendor-d3-array' }
+  const pkgToAliasMap = Object.fromEntries(
+    pkgDependencies.map((pkgJsonName) => {
+      /**
+       * Vendored packages are added as dependencies with aliases
+       * to guarantee that we reference the correct version within the monorepo
+       * examples (note aliases cannot include `@` or `/`):
+       *   d3-array        => vendor-d3-array@npm:d3-array
+       *   @types/d3-array => vendor-types-d3-array@npm:@types/d3-array
+       *
+       * This parses these dependencies into the alias source path
+       * and the actual package name.
+       */
+      const [npmAlias, packageName] = pkgJsonName.split('@npm:');
+      if (!npmAlias || !packageName) {
+        throw new Error(`Could not parse vendor name ${pkgJsonName}`);
+      }
+      return [packageName, npmAlias]; // note: reversed from pkgJson entry
+    }),
+  );
+
+  const result = Object.keys(pkgToAliasMap).reduce<{ [pkg: string]: VendoredPkg }>(
+    (all, packageName) => {
+      const npmAlias = pkgToAliasMap[packageName];
+
+      const pkg: VendoredPkg = {
+        packageName,
+        npmAlias,
+        isTypeFile: packageName.includes('@types/'),
+        typesPackageName: pkgToAliasMap?.[`@types/${packageName}`] ?? null,
+        esmPath: `${ESM_PATH}/${packageName}`,
+        cjsPath: `${CJS_PATH}/${packageName}`,
+        vendorPath: `${VENDOR_CJS_PATH}/${npmAlias}`,
+        vendorIndexPath: `${VENDOR_CJS_PATH}/${npmAlias}/src/index.js`,
+        nodeModulesPath: `${ROOT_NODE_MODULES_PATH}/${npmAlias}`,
+      };
+
+      all[packageName] = pkg;
+      return all;
+    },
+    {},
+  );
+
+  return result;
+};
+
+export const parsedVendorPkgsMap = parseVendorPkgs(packageJson.dependencies);
+
+/** Generates the content of the vendored ESM package. */
+export function getESMContent(pkgJson: PackageJson, pkg: VendoredPkg) {
+  const licenseUrl = `${pkgJson.repository.url.replace(/\.git$/, '')}/blob/main/LICENSE`;
+  return `/**
+ * \`@visx/vendor/${pkg.packageName}\` (ESM)
+ * See upstream license: ${licenseUrl}
+ *
+ * This ESM package re-exports the underlying installed dependencies of \`node_modules/${
+   pkg.packageName
+ }\`
+ */
+export * from '${pkg.npmAlias}';
+${pkg.typesPackageName ? `export * from '${pkg.typesPackageName}';` : ''}`;
+}
+
+/** Generates the content of the vendored CJS package. */
+export function getCJSContent(pkgJson: PackageJson, pkg: VendoredPkg) {
+  const licenseUrl = `${pkgJson.repository.url.replace(/\.git$/, '')}/blob/main/LICENSE`;
+  return `/**
+ * \`@visx/vendor/${pkg.packageName}\` (CommonJS)
+ * See upstream license: ${licenseUrl}
+ *
+ * This CJS package exports transpiled vendor files in \`${pkg.vendorPath}\`
+ */
+module.exports = require("../${VENDOR_CJS_DIR}${pkg.npmAlias}/src/index.js");`;
+}
+
+// note: this is how we pass these dynamic variables into the
+// babel config. it's not great but babel config files can't easily
+// import from TS modules like this
+process.env.VENDOR_CJS_DIR = VENDOR_CJS_DIR;
+process.env.VENDOR_PKG_MAP = JSON.stringify(parsedVendorPkgsMap);

--- a/packages/visx-vendor/scripts/buildVendor/utils.ts
+++ b/packages/visx-vendor/scripts/buildVendor/utils.ts
@@ -147,7 +147,7 @@ module.exports = require('./${VENDOR_CJS_DIR}${pkg.npmAlias}/src/index.js');`;
 
 /** Generates the content of the vendored TS types. */
 export function getTSContent(pkg: VendoredPkg) {
-  return `/** \`@visx/vendor/${pkg.packageName}\` (TypeScript) 
+  return `/** \`@visx/vendor/${pkg.packageName.replace('@types/', '')}\` (TypeScript) 
  *
  * Re-exports the types from \`${pkg.packageName}\` 
  */

--- a/packages/visx-vendor/test/.eslintrc
+++ b/packages/visx-vendor/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "off"
+  }
+}

--- a/packages/visx-vendor/test/d3-array.test.ts
+++ b/packages/visx-vendor/test/d3-array.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* This test verifies that these modules and types are exported correctly */
 import {
   // @ts-expect-error Make sure invalid imports fail:
@@ -13,7 +12,7 @@ import {
   bisectRight,
   bisector,
   count,
-} from '../esm/d3-array'; // @todo update to `@visx/vendor/d3-array`
+} from '@visx/vendor/d3-array';
 
 describe('d3-array', () => {
   it('exports valid functions', () => {

--- a/packages/visx-vendor/test/d3-array.test.ts
+++ b/packages/visx-vendor/test/d3-array.test.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  Adder,
+  Bin,
+  Bisector,
+  bin,
+  bisect,
+  bisectCenter,
+  bisectLeft,
+  bisectRight,
+  bisector,
+  count,
+} from '../esm/d3-array'; // @todo update to `@visx/vendor/d3-array`
+
+describe('d3-array', () => {
+  it('exports valid functions', () => {
+    expect(bisect).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/d3-color.test.ts
+++ b/packages/visx-vendor/test/d3-color.test.ts
@@ -1,0 +1,20 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  color,
+  cubehelix,
+  lab,
+  gray,
+  hcl,
+  HCLColor,
+  LabColor,
+  lch,
+  RGBColor,
+} from '@visx/vendor/d3-color';
+
+describe('d3-color', () => {
+  it('exports valid functions', () => {
+    expect(color).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/d3-format.test.ts
+++ b/packages/visx-vendor/test/d3-format.test.ts
@@ -1,0 +1,17 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  format,
+  formatDefaultLocale,
+  formatLocale,
+  formatPrefix,
+  formatSpecifier,
+  FormatSpecifierObject,
+} from '@visx/vendor/d3-format';
+
+describe('d3-format', () => {
+  it('exports valid functions', () => {
+    expect(format).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/d3-interpolate.test.ts
+++ b/packages/visx-vendor/test/d3-interpolate.test.ts
@@ -1,0 +1,13 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  interpolate,
+  NumberArray,
+} from '@visx/vendor/d3-interpolate';
+
+describe('d3-interpolate', () => {
+  it('exports valid functions', () => {
+    expect(interpolate).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/d3-scale.test.ts
+++ b/packages/visx-vendor/test/d3-scale.test.ts
@@ -1,0 +1,61 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  InterpolatorFactory,
+  NumberValue,
+  ScaleBand,
+  ScaleContinuousNumeric,
+  ScaleDiverging,
+  ScaleIdentity,
+  ScaleLinear,
+  ScaleLogarithmic,
+  ScaleOrdinal,
+  ScalePoint,
+  ScalePower,
+  ScaleQuantile,
+  ScaleQuantize,
+  ScaleRadial,
+  ScaleSequential,
+  ScaleSequentialBase,
+  ScaleSequentialQuantile,
+  ScaleSymLog,
+  ScaleThreshold,
+  ScaleTime,
+  UnknownReturnType,
+  scaleBand,
+  scaleDiverging,
+  scaleDivergingLog,
+  scaleDivergingPow,
+  scaleDivergingSqrt,
+  scaleDivergingSymlog,
+  scaleIdentity,
+  scaleImplicit,
+  scaleLinear,
+  scaleLog,
+  scaleOrdinal,
+  scalePoint,
+  scalePow,
+  scaleQuantile,
+  scaleQuantize,
+  scaleRadial,
+  scaleSequential,
+  scaleSequentialLog,
+  scaleSequentialPow,
+  scaleSequentialQuantile,
+  scaleSequentialSqrt,
+  scaleSequentialSymlog,
+  scaleSqrt,
+  scaleSymlog,
+  scaleThreshold,
+  scaleTime,
+  scaleUtc,
+  tickFormat,
+} from '@visx/vendor/d3-scale';
+
+describe('d3-scale', () => {
+  it('exports valid functions', () => {
+    expect(scaleLinear).toBeInstanceOf(Function);
+    expect(scaleBand).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/d3-time-format.test.ts
+++ b/packages/visx-vendor/test/d3-time-format.test.ts
@@ -1,0 +1,18 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  timeFormat,
+  timeParse,
+  timeFormatLocale,
+  TimeLocaleObject,
+  utcFormat,
+  isoFormat,
+} from '@visx/vendor/d3-time-format';
+
+describe('d3-time-format', () => {
+  it('exports valid functions', () => {
+    expect(timeParse).toBeInstanceOf(Function);
+    expect(timeFormat).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/d3-time.test.ts
+++ b/packages/visx-vendor/test/d3-time.test.ts
@@ -1,0 +1,16 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  CountableTimeInterval,
+  TimeInterval,
+  timeDay,
+  timeInterval,
+} from '@visx/vendor/d3-time';
+
+describe('d3-time', () => {
+  it('exports valid functions', () => {
+    expect(timeDay).toBeInstanceOf(Function);
+    expect(timeInterval).toBeInstanceOf(Function);
+  });
+});

--- a/packages/visx-vendor/test/internmap.test.ts
+++ b/packages/visx-vendor/test/internmap.test.ts
@@ -1,0 +1,14 @@
+/* This test verifies that these modules and types are exported correctly */
+import {
+  // @ts-expect-error Make sure invalid imports fail:
+  INVALID_TYPE,
+  InternSet,
+  InternMap,
+} from '@visx/vendor/internmap';
+
+describe('internmap', () => {
+  it('exports valid classes', () => {
+    expect(InternSet).toBeDefined();
+    expect(InternMap).toBeDefined();
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,7 @@
     "scripts/**/*",
     "packages/*/src/**/*",
     "packages/*/test/**/*",
-    "packages/*/types/**/*"
+    "packages/*/types/**/*",
+    "packages/*/scripts/**/*",
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,6 +17,7 @@
     "noUnusedLocals": true,
     "pretty": true,
     "removeComments": false,
+    "resolveJsonModule": true,
     "strict": true,
     "target": "es2015",
     "typeRoots": ["./node_modules/@types", "./types"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3205,7 +3205,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz#4c017521900813ea524c9ecb8d7985ec26a9ad9a"
   integrity sha512-vvSaIDf/Ov0o3KwMT+1M8+WbnnlRiGjlGD5uvk83a1mPCTd/E5x12bUJ/oP55+wUY/4Kb5kc67rVpVGJ2KUHxg==
 
-"@types/d3-interpolate@^3.0.1":
+"@types/d3-interpolate@^3.0.1", "vendor-types-d3-interpolate@npm:@types/d3-interpolate@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz#e7d17fa4a5830ad56fe22ce3b4fac8541a9572dc"
   integrity sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==
@@ -3227,7 +3227,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#315367557d51b823bec848614fac095325613fc3"
   integrity sha512-9/D7cOBKdZdTCPc6re0HeSUFBM0aFzdNdmYggUWT9SRRiYSOa6Ys2xdTwHKgc1WS3gGfwTMatBOdWCS863REsg==
 
-"@types/d3-scale@^4.0.2":
+"@types/d3-scale@^4.0.2", "vendor-types-d3-scale@npm:@types/d3-scale@^4.0.2":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.3.tgz#7a5780e934e52b6f63ad9c24b105e33dd58102b5"
   integrity sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==
@@ -5648,7 +5648,7 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
-"d3-color@1 - 3":
+"d3-color@1 - 3", "vendor-d3-color@npm:d3-color@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
@@ -5663,7 +5663,7 @@ d3-format@1, d3-format@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
   integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
 
-"d3-format@1 - 3":
+"d3-format@1 - 3", "vendor-d3-format@npm:d3-format@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
@@ -5692,7 +5692,7 @@ d3-interpolate@1, d3-interpolate@^1.1.5:
   dependencies:
     d3-color "1"
 
-"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1, "vendor-d3-interpolate@npm:d3-interpolate@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -5735,7 +5735,7 @@ d3-scale@^1.0.6:
     d3-time "1"
     d3-time-format "2"
 
-d3-scale@^4.0.2:
+d3-scale@^4.0.2, "vendor-d3-scale@npm:d3-scale@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
@@ -5767,7 +5767,7 @@ d3-time-format@2, d3-time-format@^2.0.5:
   dependencies:
     d3-time "1"
 
-"d3-time-format@2 - 4":
+"d3-time-format@2 - 4", "vendor-d3-time-format@npm:d3-time-format@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
@@ -5779,7 +5779,7 @@ d3-time@1:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", "vendor-d3-time@npm:d3-time@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
@@ -8306,7 +8306,7 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-"internmap@1 - 2":
+"internmap@1 - 2", "vendor-internmap@npm:internmap@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
@@ -14330,6 +14330,26 @@ validate-npm-package-name@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.5.tgz#857c1afffd3f51319bbc5b301956aca68acaa7b8"
   integrity sha512-Qk7fpJ6qFp+26VeQ47WY0mkwXaiq8+76RJcncDEfMc2ocRzXLO67bLFRNI4OX1aGBoPzsM5Y2T+/m1pldOgD+A==
+
+"vendor-types-d3-color@npm:@types/d3-color@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.0.tgz#6594da178ded6c7c3842f3cc0ac84b156f12f2d4"
+  integrity sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==
+
+"vendor-types-d3-format@npm:@types/d3-format@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.1.tgz#194f1317a499edd7e58766f96735bdc0216bb89d"
+  integrity sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==
+
+"vendor-types-d3-time-format@npm:@types/d3-time-format@^2.1.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-2.3.1.tgz#87a30e4513b9d1d53b920327a361f87255bf3372"
+  integrity sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA==
+
+"vendor-types-d3-time@npm:@types/d3-time@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
+  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
 
 verror@1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,6 +3171,11 @@
   resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-2.0.0.tgz#a0d63a296a2d8435a9ec59393dcac746c6174a96"
   integrity sha512-rGqfPVowNDTszSFvwoZIXvrPG7s/qKzm9piCRIH6xwTTRu7pPZ3ootULFnPkTt74B6i5lN0FpLQL24qGOw1uZA==
 
+"@types/d3-array@^3.0.3":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.5.tgz#857c1afffd3f51319bbc5b301956aca68acaa7b8"
+  integrity sha512-Qk7fpJ6qFp+26VeQ47WY0mkwXaiq8+76RJcncDEfMc2ocRzXLO67bLFRNI4OX1aGBoPzsM5Y2T+/m1pldOgD+A==
+
 "@types/d3-chord@^1.0.9":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-1.0.9.tgz#ccc5de03ff079025491b7aa6b750670a140b45ae"
@@ -3183,15 +3188,20 @@
   dependencies:
     "@types/d3" "^3"
 
-"@types/d3-color@*":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-1.2.2.tgz#80cf7cfff7401587b8f89307ba36fe4a576bc7cf"
-  integrity sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw==
+"@types/d3-color@*", "@types/d3-color@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.0.tgz#6594da178ded6c7c3842f3cc0ac84b156f12f2d4"
+  integrity sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==
 
 "@types/d3-format@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-1.3.1.tgz#35bf88264bd6bcda39251165bb827f67879c4384"
   integrity sha512-KAWvReOKMDreaAwOjdfQMm0HjcUMlQG47GwqdVKgmm20vTd2pucj0a70c3gUSHrnsmo6H2AMrkBsZU2UhJLq8A==
+
+"@types/d3-format@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.1.tgz#194f1317a499edd7e58766f96735bdc0216bb89d"
+  integrity sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==
 
 "@types/d3-geo@^1.11.1":
   version "1.11.1"
@@ -3205,7 +3215,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz#4c017521900813ea524c9ecb8d7985ec26a9ad9a"
   integrity sha512-vvSaIDf/Ov0o3KwMT+1M8+WbnnlRiGjlGD5uvk83a1mPCTd/E5x12bUJ/oP55+wUY/4Kb5kc67rVpVGJ2KUHxg==
 
-"@types/d3-interpolate@^3.0.1", "vendor-types-d3-interpolate@npm:@types/d3-interpolate@^3.0.1":
+"@types/d3-interpolate@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz#e7d17fa4a5830ad56fe22ce3b4fac8541a9572dc"
   integrity sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==
@@ -3227,7 +3237,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#315367557d51b823bec848614fac095325613fc3"
   integrity sha512-9/D7cOBKdZdTCPc6re0HeSUFBM0aFzdNdmYggUWT9SRRiYSOa6Ys2xdTwHKgc1WS3gGfwTMatBOdWCS863REsg==
 
-"@types/d3-scale@^4.0.2", "vendor-types-d3-scale@npm:@types/d3-scale@^4.0.2":
+"@types/d3-scale@^4.0.2":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.3.tgz#7a5780e934e52b6f63ad9c24b105e33dd58102b5"
   integrity sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==
@@ -3246,15 +3256,15 @@
   resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-2.1.0.tgz#011e0fb7937be34a9a8f580ae1e2f2f1336a8a22"
   integrity sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==
 
-"@types/d3-time@*":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.0.10.tgz#d338c7feac93a98a32aac875d1100f92c7b61f4f"
-  integrity sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==
+"@types/d3-time-format@^2.1.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-2.3.1.tgz#87a30e4513b9d1d53b920327a361f87255bf3372"
+  integrity sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA==
 
-"@types/d3-time@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.0.0.tgz#831dd093db91f16b83ba980e194bb8e4bcef44d6"
-  integrity sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ==
+"@types/d3-time@*", "@types/d3-time@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
+  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
 
 "@types/d3-voronoi@^1.1.9":
   version "1.1.9"
@@ -5604,17 +5614,10 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-d3-array@2:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
-  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
-  dependencies:
-    internmap "^1.0.0"
-
-"d3-array@2 - 3", "d3-array@2.10.0 - 3":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.1.tgz#39331ea706f5709417d31bbb6ec152e0328b39b3"
-  integrity sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.2.1:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
   dependencies:
     internmap "1 - 2"
 
@@ -5648,7 +5651,7 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
-"d3-color@1 - 3", "vendor-d3-color@npm:d3-color@^3.1.0":
+"d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
@@ -5663,7 +5666,7 @@ d3-format@1, d3-format@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
   integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
 
-"d3-format@1 - 3", "vendor-d3-format@npm:d3-format@^3.1.0":
+"d3-format@1 - 3", d3-format@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
@@ -5692,7 +5695,7 @@ d3-interpolate@1, d3-interpolate@^1.1.5:
   dependencies:
     d3-color "1"
 
-"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1, "vendor-d3-interpolate@npm:d3-interpolate@^3.0.1":
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -5735,7 +5738,7 @@ d3-scale@^1.0.6:
     d3-time "1"
     d3-time-format "2"
 
-d3-scale@^4.0.2, "vendor-d3-scale@npm:d3-scale@^4.0.2":
+d3-scale@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
@@ -5767,7 +5770,7 @@ d3-time-format@2, d3-time-format@^2.0.5:
   dependencies:
     d3-time "1"
 
-"d3-time-format@2 - 4", "vendor-d3-time-format@npm:d3-time-format@^4.1.0":
+"d3-time-format@2 - 4", d3-time-format@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
@@ -5779,19 +5782,12 @@ d3-time@1:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3", "vendor-d3-time@npm:d3-time@^3.1.0":
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
-
-d3-time@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.1.1.tgz#e9d8a8a88691f4548e68ca085e5ff956724a6682"
-  integrity sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==
-  dependencies:
-    d3-array "2"
 
 d3-voronoi@^1.1.2:
   version "1.1.4"
@@ -8306,15 +8302,10 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-"internmap@1 - 2", "vendor-internmap@npm:internmap@^2.0.3":
+"internmap@1 - 2", internmap@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
-
-internmap@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
-  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -14318,38 +14309,6 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-"vendor-d3-array@npm:d3-array@^3.2.1":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
-  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
-  dependencies:
-    internmap "1 - 2"
-
-"vendor-types-d3-array@npm:@types/d3-array@^3.0.3":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.5.tgz#857c1afffd3f51319bbc5b301956aca68acaa7b8"
-  integrity sha512-Qk7fpJ6qFp+26VeQ47WY0mkwXaiq8+76RJcncDEfMc2ocRzXLO67bLFRNI4OX1aGBoPzsM5Y2T+/m1pldOgD+A==
-
-"vendor-types-d3-color@npm:@types/d3-color@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.0.tgz#6594da178ded6c7c3842f3cc0ac84b156f12f2d4"
-  integrity sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==
-
-"vendor-types-d3-format@npm:@types/d3-format@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.1.tgz#194f1317a499edd7e58766f96735bdc0216bb89d"
-  integrity sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==
-
-"vendor-types-d3-time-format@npm:@types/d3-time-format@^2.1.0":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-2.3.1.tgz#87a30e4513b9d1d53b920327a361f87255bf3372"
-  integrity sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA==
-
-"vendor-types-d3-time@npm:@types/d3-time@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
-  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
 
 verror@1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,13 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
+  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
+  dependencies:
+    "@babel/highlight" "^7.22.5"
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.0", "@babel/compat-data@^7.20.1":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.5.tgz#86f172690b093373a933223b4745deeb6049e733"
@@ -128,6 +135,16 @@
   dependencies:
     "@babel/types" "^7.20.5"
     "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.5.tgz#1e7bf768688acfb05cf30b2369ef855e82d984f7"
+  integrity sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==
+  dependencies:
+    "@babel/types" "^7.22.5"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.10.1":
@@ -223,6 +240,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
+"@babel/helper-environment-visitor@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz#f06dd41b7c1f44e1f8da6c4055b41ab3a09a7e98"
+  integrity sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==
+
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz#41f8228ef0a6f1a036b8dfdfec7ce94f9a6bc096"
@@ -247,6 +269,14 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
+"@babel/helper-function-name@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz#ede300828905bb15e582c037162f99d5183af1be"
+  integrity sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==
+  dependencies:
+    "@babel/template" "^7.22.5"
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-get-function-arity@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz#7303390a81ba7cb59613895a192b93850e373f7d"
@@ -260,6 +290,13 @@
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-hoist-variables@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb"
+  integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
+  dependencies:
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-member-expression-to-functions@^7.10.1":
   version "7.10.1"
@@ -296,6 +333,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-module-imports@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
+  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-module-transforms@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz#24e2f08ee6832c60b157bb0936c86bef7210c622"
@@ -322,6 +366,20 @@
     "@babel/template" "^7.18.10"
     "@babel/traverse" "^7.20.1"
     "@babel/types" "^7.20.2"
+
+"@babel/helper-module-transforms@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz#0f65daa0716961b6e96b164034e737f60a80d2ef"
+  integrity sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-module-imports" "^7.22.5"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
+    "@babel/template" "^7.22.5"
+    "@babel/traverse" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-optimise-call-expression@^7.10.1":
   version "7.10.1"
@@ -356,6 +414,11 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+
+"@babel/helper-plugin-utils@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
+  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
 
 "@babel/helper-regex@^7.10.1":
   version "7.10.1"
@@ -410,6 +473,13 @@
   dependencies:
     "@babel/types" "^7.20.2"
 
+"@babel/helper-simple-access@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz#4938357dc7d782b80ed6dbb03a0fba3d22b1d5de"
+  integrity sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.18.9":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz#fbe4c52f60518cab8140d77101f0e63a8a230684"
@@ -431,10 +501,22 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-split-export-declaration@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz#88cf11050edb95ed08d596f7a044462189127a08"
+  integrity sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-string-parser@^7.19.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
 "@babel/helper-validator-identifier@^7.10.1":
   version "7.10.1"
@@ -460,6 +542,11 @@
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -521,7 +608,16 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.1", "@babel/parser@^7.10.2", "@babel/parser@^7.15.3", "@babel/parser@^7.18.10", "@babel/parser@^7.20.5":
+"@babel/highlight@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
+  integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.5"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.1", "@babel/parser@^7.10.2", "@babel/parser@^7.15.3", "@babel/parser@^7.18.10", "@babel/parser@^7.20.5", "@babel/parser@^7.22.5":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
   integrity sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==
@@ -984,6 +1080,15 @@
     "@babel/helper-plugin-utils" "^7.19.0"
     "@babel/helper-simple-access" "^7.19.4"
 
+"@babel/plugin-transform-modules-commonjs@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.5.tgz#7d9875908d19b8c0536085af7b053fd5bd651bfa"
+  integrity sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.22.5"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-simple-access" "^7.22.5"
+
 "@babel/plugin-transform-modules-systemjs@^7.19.6":
   version "7.19.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.6.tgz#59e2a84064b5736a4471b1aa7b13d4431d327e0d"
@@ -1373,6 +1478,15 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
+"@babel/template@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
+  integrity sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==
+  dependencies:
+    "@babel/code-frame" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/types" "^7.22.5"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.1.tgz#bbcef3031e4152a6c0b50147f4958df54ca0dd27"
@@ -1401,6 +1515,22 @@
     "@babel/helper-split-export-declaration" "^7.18.6"
     "@babel/parser" "^7.20.5"
     "@babel/types" "^7.20.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.5.tgz#44bd276690db6f4940fdb84e1cb4abd2f729ccd1"
+  integrity sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==
+  dependencies:
+    "@babel/code-frame" "^7.22.5"
+    "@babel/generator" "^7.22.5"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-function-name" "^7.22.5"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/types" "^7.22.5"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1454,6 +1584,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.5.tgz#cd93eeaab025880a3a47ec881f4b096a5b786fbe"
+  integrity sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1839,6 +1978,14 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.8", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
@@ -3137,6 +3284,14 @@
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
   integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
 
+"@types/glob@*":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"
+  integrity sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==
+  dependencies:
+    "@types/minimatch" "^5.1.2"
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -3229,6 +3384,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minimatch@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
+
 "@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
@@ -3292,6 +3452,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/semver@^7.3.12":
   version "7.3.13"
@@ -4161,6 +4329,17 @@ babel-plugin-jest-hoist@^25.5.0:
     "@babel/types" "^7.3.3"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz#2b7fc176bd55da25f516abf96015617b4f70fc73"
+  integrity sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==
+  dependencies:
+    find-babel-config "^2.0.0"
+    glob "^8.0.3"
+    pkg-up "^3.1.0"
+    reselect "^4.1.7"
+    resolve "^1.22.1"
+
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz#5d1bd3836d0a19e1b84bbf2d9640ccb6f951c122"
@@ -4319,6 +4498,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^2.3.1:
   version "2.3.2"
@@ -4986,6 +5172,11 @@ compare-func@^1.3.1:
   dependencies:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
+
+compare-versions@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.3.tgz#a9b34fea217472650ef4a2651d905f42c28ebfd7"
+  integrity sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -6671,6 +6862,11 @@ eslint@^8.30.0:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^9.4.0:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
@@ -7008,6 +7204,14 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+find-babel-config@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-2.0.0.tgz#a8216f825415a839d0f23f4d18338a1cc966f701"
+  integrity sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==
+  dependencies:
+    json5 "^2.1.1"
+    path-exists "^4.0.0"
 
 find-cache-dir@3.3.1, find-cache-dir@^3.3.1:
   version "3.3.1"
@@ -7454,6 +7658,17 @@ glob@^7.2.0:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -8210,6 +8425,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.11.0:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
+  integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.2.0:
   version "2.5.0"
@@ -9238,6 +9460,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.1.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
@@ -10015,6 +10242,13 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@^3.0.1:
   version "3.0.2"
@@ -11213,6 +11447,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 platform@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
@@ -12239,6 +12480,11 @@ require-relative@^0.8.7:
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
+reselect@^4.1.7:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -12299,6 +12545,15 @@ resolve@^1.22.0:
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
     is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.1:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -14063,6 +14318,18 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+"vendor-d3-array@npm:d3-array@^3.2.1":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+"vendor-types-d3-array@npm:@types/d3-array@^3.0.3":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.5.tgz#857c1afffd3f51319bbc5b301956aca68acaa7b8"
+  integrity sha512-Qk7fpJ6qFp+26VeQ47WY0mkwXaiq8+76RJcncDEfMc2ocRzXLO67bLFRNI4OX1aGBoPzsM5Y2T+/m1pldOgD+A==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
#### :house: Internal

This is part of https://github.com/airbnb/visx/pull/1716 and adds the logic for vendoring `esm` and `cjs` versions of ESM-only libs. Again this is heavily based on https://github.com/FormidableLabs/victory/tree/main/packages/victory-vendor

Some key notes for what this package does (some of this is also included in the readme):
- the `package.json` `dependencies` defines which packages are vendored. as noted in https://github.com/airbnb/visx/pull/1717, this is assumed to include **all transitive ESM-only dependencies** (e.g,. ESM-only `d3-scale` depends on another ESM-only `d3-array`) so that we can vendor all of them

- ~dependencies use [`npm` aliases](https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias) of the form `d3-array` => `vendor-d3-array@npm:d3-array`~
  - ~why? one challenge with this repo is that different `visx` packages may use different versions of the same `d3-` package meaning that some dependencies might live in the root `node_modules` or the `node_modules` of a given package. adding a `vendor-` alias is a simple way to **guarantee** that we are vendoring / sourcing the right version of the right package from the root `node_modules`~
  - **EDIT** this added a great deal of complexity (and ultimately would require us to fully-transpile ESM versions of ESM-only libraries to have internally-consistent references), so the approach switched to using `yarn` [`nohoist`](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/)

- for every vendored package `<pkg>` we export the following (note: none of these are ever checked in, they are git-ignored):
  - an ESM version of the package in `esm/<pkg>.js` (this exports the original ESM-only `<pkg>` code)
  - a CJS version of the package in `lib/<pkg>.js`
    - this points to the transpiled version of the **entire** `<pkg>` package in `vendor-cjs/<pgk>/src/**/*.js`
    - `vendor-cjs/<pkg>/LICENSE` contains the upstream license of the vendored package
    - within `vendor-cjs/<pgk>/`, all references to **other** ESM-only packages are replaced by references to the appropriate CJS vendored packages.
      - e.g., `vendor-cjs/d3-scale/src/band.js` references `d3-array`, which is replaced by `"../../d3-array/src/index.js"`
  - TypeScript types from `@types/<pkg>` as root `<pkg>.d.ts` files (when available as specified in the `package.json` `dependencies`)
  - a root `<pkg>.js` file (pointing to the CJS version of the lib) for tooling that doesn't yet
  support `package.json:exports` ([conditional exports](https://nodejs.org/api/packages.html#conditional-exports))

TODO 
- [x] add tests for all vendored packages
- [x] PR to update all references to ESM-only packages to `@visx/vendor` (`@visx/scale` is updated in this PR as a proof of concept) https://github.com/airbnb/visx/pull/1719

<details>
  <summary>Here is a complete set of files generated for `d3-array`</summary>


`packages/visx-vendor/esm/d3-array.js`
```ts
/**
 * `@visx/vendor/d3-array` (ESM)
 * See upstream license: https://github.com/d3/d3-array/blob/main/LICENSE
 *
 * This ESM package re-exports the underlying installed dependencies of 
 * `node_modules/d3-array` (aliased as `d3-array`)
 */
export * from 'd3-array';
```

`packages/visx-vendor/lib/d3-array.js`
```ts
/**
 * `@visx/vendor/d3-array` (CommonJS)
 * See upstream license: https://github.com/d3/d3-array/blob/main/LICENSE
 *
 * This CJS package exports transpiled vendor files in `vendor-cjs/d3-array`
 */
module.exports = require('../vendor-cjs/d3-array/src/index.js');
```

`packages/visx-vendor/vendor-cjs/d3-array/`
(not shown because it's the transpiled lib, includes `src/**/.js` and `LICENSE`)

`packages/visx-vendor/d3-array.d.ts`
```ts
/** `@visx/vendor/d3-array` (TypeScript) 
 *
 * Re-exports the types from `@types/d3-array`
 */
export * from 'd3-array';
```

`packages/visx-vendor/d3-array.js`
```ts
/**
 * `@visx/vendor/d3-array` (CommonJS)
 * See upstream license: https://github.com/d3/d3-array/blob/main/LICENSE
 *
 * This file only exists for tooling that doesn't work yet with package.json:exports
 * by proxying through the CommonJS version.
 */
module.exports = require('./vendor-cjs/d3-array/src/index.js');
```

</details>