### PR TITLE
vendor: add files entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "test": "yarn run jest",
     "test:watch": "yarn run jest --watch",
     "ts": "ts-node --project ./tsconfig.node.json",
-    "type": "lerna exec --parallel -- tsc --build",
+    "type": "yarn type:clean && yarn type:build",
+    "type:build": "lerna exec --parallel -- tsc --build",
+    "type:clean": "find . -type f -name 'tsconfig.tsbuildinfo' -delete",
     "type:pkg": "lerna exec --scope $PKG -- tsc --build --verbose",
     "type:update-refs": "yarn run ts ./scripts/updateTsReferences.ts",
     "vendor-check": "yarn run ts ./packages/visx-vendor/scripts/flagVendorRequirements.ts"

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -51,5 +51,12 @@
       "import": "./esm/internmap.js",
       "require": "./lib/internmap.js"
     }
-  }
+  },
+  "files": [
+    "lib/",
+    "esm/",
+    "vendor-cjs/",
+    "./d3-*",
+    "./internmap.js"
+  ]
 }

--- a/packages/visx-xychart/tsconfig.json
+++ b/packages/visx-xychart/tsconfig.json
@@ -49,10 +49,10 @@
       "path": "../visx-tooltip"
     },
     {
-      "path": "../visx-voronoi"
+      "path": "../visx-vendor"
     },
     {
-      "path": "../visx-vendor"
+      "path": "../visx-voronoi"
     }
   ]
 }


### PR DESCRIPTION
#### :bug: Bug Fix

The published contents of `@visx/vendor` are off in the first alpha version. 
<img src="https://github.com/airbnb/visx/assets/4496521/e3095448-8b55-4a10-baa9-2fcb0fb20aa7" width="300" />

It seems like the default behavior should be to include **all** files, so this seems like the generated `lib/`, `esm/`, `vendor-cjs/`, index, and type files weren't published. Will do the following:

- [x] add explicit `files` entry to the `package.json`
- [ ] ~debug why `lib/`, `esm/`, ... were not published~
  - unclear, the github actions logs suggest everything was generated. validating this locally and will merge this with the simple `files` fix if it works locally