### PR TITLE
new(axis): add shapeRendering prop to Axis

### DIFF
--- a/packages/visx-axis/src/axis/AxisRenderer.tsx
+++ b/packages/visx-axis/src/axis/AxisRenderer.tsx
@@ -29,6 +29,7 @@ export default function AxisRenderer<Scale extends AxisScale>({
   labelProps = defaultTextProps,
   orientation = Orientation.bottom,
   scale,
+  shapeRendering,
   stroke = '#222',
   strokeDasharray,
   strokeWidth = 1,
@@ -78,6 +79,7 @@ export default function AxisRenderer<Scale extends AxisScale>({
           className={cx('visx-axis-line', axisLineClassName)}
           from={axisFromPoint}
           to={axisToPoint}
+          shapeRendering={shapeRendering}
           stroke={stroke}
           strokeWidth={strokeWidth}
           strokeDasharray={strokeDasharray}

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -71,6 +71,8 @@ export type CommonProps<Scale extends AxisScale> = {
   orientation?: ValueOf<typeof Orientation>;
   /** Pixel padding to apply to axis sides. */
   rangePadding?: number | { start?: number; end?: number };
+  /** Shape rendering for the lines. */
+  shapeRendering?: SVGProps<SVGLineElement>['shapeRendering'];
   /** The color for the stroke of the lines. */
   stroke?: string;
   /** The pixel value for the width of the lines. */


### PR DESCRIPTION
#### :boom: Breaking Changes

None.

#### :rocket: Enhancements

Additional flexibility when using `Axis`.

#### :memo: Documentation

`shapeRendering` can now be configured for `Axis` lines.

#### :bug: Bug Fix

Not sure if this was introduced by #840. I haven't dug much into it. But I have noticed that on Windows, Firefox, when using the `Axis` with a `scaleLinear` and dashed pattern, some vertical lines looked very thick while others very thin.

After playing around in the HTML, I figured the culprit was the "smart" `shapeRendering`. So I want a way to disable it without resorting to ugly hacks.

#### :house: Internal

The `CommonProps` for `visx-types` have changed.
