### PR TITLE
feat(axis): Expose innerRef prop on the various Axis components

### DIFF
--- a/packages/visx-axis/src/axis/Axis.tsx
+++ b/packages/visx-axis/src/axis/Axis.tsx
@@ -20,6 +20,7 @@ export default function Axis<Scale extends AxisScale>({
   hideAxisLine = false,
   hideTicks = false,
   hideZero = false,
+  innerRef,
   left = 0,
   numTicks = 10,
   orientation = Orientation.bottom,
@@ -69,7 +70,7 @@ export default function Axis<Scale extends AxisScale>({
   });
 
   return (
-    <Group className={cx('visx-axis', axisClassName)} top={top} left={left}>
+    <Group className={cx('visx-axis', axisClassName)} innerRef={innerRef} top={top} left={left}>
       {children({
         ...restProps,
         axisFromPoint,

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -1,6 +1,6 @@
 import { D3Scale, NumberLike, ScaleInput, ValueOf } from '@visx/scale';
 import { TextProps } from '@visx/text/lib/Text';
-import { ReactNode, SVGProps } from 'react';
+import { ReactNode, Ref, SVGProps } from 'react';
 import Orientation from './constants/orientation';
 
 // In order to plot values on an axis, output of the scale must be number.
@@ -132,6 +132,8 @@ export type SharedAxisProps<Scale extends AxisScale> = CommonProps<Scale> & {
   axisClassName?: string;
   /** A left pixel offset applied to the entire axis. */
   left?: number;
+  /** The reference to the axis group element */
+  innerRef?: Ref<SVGGElement>;
   /** A [d3](https://github.com/d3/d3-scale) or [visx](https://github.com/airbnb/visx/tree/master/packages/visx-scale) scale function. */
   scale: Scale;
   /** An array of values that determine the number and values of the ticks. Falls back to `scale.ticks()` or `.domain()`. */

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -132,7 +132,7 @@ export type SharedAxisProps<Scale extends AxisScale> = CommonProps<Scale> & {
   axisClassName?: string;
   /** A left pixel offset applied to the entire axis. */
   left?: number;
-  /** The reference to the axis group element */
+  /** The reference to the outermost axis group element. */
   innerRef?: Ref<SVGGElement>;
   /** A [d3](https://github.com/d3/d3-scale) or [visx](https://github.com/airbnb/visx/tree/master/packages/visx-scale) scale function. */
   scale: Scale;

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -132,7 +132,7 @@ export type SharedAxisProps<Scale extends AxisScale> = CommonProps<Scale> & {
   axisClassName?: string;
   /** A left pixel offset applied to the entire axis. */
   left?: number;
-  /** The reference to the outermost axis group element. */
+  /** The ref to the outermost axis group element. */
   innerRef?: Ref<SVGGElement>;
   /** A [d3](https://github.com/d3/d3-scale) or [visx](https://github.com/airbnb/visx/tree/master/packages/visx-scale) scale function. */
   scale: Scale;

--- a/packages/visx-axis/test/Axis.test.tsx
+++ b/packages/visx-axis/test/Axis.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom';
 
 import { Line } from '@visx/shape';
 import { Text } from '@visx/text';

--- a/packages/visx-axis/test/Axis.test.tsx
+++ b/packages/visx-axis/test/Axis.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import { Line } from '@visx/shape';
 import { Text } from '@visx/text';
@@ -214,5 +216,16 @@ describe('<Axis />', () => {
     // Third point
     expect(points.at(2).prop('from')).toEqual({ x: 10.5, y: 0 });
     expect(points.at(2).prop('to')).toEqual({ x: 0.5, y: 0 });
+  });
+
+  test('should expose its ref via an innerRef prop', () => {
+    const fakeRef = React.createRef<SVGGElement>();
+    const { container } = render(
+      <svg>
+        <Axis {...axisProps} innerRef={fakeRef} />
+      </svg>,
+    );
+    const AxisGroupElement = container.querySelector('g.visx-axis');
+    expect(fakeRef.current).toBe(AxisGroupElement);
   });
 });


### PR DESCRIPTION
#### :rocket: Enhancements

- Expose the innerRef prop on all the various the `Axis` components. This makes it possible to get the dimensions of the of the `Axis` without using `getStringWidth` on all the tick values.

closes: #1086 
