### PR TITLE
fix: correctly pass through offset from AnimatedGridRows/Columns

### DIFF
--- a/packages/visx-react-spring/src/grid/AnimatedGridColumns.tsx
+++ b/packages/visx-react-spring/src/grid/AnimatedGridColumns.tsx
@@ -23,6 +23,7 @@ export default function AnimatedGridColumns<Scale extends GridScale>({
       numTicks={numTicks}
       tickValues={tickValues}
       className={className}
+      offset={offset}
       top={top}
       left={left}
     >

--- a/packages/visx-react-spring/src/grid/AnimatedGridRows.tsx
+++ b/packages/visx-react-spring/src/grid/AnimatedGridRows.tsx
@@ -25,6 +25,7 @@ export default function AnimatedGridRows<Scale extends GridScale>({
       className={className}
       top={top}
       left={left}
+      offset={offset}
     >
       {({ lines }) => (
         <AnimatedGridLines


### PR DESCRIPTION
#### :bug: Bug Fix
- Correctly pass through `offset` in AnimatedGridRows
- Correctly pass through `offset` in AnimatedGridColumns
