### PR TITLE
fix: typo in DragITile description

### DIFF
--- a/packages/visx-demo/src/components/Gallery/DragITile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DragITile.tsx
@@ -11,7 +11,7 @@ export default function DragITile() {
   return (
     <GalleryTile<DragIProps>
       title="Drag i"
-      description="<Drag.Drag />>"
+      description="<Drag.Drag />"
       exampleRenderer={DragI}
       exampleUrl="/drag-i"
       tileStyles={tileStyles}


### PR DESCRIPTION
#### :bug: Bug Fix

- Fixes typo in `DragITile` description. There is an extra trailing ">" character.