### PR TITLE
Revert "new(axis): add shapeRendering prop to Axis"

### DIFF
--- a/packages/visx-axis/src/axis/AxisRenderer.tsx
+++ b/packages/visx-axis/src/axis/AxisRenderer.tsx
@@ -29,7 +29,6 @@ export default function AxisRenderer<Scale extends AxisScale>({
   labelProps,
   orientation = Orientation.bottom,
   scale,
-  shapeRendering,
   stroke = '#222',
   strokeDasharray,
   strokeWidth = 1,
@@ -83,7 +82,6 @@ export default function AxisRenderer<Scale extends AxisScale>({
           className={cx('visx-axis-line', axisLineClassName)}
           from={axisFromPoint}
           to={axisToPoint}
-          shapeRendering={shapeRendering}
           stroke={stroke}
           strokeWidth={strokeWidth}
           strokeDasharray={strokeDasharray}

--- a/packages/visx-axis/src/types.ts
+++ b/packages/visx-axis/src/types.ts
@@ -71,8 +71,6 @@ export type CommonProps<Scale extends AxisScale> = {
   orientation?: ValueOf<typeof Orientation>;
   /** Pixel padding to apply to axis sides. */
   rangePadding?: number | { start?: number; end?: number };
-  /** Shape rendering for the lines. */
-  shapeRendering?: SVGProps<SVGLineElement>['shapeRendering'];
   /** The color for the stroke of the lines. */
   stroke?: string;
   /** The pixel value for the width of the lines. */


### PR DESCRIPTION
Reverts airbnb/visx#1739 . this actually made the tick line rendering **more blurry** as it overrode https://github.com/airbnb/visx/pull/840

<img width="724" alt="image" src="https://github.com/airbnb/visx/assets/4496521/2b863e87-fbb8-49ed-a0ef-e7b409b6946d">

by removing this, you can still set it via `axisLineClassName`, and you can set it for tick lines via `tickLineProps`


cc @Lonami 