### PR TITLE
Fix useParentSize not updating width and height

### DIFF
--- a/packages/visx-responsive/src/hooks/useParentSize.ts
+++ b/packages/visx-responsive/src/hooks/useParentSize.ts
@@ -80,7 +80,7 @@ export default function useParentSize<T extends HTMLElement = HTMLDivElement>({
       observer.disconnect();
       resize.cancel();
     };
-  }, [resize, resizeObserverPolyfill]);
+  }, [resize, parentRef.current, resizeObserverPolyfill])
 
   return { parentRef, resize, ...state };
 }


### PR DESCRIPTION
#### :bug: Bug Fix
Fixes: https://github.com/airbnb/visx/issues/1816

#### Description
The `parentRef` is initially `null`, so the observer is not registered on the ref element (`observer.observe(parentRef.current);` not executed) in the initial render. If we don't add `parentRef.current ` to the dependency array, the `useEffect` won't be executed after `parentRef` is assigned.