### PR TITLE
brush: fix brush jumping around after mouseup

### DIFF
--- a/packages/visx-brush/src/BaseBrush.tsx
+++ b/packages/visx-brush/src/BaseBrush.tsx
@@ -16,6 +16,7 @@ import {
   BrushPageOffset,
 } from './types';
 import { getPageCoordinates } from './utils';
+import debounce from 'lodash/debounce';
 
 type PointerHandlerEvent = React.PointerEvent<SVGRectElement>;
 
@@ -224,7 +225,7 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
     }
   };
 
-  handleWindowPointerMove = (event: MouseEvent) => {
+  handleWindowPointerMove = debounce((event: MouseEvent) => {
     const { useWindowMoveEvents } = this.props;
     const { brushingType, isBrushing, brushPageOffset, start } = this.state;
 
@@ -318,7 +319,7 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
         return newState;
       });
     }
-  };
+  }, 1);
 
   getExtent = (start: Partial<Point>, end: Partial<Point>) => {
     const { brushDirection, width, height } = this.props;

--- a/packages/visx-brush/src/BaseBrush.tsx
+++ b/packages/visx-brush/src/BaseBrush.tsx
@@ -15,8 +15,7 @@ import {
   BrushingType,
   BrushPageOffset,
 } from './types';
-import { getPageCoordinates } from './utils';
-import debounce from 'lodash/debounce';
+import { getPageCoordinates, debounce } from './utils';
 
 type PointerHandlerEvent = React.PointerEvent<SVGRectElement>;
 

--- a/packages/visx-brush/src/BaseBrush.tsx
+++ b/packages/visx-brush/src/BaseBrush.tsx
@@ -15,7 +15,7 @@ import {
   BrushingType,
   BrushPageOffset,
 } from './types';
-import { getPageCoordinates, debounce } from './utils';
+import { debounce, getPageCoordinates } from './utils';
 
 type PointerHandlerEvent = React.PointerEvent<SVGRectElement>;
 
@@ -177,14 +177,14 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
   componentDidMount() {
     if (this.props.useWindowMoveEvents) {
       window.addEventListener('mouseup', this.handleWindowPointerUp);
-      window.addEventListener('mousemove', this.handleWindowPointerMove);
+      window.addEventListener('mousemove', this.debouncedHandleWindowPointerMove);
     }
   }
 
   componentWillUnmount() {
     if (this.props.useWindowMoveEvents) {
       window.removeEventListener('mouseup', this.handleWindowPointerUp);
-      window.removeEventListener('mousemove', this.handleWindowPointerMove);
+      window.removeEventListener('mousemove', this.debouncedHandleWindowPointerMove);
     }
   }
 
@@ -224,7 +224,7 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
     }
   };
 
-  handleWindowPointerMove = debounce((event: MouseEvent) => {
+  handleWindowPointerMove = (event: MouseEvent) => {
     const { useWindowMoveEvents } = this.props;
     const { brushingType, isBrushing, brushPageOffset, start } = this.state;
 
@@ -318,7 +318,9 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
         return newState;
       });
     }
-  }, 1);
+  };
+
+  debouncedHandleWindowPointerMove = debounce(this.handleWindowPointerMove, 1);
 
   getExtent = (start: Partial<Point>, end: Partial<Point>) => {
     const { brushDirection, width, height } = this.props;

--- a/packages/visx-brush/src/utils.ts
+++ b/packages/visx-brush/src/utils.ts
@@ -70,10 +70,11 @@ export function getPageCoordinates(event: MouseTouchOrPointerEvent) {
   };
 }
 
-//Taken from https://dev.to/cantem/how-to-write-a-debounce-function-1bdf
+// Taken from https://dev.to/cantem/how-to-write-a-debounce-function-1bdf
+// With some modifications
 export function debounce<T extends Function>(func: T, delay: number): (...args: any[]) => void {
   let timeoutId: ReturnType<typeof setTimeout>;
-  return function (this: any, ...args: any[]) {
+  return function debouncedFn(this: unknown, ...args: unknown[]) {
     const context = this;
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => {

--- a/packages/visx-brush/src/utils.ts
+++ b/packages/visx-brush/src/utils.ts
@@ -75,10 +75,9 @@ export function getPageCoordinates(event: MouseTouchOrPointerEvent) {
 export function debounce<T extends Function>(func: T, delay: number): (...args: any[]) => void {
   let timeoutId: ReturnType<typeof setTimeout>;
   return function debouncedFn(this: unknown, ...args: unknown[]) {
-    const context = this;
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => {
-      func.apply(context, args);
+      func.apply(this, args);
     }, delay);
   };
 }

--- a/packages/visx-brush/src/utils.ts
+++ b/packages/visx-brush/src/utils.ts
@@ -70,8 +70,7 @@ export function getPageCoordinates(event: MouseTouchOrPointerEvent) {
   };
 }
 
-// Taken from https://dev.to/cantem/how-to-write-a-debounce-function-1bdf
-// With some modifications
+// Tweaked from https://dev.to/cantem/how-to-write-a-debounce-function-1bdf
 export function debounce<T extends Function>(func: T, delay: number): (...args: any[]) => void {
   let timeoutId: ReturnType<typeof setTimeout>;
   return function debouncedFn(this: unknown, ...args: unknown[]) {

--- a/packages/visx-brush/src/utils.ts
+++ b/packages/visx-brush/src/utils.ts
@@ -69,3 +69,15 @@ export function getPageCoordinates(event: MouseTouchOrPointerEvent) {
     pageY: pointerEvent.pageY,
   };
 }
+
+//Taken from https://dev.to/cantem/how-to-write-a-debounce-function-1bdf
+export function debounce<T extends Function>(func: T, delay: number): (...args: any[]) => void {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (this: any, ...args: any[]) {
+    const context = this;
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      func.apply(context, args);
+    }, delay);
+  };
+}


### PR DESCRIPTION
#### :bug: Bug Fix

**How to induce?** 
resize the brush window by dragging and releasing one handle quickly, or quickly drag the brush window and release (harder to induce this way)

**Impact?**
Handle ends up quite far away from the mouse pointer's location. Sometimes the location of _both_ handles will be updated, resulting in a drastic resize of the brush window.

Two relevant issue have been linked below- I believe this PR should resolve both of them!

[Issue 1](https://github.com/airbnb/visx/issues/1804)
[Issue 2](https://github.com/airbnb/visx/issues/1736)

**Root cause** 
`mouseup` action is _supposed_ to disable subsequent dragging of the handle upon `mousemove`. This is achieved by updating the brush's state. However, when moving quickly, `mousemove` actions can trigger `handleWindowPointerMove` _before_ the state change is complete. This leads to handle movement _after_ `mouseup`. Additionally, the stale state causes the occasionally erratic placement of the handle(s).
 
#### Before 

https://github.com/airbnb/visx/assets/166535835/a1c82e0e-edae-449b-88ca-1259c40eb65a

#### After

Can't induce the bug anymore, even with very quick use of the brush.

https://github.com/airbnb/visx/assets/166535835/53bfc639-feab-4034-8e41-ac34817b13ba

