### PR TITLE
feat(xychart): improve performance when hovering with tooltip

### DIFF
--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useRef } from 'react';
+import React, { memo, useCallback, useRef } from 'react';
 import { animated, useSpring } from '@react-spring/web';
 // @ts-expect-error no types
 import { interpolatePath } from 'd3-interpolate-path';
 import debounce from 'lodash/debounce';
 
-export default function AnimatedPath({
+function AnimatedPath({
   d,
   stroke = 'transparent',
   fill = 'transparent',
@@ -44,3 +44,5 @@ export default function AnimatedPath({
     />
   );
 }
+
+export default memo(AnimatedPath);


### PR DESCRIPTION
#### :rocket: Enhancements

- Improves performance drastically when hovering over XYChart with tooltips on. This is achieved by no longer re-rendering unless any of the props change, as renders are quite expensive with `d3-interpolate-path`

#### :memo: Documentation

- Added an gallery control to select data size for testing


This could also be achieved by doing a comparison for `previousD.current === d` - let me know if that's preferable over using React `memo`.
