### PR TITLE
Allow custom gesture handlers in Zoom

### DIFF
--- a/packages/visx-zoom/src/types.ts
+++ b/packages/visx-zoom/src/types.ts
@@ -1,4 +1,10 @@
-import { UserHandlers, WebKitGestureEvent, Handler } from '@use-gesture/react';
+import {
+  UserHandlers,
+  WebKitGestureEvent,
+  Handler,
+  GestureHandlers,
+  EventTypes,
+} from '@use-gesture/react';
 import {
   RefObject,
   MouseEvent as ReactMouseEvent,
@@ -45,6 +51,10 @@ export interface ScaleSignature {
   scaleY?: TransformMatrix['scaleY'];
   point?: Point;
 }
+
+export type CreateGestureHandlers = <ElementType>(
+  zoom: ProvidedZoom<ElementType>,
+) => GestureHandlers<EventTypes>;
 
 export interface ProvidedZoom<ElementType> {
   /** Sets translateX/Y to the center defined by width and height. */


### PR DESCRIPTION
#### :rocket: Enhancements

- Introduce 'createGestureHandlers' function prop in the `Zoom` component to enable developers define custom gestures.
This allows for flexibility in disabling wheel events or overriding default pinch gestures, improving customization options.

#### :memo: Documentation

- Added basic description for the new `createGestureHandlers` prop.


Should close #1798 and #1845 
