### PR TITLE
fix: don't include all of lodash

### DIFF
--- a/packages/visx-responsive/package.json
+++ b/packages/visx-responsive/package.json
@@ -28,9 +28,9 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/lodash": "^4.14.172",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/react": "*",
-    "lodash": "^4.17.21",
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {

--- a/packages/visx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSize.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import React from 'react';
 import {
   DebounceSettings,

--- a/packages/visx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withScreenSize.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import React from 'react';
 import { Simplify, DebounceSettings } from '../types';
 

--- a/packages/visx-responsive/src/hooks/useParentSize.ts
+++ b/packages/visx-responsive/src/hooks/useParentSize.ts
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import { RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { DebounceSettings, PrivateWindow, ResizeObserverPolyfill } from '../types';
 

--- a/packages/visx-responsive/src/hooks/useScreenSize.ts
+++ b/packages/visx-responsive/src/hooks/useScreenSize.ts
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import { useEffect, useMemo, useState } from 'react';
 import { DebounceSettings } from '../types/index';
 

--- a/packages/visx-shape/package.json
+++ b/packages/visx-shape/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@types/d3-path": "^1.0.8",
     "@types/d3-shape": "^1.3.1",
-    "@types/lodash": "^4.14.172",
     "@types/react": "*",
     "@visx/curve": "3.3.0",
     "@visx/group": "3.3.0",
@@ -31,7 +30,6 @@
     "classnames": "^2.3.1",
     "d3-path": "^1.0.5",
     "d3-shape": "^1.2.0",
-    "lodash": "^4.17.21",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/visx-text/package.json
+++ b/packages/visx-text/package.json
@@ -28,10 +28,10 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/lodash": "^4.14.172",
+    "@types/lodash.memoize": "^4.1.9",
     "@types/react": "*",
     "classnames": "^2.3.1",
-    "lodash": "^4.17.21",
+    "lodash.memoize": "^4.1.2",
     "prop-types": "^15.7.2",
     "reduce-css-calc": "^1.3.0"
   },

--- a/packages/visx-text/src/util/getStringWidth.ts
+++ b/packages/visx-text/src/util/getStringWidth.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash/memoize';
+import memoize from 'lodash.memoize';
 
 const MEASUREMENT_ELEMENT_ID = '__react_svg_text_measurement_id';
 

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -40,7 +40,7 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.172",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/react": "*",
     "@visx/annotation": "3.3.0",
     "@visx/axis": "3.10.1",
@@ -58,7 +58,7 @@
     "classnames": "^2.3.1",
     "d3-interpolate-path": "2.2.1",
     "d3-shape": "^2.0.0",
-    "lodash": "^4.17.21",
+    "lodash.debounce": "^4.0.8",
     "mitt": "^2.1.0",
     "prop-types": "^15.6.2"
   },

--- a/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
+++ b/packages/visx-xychart/src/components/series/private/AnimatedPath.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useRef } from 'react';
 import { animated, useSpring } from '@react-spring/web';
 // @ts-expect-error no types
 import { interpolatePath } from 'd3-interpolate-path';
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 
 function AnimatedPath({
   d,

--- a/packages/visx-xychart/src/providers/TooltipProvider.tsx
+++ b/packages/visx-xychart/src/providers/TooltipProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import { useTooltip } from '@visx/tooltip';
 import TooltipContext from '../context/TooltipContext';
 import { EventHandlerParams, TooltipContextType, TooltipData } from '../types';


### PR DESCRIPTION
#### :boom: Breaking Changes

- None

#### :rocket: Enhancements

- Visx packages now only depend on specific lodash function packages, rather than all of lodash. This affects `visx-responsive`, `visx-text`,  and `visx-xychart`.

#### :memo: Documentation

- None

#### :bug: Bug Fix

- None

#### :house: Internal

- None
