### PR TITLE
[Bugfix: Text] Fix ballooning SVG dimensions on Firefox

### DIFF
--- a/packages/visx-text/src/Text.tsx
+++ b/packages/visx-text/src/Text.tsx
@@ -27,7 +27,7 @@ export default function Text(props: TextProps) {
   const { wordsByLines, startDy, transform } = useText(props);
 
   return (
-    <svg ref={innerRef} x={dx} y={dy} fontSize={fontSize} style={SVG_STYLE}>
+    <svg ref={innerRef} x={dx} y={dy} fontSize={fontSize} style={SVG_STYLE} height={1} width={1}>
       {wordsByLines.length > 0 ? (
         <text ref={innerTextRef} transform={transform} {...textProps} textAnchor={textAnchor}>
           {wordsByLines.map((line, index) => (


### PR DESCRIPTION
#### :bug: Bug Fix

Hey guys! Recently noticed that `Text`'s svg wrapper blows up to max width/height on Firefox. This has the impact of inflating the parent container as well, and generally polluting the DOM inaccurately sized containers.

This _is_  an accepted implementation difference between Firefox and Safari/Chrome for SVGs with 0 width/height. And, `Text` is still _displaying_ correctly. However, this behavior is a barrier in implementing dynamic layouts, since 1 `Text` element can mess up significant portions of the DOM with inaccurately sized elements. For example, I noticed this issue manifesting via `Axis`, where it was bubbling up from the tickLabel's `Text` components.

Visx is so powerful because it abstracts finicky SVG components - so ideally, I think `Text` should be browser agnostic and handle this svg "quirk" on its own.

Let me know what you think! Thanks!

#### Axis on Firefox with this issue:

<img width="788" alt="Screenshot 2024-06-14 at 3 00 50 PM" src="https://github.com/airbnb/visx/assets/166535835/fb695354-f9e2-43ed-9632-47c92796f5a3">

#### Axis on Firefox after fix:
<img width="831" alt="Screenshot 2024-06-14 at 3 14 43 PM" src="https://github.com/airbnb/visx/assets/166535835/e21a786c-c8c8-412c-8a69-47ebf25f53a8">

#### Axis on Chrome (before and after)
<img width="812" alt="Screenshot 2024-06-14 at 3 00 06 PM" src="https://github.com/airbnb/visx/assets/166535835/45cf8607-9e49-4241-ad3a-0c24a7d19887">