### PR TITLE
Fix code snippet for Annotation component

### DIFF
--- a/packages/visx-xychart/README.md
+++ b/packages/visx-xychart/README.md
@@ -265,7 +265,7 @@ export default () => (
       <AnnotationCircleSubject />
       {/** Connect label to CircleSubject */}
       <AnnotationConnector />
-    </AnimatedAnnotation>
+    </Annotation>
   </XYChart>
 );
 ```


### PR DESCRIPTION
#### :memo: Documentation

Hello, I noticed, that in the code snippet for the `Annotation`-component, an incorrect closing tag was used.

Cheers