### PR TITLE
Update Example.tsx of axis documentation

### DIFF
--- a/packages/visx-demo/src/sandboxes/visx-axis/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-axis/Example.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo } from 'react';
 import AreaClosed from '@visx/shape/lib/shapes/AreaClosed';
 import { curveMonotoneX } from '@visx/curve';
-import { scaleUtc, scaleLinear, scaleLog, scaleBand, ScaleInput, coerceNumber } from '@visx/scale';
+import { scaleUtc, scaleLinear, scaleLog, scaleBand, ScaleInput, coerceNumber }
+  from '@visx/scale';
 import { Axis, Orientation, SharedAxisProps, AxisScale } from '@visx/axis';
 import { GridRows, GridColumns } from '@visx/grid';
 import { AnimatedAxis, AnimatedGridRows, AnimatedGridColumns } from '@visx/react-spring';


### PR DESCRIPTION
#### :memo: Documentation

Hello, I noticed today, that in the [code listing for the axis example](https://airbnb.io/visx/axis) the last part of the line gets cut off.

![airbnb io_visx_barstack](https://github.com/user-attachments/assets/0130e504-d67e-4ba2-b069-e703c8b721d4)

This minute change should prevent that.

Cheers