### PR TITLE
Fix for stacked bars with a mix of strings and numbers in the x-axis

### DIFF
--- a/packages/visx-xychart/src/utils/combineBarStackData.ts
+++ b/packages/visx-xychart/src/utils/combineBarStackData.ts
@@ -20,9 +20,7 @@ export default function combineBarStackData<
   seriesChildren: React.ReactElement<SeriesProps<XScale, YScale, Datum>>[],
   horizontal?: boolean,
 ): CombinedStackData<XScale, YScale>[] {
-  const dataByStackValue: {
-    [stackValue: string]: CombinedStackData<XScale, YScale>;
-  } = {};
+  const dataByStackValue = new Map<string, CombinedStackData<XScale, YScale>>();
 
   seriesChildren.forEach((child) => {
     const { dataKey, data, xAccessor, yAccessor } = child.props;
@@ -36,11 +34,16 @@ export default function combineBarStackData<
       const stack = stackFn(d);
       const numericValue = valueFn(d);
       const stackKey = String(stack);
-      if (!dataByStackValue[stackKey]) {
-        dataByStackValue[stackKey] = { stack, positiveSum: 0, negativeSum: 0 };
+      if (!dataByStackValue.has(stackKey)) {
+        dataByStackValue.set(stackKey, {
+          stack,
+          positiveSum: 0,
+          negativeSum: 0,
+        });
       }
-      dataByStackValue[stackKey][dataKey] = numericValue;
-      dataByStackValue[stackKey][numericValue >= 0 ? 'positiveSum' : 'negativeSum'] += numericValue;
+      const stackEntry = dataByStackValue.get(stackKey)!;
+      stackEntry[dataKey] = numericValue;
+      stackEntry[numericValue >= 0 ? 'positiveSum' : 'negativeSum'] += numericValue;
     });
   });
 

--- a/packages/visx-xychart/src/utils/combineBarStackData.ts
+++ b/packages/visx-xychart/src/utils/combineBarStackData.ts
@@ -47,5 +47,5 @@ export default function combineBarStackData<
     });
   });
 
-  return Object.values(dataByStackValue);
+  return Array.from(dataByStackValue.values());
 }


### PR DESCRIPTION
#### :bug: Bug Fix
## issue
If stacked bars have a mix of string and number values in the x-axis, the order breaks the stacked bars. This makes it look like the data is correct but the values in the data do not match the values shown in the chart.

## example
https://codesandbox.io/p/sandbox/vibrant-joana-hht45t
in the example above if you look at L2 Males the tooltips show 10 but the value should really be 30 (ie its showing the values for L2, not 1)

## solution
The issue was in `visx/xycharts/lib/utils/combineBarStackData` the order was being lost due to an object being used to hold `dataByStackValue`. Objects do not follow a consistent ordering. If we change this to use a Map we are [guaranteed to have the keys  be iterated in order of insertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_and_maps_compared) 

## fix
use a Map rather than an object to store the data, this preserves the order of the data and prevents issues when the x columns are a mix of numbers and strings