### PR TITLE
perf(demo): lazy render example tiles

### DIFF
--- a/packages/visx-demo/src/components/GalleryTile.tsx
+++ b/packages/visx-demo/src/components/GalleryTile.tsx
@@ -30,23 +30,24 @@ function useEverVisible() {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          // ever visible
           setIsVisible((visible) => visible || entry.isIntersecting);
         });
       },
       {
         root: null, // viewport is the root
-        threshold: 0.05, // 10% visibility threshold
+        threshold: 0.01,
       },
     );
 
+    let curr;
     if (ref.current) {
+      curr = ref.current;
       observer.observe(ref.current);
     }
 
     return () => {
-      if (ref.current) {
-        observer.unobserve(ref.current);
+      if (curr) {
+        observer.unobserve(curr);
       }
     };
   }, [ref]);

--- a/packages/visx-demo/src/components/GalleryTile.tsx
+++ b/packages/visx-demo/src/components/GalleryTile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
 import { WidthAndHeight } from '../types';

--- a/packages/visx-demo/src/components/GalleryTile.tsx
+++ b/packages/visx-demo/src/components/GalleryTile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
 import { WidthAndHeight } from '../types';
@@ -50,7 +50,7 @@ function useEverVisible() {
         observer.unobserve(curr);
       }
     };
-  }, [ref]);
+  }, []);
 
   return { everVisible, ref };
 }

--- a/packages/visx-demo/src/components/GalleryTile.tsx
+++ b/packages/visx-demo/src/components/GalleryTile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import ParentSize from '@visx/responsive/lib/components/ParentSize';
 import { WidthAndHeight } from '../types';
@@ -18,6 +18,42 @@ type Props<ExampleProps extends WidthAndHeight> = {
 const renderLinkWrapper = (url: string | undefined, node: React.ReactNode) =>
   url ? <Link href={url}>{node}</Link> : node;
 
+/**
+ * hook which returns if the ref was ever visible.
+ * used for better perf/not rendering all tiles on load.
+ */
+function useEverVisible() {
+  const ref = useRef();
+  const [everVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          // ever visible
+          setIsVisible((visible) => visible || entry.isIntersecting);
+        });
+      },
+      {
+        root: null, // viewport is the root
+        threshold: 0.05, // 10% visibility threshold
+      },
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, [ref]);
+
+  return { everVisible, ref };
+}
+
 export default function GalleryTile<ExampleProps extends WidthAndHeight>({
   description,
   detailsHeight = 76,
@@ -28,21 +64,24 @@ export default function GalleryTile<ExampleProps extends WidthAndHeight>({
   tileStyles,
   title,
 }: Props<ExampleProps>) {
+  const { everVisible, ref } = useEverVisible();
   return (
     <>
       {renderLinkWrapper(
         exampleUrl,
-        <div className="gallery-tile" style={tileStyles}>
+        <div ref={ref} className="gallery-tile" style={tileStyles}>
           <div className="image">
-            <ParentSize>
-              {({ width, height }) =>
-                React.createElement(exampleRenderer, {
-                  width,
-                  height: height + (title || description ? detailsHeight : 0),
-                  ...exampleProps,
-                } as ExampleProps)
-              }
-            </ParentSize>
+            {everVisible && (
+              <ParentSize>
+                {({ width, height }) =>
+                  React.createElement(exampleRenderer, {
+                    width,
+                    height: height + (title || description ? detailsHeight : 0),
+                    ...exampleProps,
+                  } as ExampleProps)
+                }
+              </ParentSize>
+            )}
           </div>
           {(title || description) && (
             <div className="details" style={detailsStyles}>

--- a/packages/visx-demo/src/components/GalleryTile.tsx
+++ b/packages/visx-demo/src/components/GalleryTile.tsx
@@ -48,6 +48,7 @@ function useEverVisible() {
     return () => {
       if (curr) {
         observer.unobserve(curr);
+        observer.disconnect();
       }
     };
   }, []);
@@ -72,6 +73,7 @@ export default function GalleryTile<ExampleProps extends WidthAndHeight>({
         exampleUrl,
         <div ref={ref} className="gallery-tile" style={tileStyles}>
           <div className="image">
+            {/** lazy render */}
             {everVisible && (
               <ParentSize>
                 {({ width, height }) =>


### PR DESCRIPTION
#### :rocket: Enhancements

Improve the performance of the initial gallery page load by lazy rendering visible tiles

| Before | After | 
| -- | -- |
| ![slower](https://github.com/user-attachments/assets/084f81b0-3435-4467-9c57-97f83a958921)  | ![faster](https://github.com/user-attachments/assets/2381ea2e-3e90-4b37-9891-e4f8b7987f6d)  |


