### PR TITLE
Attempt to fix API docs in #1894

### DIFF
--- a/packages/visx-annotation/src/components/Annotation.tsx
+++ b/packages/visx-annotation/src/components/Annotation.tsx
@@ -7,7 +7,8 @@ export type AnnotationProps = Pick<AnnotationContextType, 'x' | 'y' | 'dx' | 'dy
   children: React.ReactNode;
 };
 
-export default function Annotation({ x, y, dx, dy, children }: AnnotationProps) {
+export default Annotation;
+function Annotation({ x, y, dx, dy, children }: AnnotationProps) {
   const value = useMemo(() => ({ x, y, dx, dy }), [x, y, dx, dy]);
   return <AnnotationContext.Provider value={value}>{children}</AnnotationContext.Provider>;
 }

--- a/packages/visx-annotation/src/components/CircleSubject.tsx
+++ b/packages/visx-annotation/src/components/CircleSubject.tsx
@@ -12,7 +12,8 @@ export type CircleSubjectProps = Pick<AnnotationContextType, 'x' | 'y'> & {
   radius?: number;
 };
 
-export default function CircleSubject({
+export default CircleSubject;
+function CircleSubject({
   className,
   x: propsX,
   y: propsY,

--- a/packages/visx-annotation/src/components/Connector.tsx
+++ b/packages/visx-annotation/src/components/Connector.tsx
@@ -17,7 +17,8 @@ export type ConnectorProps = Pick<AnnotationContextType, 'x' | 'y' | 'dx' | 'dy'
   pathProps?: React.SVGProps<SVGPathElement>;
 };
 
-export default function Connector({
+export default Connector;
+function Connector({
   className,
   x: propsX,
   y: propsY,

--- a/packages/visx-annotation/src/components/EditableAnnotation.tsx
+++ b/packages/visx-annotation/src/components/EditableAnnotation.tsx
@@ -44,7 +44,8 @@ const defaultDragHandleProps = {
   strokeWidth: 2,
 };
 
-export default function EditableAnnotation({
+export default EditableAnnotation;
+function EditableAnnotation({
   canEditLabel = true,
   canEditSubject = true,
   children,

--- a/packages/visx-annotation/src/components/HtmlLabel.tsx
+++ b/packages/visx-annotation/src/components/HtmlLabel.tsx
@@ -24,7 +24,8 @@ export type HtmlLabelProps = Pick<
   /** Optional styles to apply to the HTML container. */
   containerStyle?: React.CSSProperties;
 };
-export default function HtmlLabel({
+export default HtmlLabel;
+function HtmlLabel({
   anchorLineStroke = '#222',
   children,
   className,

--- a/packages/visx-annotation/src/components/Label.tsx
+++ b/packages/visx-annotation/src/components/Label.tsx
@@ -69,7 +69,8 @@ function getCompletePadding(padding: LabelProps['backgroundPadding']) {
   return { ...DEFAULT_PADDING, ...padding };
 }
 
-export default function Label({
+export default Label;
+function Label({
   anchorLineStroke = '#222',
   backgroundFill = '#eaeaea',
   backgroundPadding,

--- a/packages/visx-annotation/src/components/LabelAnchorLine.tsx
+++ b/packages/visx-annotation/src/components/LabelAnchorLine.tsx
@@ -10,7 +10,8 @@ interface AnchorLineProps {
   height: number;
 }
 
-export default function AnchorLine({
+export default AnchorLine;
+function AnchorLine({
   anchorLineOrientation,
   anchorLineStroke,
   verticalAnchor,

--- a/packages/visx-annotation/src/components/LineSubject.tsx
+++ b/packages/visx-annotation/src/components/LineSubject.tsx
@@ -21,7 +21,8 @@ export type LineSubjectProps = {
   max: number;
 };
 
-export default function LineSubject({
+export default LineSubject;
+function LineSubject({
   className,
   x: propsX,
   y: propsY,

--- a/packages/visx-demo/next.config.js
+++ b/packages/visx-demo/next.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 const path = require('path');
+const ReactDocgenTypescriptPlugin = require('react-docgen-typescript-plugin').default;
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -22,27 +23,33 @@ const nextConfig = {
     const babelConfig = config.module.rules[1];
     babelConfig.include.push(/visx-.*\/src/);
 
-    config.module.rules.push({
-      test: /\.tsx?$/,
-      use: [
-        {
-          loader: 'react-docgen-typescript-loader',
-          options: {
-            // display types from outside a component's source even tho
-            // we hide these with the propFilter below, if we don't do
-            // this the component's own props become `any`
-            tsconfigPath: path.resolve(__dirname, './tsconfig.json'),
-            // filter props like React.HTMLProps/React.SVGProps
-            propFilter(prop) {
-              if (prop.parent) {
-                return !prop.parent.fileName.includes('node_modules');
-              }
-              return true;
-            },
-          },
-        },
-      ],
-    });
+    config.plugins.push(
+      new ReactDocgenTypescriptPlugin({
+        tsconfigPath: path.resolve(__dirname, './tsconfig.json'),
+      }),
+    );
+
+    // config.module.rules.push({
+    //   test: /\.tsx?$/,
+    //   use: [
+    //     {
+    //       loader: 'react-docgen-typescript-loader',
+    //       options: {
+    //         // display types from outside a component's source even tho
+    //         // we hide these with the propFilter below, if we don't do
+    //         // this the component's own props become `any`
+    //         tsconfigPath: path.resolve(__dirname, './tsconfig.json'),
+    //         // filter props like React.HTMLProps/React.SVGProps
+    //         propFilter(prop) {
+    //           if (prop.parent) {
+    //             return !prop.parent.fileName.includes('node_modules');
+    //           }
+    //           return true;
+    //         },
+    //       },
+    //     },
+    //   ],
+    // });
 
     return config;
   },

--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_OPTIONS=--openssl-legacy-provider next build && NODE_OPTIONS=--openssl-legacy-provider next export",
     "deploy": "rm -rf out && yarn build && cd out && touch .nojekyll && git init && git add . && git commit -m \"Deploy commit\" && git remote add origin git@github.com:airbnb/visx.git && git push -f origin master:gh-pages",
-    "dev": "NODE_OPTIONS=--openssl-legacy-provider next",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider NEXT_PRIVATE_LOCAL_WEBPACK=1 next",
     "happo": "happo",
     "happo-ci-github-actions": "NODE_OPTIONS=--openssl-legacy-provider happo-ci-github-actions",
     "preview": "yarn build && cd ./out && npx serve",
@@ -86,13 +86,14 @@
     "prismjs": "^1.19.0",
     "raw-loader": "^4.0.0",
     "react": "^19.0.0",
-    "react-docgen-typescript-loader": "3.7.2",
+    "react-docgen-typescript-plugin": "^1.0.8",
     "react-dom": "^19.0.0",
     "react-github-button": "^0.1.10",
     "react-markdown": "^4.3.1",
     "react-tilt": "^0.1.4",
     "recompose": "^0.26.0",
-    "topojson-client": "^3.0.0"
+    "topojson-client": "^3.0.0",
+    "webpack": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/visx-demo/src/components/ApiTable.tsx
+++ b/packages/visx-demo/src/components/ApiTable.tsx
@@ -10,7 +10,8 @@ type Props = {
 const alphaSort = (a: PropInfo, b: PropInfo) => a.name.localeCompare(b.name);
 
 /** Renders a list of props for the passed docgenInfo */
-export default function ApiTable({ docgenInfo }: Props) {
+export default ApiTable;
+function ApiTable({ docgenInfo }: Props) {
   const { displayName = '' } = docgenInfo;
   const anchorId = displayName;
 

--- a/packages/visx-demo/src/components/Codeblock.tsx
+++ b/packages/visx-demo/src/components/Codeblock.tsx
@@ -16,7 +16,8 @@ function Lines({ lines }: { lines: number[] }) {
   );
 }
 
-export default function ({ children }: { children: string }) {
+export default ;
+function ({ children }: { children: string }) {
   const match = children.match(/\n(?!$)/g);
   const linesNum = match ? match.length + 1 : 1;
   const lines: number[] = new Array(linesNum + 1).fill(1);

--- a/packages/visx-demo/src/components/DocPage.tsx
+++ b/packages/visx-demo/src/components/DocPage.tsx
@@ -15,7 +15,8 @@ type Props = {
   readme: string;
 };
 
-export default function DocPage({ components, examples, visxPackage, readme }: Props) {
+export default DocPage;
+function DocPage({ components, examples, visxPackage, readme }: Props) {
   return (
     <Page wrapper={false} title={`@visx/${visxPackage} documentation`}>
       <div className="doc-container">

--- a/packages/visx-demo/src/components/Gallery/AnnotationTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/AnnotationTile.tsx
@@ -15,7 +15,8 @@ const exampleProps = { compact: true };
 const exampleRenderer: React.FC<AnnotationProps> = (props) =>
   props.width > 0 && props.height > 0 ? <Annotation {...props} /> : null;
 
-export default function AnnotationTile() {
+export default AnnotationTile;
+function AnnotationTile() {
   return (
     <GalleryTile<AnnotationProps>
       title="Annotation"

--- a/packages/visx-demo/src/components/Gallery/AreaTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/AreaTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-area/package.json';
 const tileStyles = { background };
 const detailsStyles = { color: accentColor };
 
-export default function AreaTile() {
+export default AreaTile;
+function AreaTile() {
   return (
     <GalleryTile<AreaProps>
       title="AreaClosed"

--- a/packages/visx-demo/src/components/Gallery/AxisTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/AxisTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { backgroundColor };
 const detailsStyles = { color: labelColor };
 const exampleProps = { showControls: false };
 
-export default function AxisTile() {
+export default AxisTile;
+function AxisTile() {
   return (
     <GalleryTile<AxisProps>
       title="Axes & scales"

--- a/packages/visx-demo/src/components/Gallery/BarGroupHorizontalTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/BarGroupHorizontalTile.tsx
@@ -12,7 +12,8 @@ const tileStyles = { background };
 const detailsStyles = { color: green };
 const exampleProps = { margin: { top: 20, bottom: 70, left: 50, right: 20 } };
 
-export default function BarGroupHorizontalTile() {
+export default BarGroupHorizontalTile;
+function BarGroupHorizontalTile() {
   return (
     <GalleryTile<BarGroupHorizontalProps>
       title="Bar Group Horizontal"

--- a/packages/visx-demo/src/components/Gallery/BarGroupTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/BarGroupTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-bargroup/package.js
 const tileStyles = { background };
 const detailsStyles = { color: green };
 
-export default function BarGroupTile() {
+export default BarGroupTile;
+function BarGroupTile() {
   return (
     <GalleryTile<BarGroupProps>
       title="Bar Group"

--- a/packages/visx-demo/src/components/Gallery/BarStackHorizontalTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/BarStackHorizontalTile.tsx
@@ -11,7 +11,8 @@ export { default as packageJson } from '../../sandboxes/visx-barstack-horizontal
 const tileStyles = { background };
 const detailsStyles = { color: purple3, zIndex: 1 };
 
-export default function BarStackHorizontalTile() {
+export default BarStackHorizontalTile;
+function BarStackHorizontalTile() {
   return (
     <GalleryTile<BarStackHorizontalProps>
       title="Bar Stack Horizontal"

--- a/packages/visx-demo/src/components/Gallery/BarStackTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/BarStackTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-barstack/package.js
 const tileStyles = { background };
 const detailsStyles = { color: purple3, zIndex: 1 };
 
-export default function BarStackTile() {
+export default BarStackTile;
+function BarStackTile() {
   return (
     <GalleryTile<BarStackProps>
       title="Bar Stack"

--- a/packages/visx-demo/src/components/Gallery/BarsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/BarsTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-bars/package.json';
 const tileStyles = { background: '#5290e7' };
 const detailsStyles = { color: 'rgba(25, 231, 217, 1)' };
 
-export default function BarsTile() {
+export default BarsTile;
+function BarsTile() {
   return (
     <GalleryTile<BarsProps>
       title="Bars"

--- a/packages/visx-demo/src/components/Gallery/BrushTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/BrushTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { border: `1px solid ${accentColor}` };
 const detailsStyles = { color: background };
 const exampleProps = { compact: true, margin: { top: 10, left: 50, bottom: 60, right: 20 } };
 
-export default function BrushTile() {
+export default BrushTile;
+function BrushTile() {
   return (
     <GalleryTile<BrushProps>
       title="Brush"

--- a/packages/visx-demo/src/components/Gallery/ChordTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/ChordTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-chord/package.json'
 const tileStyles = { background: '#e4e3d8' };
 const detailsStyles = { color: '#111' };
 
-export default function ChordTile() {
+export default ChordTile;
+function ChordTile() {
   return (
     <GalleryTile<ChordProps>
       title="Chord"

--- a/packages/visx-demo/src/components/Gallery/CurvesTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/CurvesTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { border: '1px solid lightgray' };
 const detailsStyles = { color: '#222' };
 const exampleProps = { showControls: false };
 
-export default function CurvesTile() {
+export default CurvesTile;
+function CurvesTile() {
   return (
     <GalleryTile<CurveProps>
       title="Curves"

--- a/packages/visx-demo/src/components/Gallery/DelaunayTriangulationTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DelaunayTriangulationTile.tsx
@@ -12,7 +12,8 @@ const tileStyles = {
 };
 const detailsStyles = { background: 'white', color: '#5B247A', borderRadius: '0 0 14px 14px' };
 
-export default function DelaunayTriangulationTile() {
+export default DelaunayTriangulationTile;
+function DelaunayTriangulationTile() {
   return (
     <GalleryTile<DelaunayTriangulationProps>
       title="Delaunay Triangulation"

--- a/packages/visx-demo/src/components/Gallery/DelaunayVoronoiTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DelaunayVoronoiTile.tsx
@@ -12,7 +12,8 @@ const tileStyles = {
 };
 const detailsStyles = { background: 'white', color: '#eb6d88', borderRadius: '0 0 14px 14px' };
 
-export default function DelaunayTile() {
+export default DelaunayTile;
+function DelaunayTile() {
   return (
     <GalleryTile<VoronoiProps>
       title="Voronoi Overlay"

--- a/packages/visx-demo/src/components/Gallery/DendrogramsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DendrogramsTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: green };
 const exampleProps = { margin: { top: 40, left: 0, right: 0, bottom: 90 } };
 
-export default function DendrogramsTile() {
+export default DendrogramsTile;
+function DendrogramsTile() {
   return (
     <GalleryTile<DendrogramProps>
       title="Dendrograms"

--- a/packages/visx-demo/src/components/Gallery/DotsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DotsTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background: '#fd6e7f' };
 const detailsStyles = { color: '#f6c431' };
 const exampleProps = { showControls: false };
 
-export default function DotsTile() {
+export default DotsTile;
+function DotsTile() {
   return (
     <GalleryTile<DotsProps>
       title="Dots"

--- a/packages/visx-demo/src/components/Gallery/DragIITile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DragIITile.tsx
@@ -10,7 +10,8 @@ const tileStyles = { background: '#04002b', borderRadius: 14 };
 const detailsStyles = { color: '#ff614e', zIndex: 1 };
 const exampleProps = { data: drawData };
 
-export default function DragIITile() {
+export default DragIITile;
+function DragIITile() {
   return (
     <GalleryTile<DragIIProps>
       title="Drag ii"

--- a/packages/visx-demo/src/components/Gallery/DragITile.tsx
+++ b/packages/visx-demo/src/components/Gallery/DragITile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-drag-i/package.json
 const tileStyles = { background: '#c4c3cb', borderRadius: 14 };
 const detailsStyles = { color: '#6437d6', zIndex: 1 };
 
-export default function DragITile() {
+export default DragITile;
+function DragITile() {
   return (
     <GalleryTile<DragIProps>
       title="Drag i"

--- a/packages/visx-demo/src/components/Gallery/GeoAlbersUsaTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/GeoAlbersUsaTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-geo-albers-usa/pack
 const tileStyles = { background };
 const detailsStyles = { color: colors[1] };
 
-export default function GeoAlbersUsaTile() {
+export default GeoAlbersUsaTile;
+function GeoAlbersUsaTile() {
   return (
     <GalleryTile<GeoAlbersUsaProps>
       title="AlbersUsa"

--- a/packages/visx-demo/src/components/Gallery/GeoCustomTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/GeoCustomTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: '#019ece' };
 const exampleProps = { events: false };
 
-export default function GeoCustomTile() {
+export default GeoCustomTile;
+function GeoCustomTile() {
   return (
     <GalleryTile<GeoCustomProps>
       title="Custom Projection"

--- a/packages/visx-demo/src/components/Gallery/GeoMercatorTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/GeoMercatorTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-geo-mercator/packag
 const tileStyles = { background };
 const detailsStyles = { color: '#f63a48' };
 
-export default function GeoMercatorTile() {
+export default GeoMercatorTile;
+function GeoMercatorTile() {
   return (
     <GalleryTile<GeoMercatorProps>
       title="Mercator"

--- a/packages/visx-demo/src/components/Gallery/GlyphsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/GlyphsTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background: secondaryColor };
 const detailsStyles = { color: primaryColor };
 const exampleProps = { margin: { top: 30, left: 10, right: 10, bottom: 80 } };
 
-export default function GlyphsTile() {
+export default GlyphsTile;
+function GlyphsTile() {
   return (
     <GalleryTile<GlyphProps>
       title="Glyphs"

--- a/packages/visx-demo/src/components/Gallery/GradientsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/GradientsTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-gradient/package.js
 const tileStyles = { background: 'white', boxShadow: '0 1px 6px rgba(0,0,0,0.1)' };
 const detailsStyles = { color: '#333' };
 
-export default function GradientsTile() {
+export default GradientsTile;
+function GradientsTile() {
   return (
     <GalleryTile<GradientProps>
       title="Gradients"

--- a/packages/visx-demo/src/components/Gallery/HeatmapsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/HeatmapsTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-heatmap/package.jso
 const tileStyles = { background };
 const detailsStyles = { color: 'rgba(255,255,255,0.3)' };
 
-export default function HeatmapsTile() {
+export default HeatmapsTile;
+function HeatmapsTile() {
   return (
     <GalleryTile<HeatmapProps>
       title="Heatmaps"

--- a/packages/visx-demo/src/components/Gallery/LegendsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/LegendsTile.tsx
@@ -7,7 +7,8 @@ export { default as packageJson } from '../../sandboxes/visx-legend/package.json
 const tileStyles = { background: 'black' };
 const detailsStyles = { color: '#aaa' };
 
-export default function LegendsTile() {
+export default LegendsTile;
+function LegendsTile() {
   return (
     <GalleryTile<any>
       title="Legends"

--- a/packages/visx-demo/src/components/Gallery/LineRadialTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/LineRadialTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: blue };
 const exampleProps = { animate: false };
 
-export default function LineRadialTile() {
+export default LineRadialTile;
+function LineRadialTile() {
   return (
     <GalleryTile<LineRadialProps>
       title="Radial Lines"

--- a/packages/visx-demo/src/components/Gallery/LinkTypesTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/LinkTypesTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-linktypes/package.j
 const tileStyles = { background: '#272b4d' };
 const detailsStyles = { color: '#269688' };
 
-export default function LinkTypesTile() {
+export default LinkTypesTile;
+function LinkTypesTile() {
   return (
     <GalleryTile<LinkTypesProps>
       title="Link Types"

--- a/packages/visx-demo/src/components/Gallery/NetworkTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/NetworkTile.tsx
@@ -7,7 +7,8 @@ export { default as packageJson } from '../../sandboxes/visx-network/package.jso
 
 const tileStyles = { background };
 
-export default function NetworkTile() {
+export default NetworkTile;
+function NetworkTile() {
   return (
     <GalleryTile<NetworkProps>
       title="Network"

--- a/packages/visx-demo/src/components/Gallery/PackTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/PackTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-pack/package.json';
 const tileStyles = { background: 'white', boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px' };
 const detailsStyles = { color: '#fd6c6f' };
 
-export default function PackTile() {
+export default PackTile;
+function PackTile() {
   return (
     <GalleryTile<PackProps>
       title="Pack"

--- a/packages/visx-demo/src/components/Gallery/PatternsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/PatternsTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-pattern/package.jso
 const tileStyles = { background: '#f5f2e3' };
 const detailsStyles = { color: '#333' };
 
-export default function PatternsTile() {
+export default PatternsTile;
+function PatternsTile() {
   return (
     <GalleryTile<PatternProps>
       title="Patterns"

--- a/packages/visx-demo/src/components/Gallery/PiesTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/PiesTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background: '#7f82e3' };
 const detailsStyles = { color: 'rgb(93,30,91)' };
 const exampleProps = { animate: false, margin: { top: 20, right: 20, bottom: 80, left: 20 } };
 
-export default function PiesTile() {
+export default PiesTile;
+function PiesTile() {
   return (
     <GalleryTile<PieProps>
       title="Pies & donuts"

--- a/packages/visx-demo/src/components/Gallery/PolygonsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/PolygonsTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: 'white' };
 const exampleProps = { margin: { top: 10, right: 0, bottom: 76, left: 0 } };
 
-export default function PolygonsTile() {
+export default PolygonsTile;
+function PolygonsTile() {
   return (
     <GalleryTile<PolygonProps>
       title="Polygons"

--- a/packages/visx-demo/src/components/Gallery/RadarTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/RadarTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-radar/package.json'
 const tileStyles = { background };
 const detailsStyles = { color: pumpkin };
 
-export default function RadarTile() {
+export default RadarTile;
+function RadarTile() {
   return (
     <GalleryTile<RadarProps>
       title="Radar"

--- a/packages/visx-demo/src/components/Gallery/RadialBarsTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/RadialBarsTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background: '#3dbdb1' };
 const detailsStyles = { color: '#93F9B9' };
 const exampleProps = { showControls: false };
 
-export default function BarsTile() {
+export default BarsTile;
+function BarsTile() {
   return (
     <GalleryTile<RadialBarsProps>
       title="Radial Bars"

--- a/packages/visx-demo/src/components/Gallery/ResponsiveTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/ResponsiveTile.tsx
@@ -15,7 +15,8 @@ const detailsStyles = {
   borderBottomRightRadius: '14px',
 };
 
-export default function ResponsiveTile() {
+export default ResponsiveTile;
+function ResponsiveTile() {
   return (
     <GalleryTile<ResponsiveProps>
       title="Responsive"

--- a/packages/visx-demo/src/components/Gallery/SankeyTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/SankeyTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color };
 const exampleProps = { showControls: false };
 
-export default function SankeyTile() {
+export default SankeyTile;
+function SankeyTile() {
   return (
     <GalleryTile<SankeyDemoProps>
       title="Sankey"

--- a/packages/visx-demo/src/components/Gallery/SplitLinePathTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/SplitLinePathTile.tsx
@@ -10,7 +10,8 @@ export { default as packageJson } from '../../sandboxes/visx-shape-splitlinepath
 const tileStyles = { background: backgroundLight };
 const detailsStyles = { color: 'white' };
 
-export default function SplitLinePathTile() {
+export default SplitLinePathTile;
+function SplitLinePathTile() {
   return (
     <GalleryTile<SplitLinePathExampleProps>
       title="SplitLinePath"

--- a/packages/visx-demo/src/components/Gallery/StackedAreasTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/StackedAreasTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-stacked-areas/packa
 const tileStyles = { background };
 const detailsStyles = { color: 'rgba(251, 224, 137, 1.000)' };
 
-export default function StackedAreasTile() {
+export default StackedAreasTile;
+function StackedAreasTile() {
   return (
     <GalleryTile<StackedAreasProps>
       title="Stacked Areas"

--- a/packages/visx-demo/src/components/Gallery/StatsPlotTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/StatsPlotTile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-stats/package.json'
 const tileStyles = { background: '#8a88e3' };
 const detailsStyles = { color: '#ffffff', zIndex: 1 };
 
-export default function StatsPlotTile() {
+export default StatsPlotTile;
+function StatsPlotTile() {
   return (
     <GalleryTile<StatsPlotProps>
       title="Stats Plots"

--- a/packages/visx-demo/src/components/Gallery/StreamGraphTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/StreamGraphTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: 'rgb(93,30,91)' };
 const exampleProps = { animate: false };
 
-export default function StreamGraphTile() {
+export default StreamGraphTile;
+function StreamGraphTile() {
   return (
     <GalleryTile<StreamGraphProps>
       title="Streamgraph"

--- a/packages/visx-demo/src/components/Gallery/TextTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/TextTile.tsx
@@ -29,7 +29,8 @@ function Text() {
   );
 }
 
-export default function TextTile() {
+export default TextTile;
+function TextTile() {
   return (
     <GalleryTile<any>
       title="Text"

--- a/packages/visx-demo/src/components/Gallery/ThresholdTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/ThresholdTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: '#111' };
 const exampleProps = { margin: { top: 40, left: 40, right: 20, bottom: 30 } };
 
-export default function ThresholdTile() {
+export default ThresholdTile;
+function ThresholdTile() {
   return (
     <GalleryTile<ThresholdProps>
       title="Area difference chart"

--- a/packages/visx-demo/src/components/Gallery/TooltipTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/TooltipTile.tsx
@@ -11,7 +11,8 @@ const detailsStyles = {
   color: 'rgba(53,71,125,1)',
 };
 
-export default function DotsTile() {
+export default DotsTile;
+function DotsTile() {
   return (
     <GalleryTile<TooltipProps>
       title="Tooltip"

--- a/packages/visx-demo/src/components/Gallery/TreemapTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/TreemapTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: color1 };
 const exampleProps = { margin: { top: 0, left: 10, right: 10, bottom: 76 } };
 
-export default function TreemapTile() {
+export default TreemapTile;
+function TreemapTile() {
   return (
     <GalleryTile<TreemapProps>
       title="Treemap"

--- a/packages/visx-demo/src/components/Gallery/TreesTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/TreesTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background };
 const detailsStyles = { color: '#269688' };
 const exampleProps = { margin: { top: 10, left: 30, right: 40, bottom: 76 } };
 
-export default function TreesTile() {
+export default TreesTile;
+function TreesTile() {
   return (
     <GalleryTile<TreeProps>
       title="Trees"

--- a/packages/visx-demo/src/components/Gallery/VoronoiTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/VoronoiTile.tsx
@@ -12,7 +12,8 @@ const tileStyles = {
 };
 const detailsStyles = { background: 'white', color: '#eb6d88', borderRadius: '0 0 14px 14px' };
 
-export default function VoronoiTile() {
+export default VoronoiTile;
+function VoronoiTile() {
   return (
     <GalleryTile<VoronoiProps>
       title="Voronoi overlay"

--- a/packages/visx-demo/src/components/Gallery/WordcloudTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/WordcloudTile.tsx
@@ -9,7 +9,8 @@ const tileStyles = { background: '#e4e3d8' };
 const detailsStyles = { color: '#111' };
 const renderer = (size: WidthAndHeight) => <Wordcloud width={size.width} height={size.height} />;
 
-export default function WordcloudTile() {
+export default WordcloudTile;
+function WordcloudTile() {
   return (
     <GalleryTile
       title="Wordcloud"

--- a/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
+++ b/packages/visx-demo/src/components/Gallery/XYChartTile.tsx
@@ -12,7 +12,8 @@ export { default as packageJson } from '../../sandboxes/visx-xychart/package.jso
 
 const tileStyles = { background: '#222' };
 
-export default function XYChartITile() {
+export default XYChartITile;
+function XYChartITile() {
   return (
     <GalleryTile<XYChartProps>
       title="XYChart"

--- a/packages/visx-demo/src/components/Gallery/ZoomITile.tsx
+++ b/packages/visx-demo/src/components/Gallery/ZoomITile.tsx
@@ -8,7 +8,8 @@ export { default as packageJson } from '../../sandboxes/visx-zoom-i/package.json
 const tileStyles = { background: '#0a0a0a' };
 const detailsStyles = { color: '#ccc' };
 
-export default function ZoomITile() {
+export default ZoomITile;
+function ZoomITile() {
   return (
     <GalleryTile<ZoomIProps>
       title="Zoom"

--- a/packages/visx-demo/src/components/Gallery/index.tsx
+++ b/packages/visx-demo/src/components/Gallery/index.tsx
@@ -108,7 +108,8 @@ export const tiles = [
   WordcloudTile,
 ];
 
-export default function Gallery() {
+export default Gallery;
+function Gallery() {
   const router = useRouter();
   const { pkg: routePackage } = router.query;
 

--- a/packages/visx-demo/src/components/GalleryTile.tsx
+++ b/packages/visx-demo/src/components/GalleryTile.tsx
@@ -18,7 +18,8 @@ type Props<ExampleProps extends WidthAndHeight> = {
 const renderLinkWrapper = (url: string | undefined, node: React.ReactNode) =>
   url ? <Link href={url}>{node}</Link> : node;
 
-export default function GalleryTile<ExampleProps extends WidthAndHeight>({
+export default GalleryTile;
+function GalleryTile<ExampleProps extends WidthAndHeight>({
   description,
   detailsHeight = 76,
   detailsStyles,

--- a/packages/visx-demo/src/components/PackageList.tsx
+++ b/packages/visx-demo/src/components/PackageList.tsx
@@ -3,7 +3,8 @@ import Link from 'next/link';
 import cx from 'classnames';
 import type { VisxPackage } from '../types';
 
-export default function PackageList({
+export default PackageList;
+function PackageList({
   emphasizePackage,
   compact,
   grid,

--- a/packages/visx-demo/src/components/util/extractVisxDepsFromPackageJson.ts
+++ b/packages/visx-demo/src/components/util/extractVisxDepsFromPackageJson.ts
@@ -1,6 +1,7 @@
 import type { PackageJson } from '../../types';
 
-export default function extractVisxDepsFromPackageJson(packageJson?: PackageJson) {
+export default extractVisxDepsFromPackageJson;
+function extractVisxDepsFromPackageJson(packageJson?: PackageJson) {
   const visxDeps: string[] = [];
 
   Object.keys(packageJson?.dependencies ?? {}).forEach((dep) => {

--- a/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/Example.tsx
@@ -14,7 +14,8 @@ export type AnnotationProps = {
 export const orange = '#ff7e67';
 export const greens = ['#ecf4f3', '#68b0ab', '#006a71'];
 
-export default function Example({ width, height, compact = false }: AnnotationProps) {
+export default Example;
+function Example({ width, height, compact = false }: AnnotationProps) {
   return (
     <ExampleControls width={width} height={height} compact={compact}>
       {({

--- a/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/ExampleControls.tsx
@@ -44,7 +44,8 @@ const getStockValue = (d: AppleStock) => d.close;
 const annotateDatum = data[Math.floor(data.length / 2) + 4];
 const approxTooltipHeight = 70;
 
-export default function ExampleControls({
+export default ExampleControls;
+function ExampleControls({
   width,
   height,
   compact = false,

--- a/packages/visx-demo/src/sandboxes/visx-annotation/findNearestDatum.ts
+++ b/packages/visx-demo/src/sandboxes/visx-annotation/findNearestDatum.ts
@@ -2,7 +2,8 @@ import type { AppleStock } from '@visx/mock-data/lib/mocks/appleStock';
 import { bisector } from '@visx/vendor/d3-array';
 import type { scaleLinear, scaleTime } from '@visx/scale';
 
-export default function findNearestDatum({
+export default findNearestDatum;
+function findNearestDatum({
   value,
   scale,
   accessor,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,6 +1796,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.6.tgz#9d71ca886e32502eb9362c9a74a46787c36df81a"
+  integrity sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+
 "@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
@@ -2678,6 +2686,27 @@
   resolved "https://registry.yarnpkg.com/@types/d3-voronoi/-/d3-voronoi-1.1.9.tgz#7bbc210818a3a5c5e0bafb051420df206617c9e5"
   integrity sha512-DExNQkaHd1F3dFPvGA/Aw2NGyjMln6E9QzsiqOcBgnE+VInYnFBHBBySbZQts6z6xD+5jTfKCP7M4OqMyVjdwQ==
 
+"@types/eslint-scope@^3.7.7":
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
+  integrity sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
+"@types/eslint@*":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.1.tgz#d5795ad732ce81715f27f75da913004a56751584"
+  integrity sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*", "@types/estree@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
+  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
+
 "@types/geojson@*":
   version "7946.0.7"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
@@ -2742,6 +2771,11 @@
     "@types/node" "*"
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
+
+"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/json-schema@^7.0.4":
   version "7.0.4"
@@ -2970,17 +3004,136 @@
   dependencies:
     "@use-gesture/core" "10.3.1"
 
-"@webpack-contrib/schema-utils@^1.0.0-beta.0":
-  version "1.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
-  integrity sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==
+"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.14.1.tgz#a9f6a07f2b03c95c8d38c4536a1fdfb521ff55b6"
+  integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
   dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-    chalk "^2.3.2"
-    strip-ansi "^4.0.0"
-    text-table "^0.2.0"
-    webpack-log "^1.1.2"
+    "@webassemblyjs/helper-numbers" "1.13.2"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+
+"@webassemblyjs/floating-point-hex-parser@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz#fcca1eeddb1cc4e7b6eed4fc7956d6813b21b9fb"
+  integrity sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==
+
+"@webassemblyjs/helper-api-error@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz#e0a16152248bc38daee76dd7e21f15c5ef3ab1e7"
+  integrity sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==
+
+"@webassemblyjs/helper-buffer@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz#822a9bc603166531f7d5df84e67b5bf99b72b96b"
+  integrity sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==
+
+"@webassemblyjs/helper-numbers@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz#dbd932548e7119f4b8a7877fd5a8d20e63490b2d"
+  integrity sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.13.2"
+    "@webassemblyjs/helper-api-error" "1.13.2"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz#e556108758f448aae84c850e593ce18a0eb31e0b"
+  integrity sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==
+
+"@webassemblyjs/helper-wasm-section@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz#9629dda9c4430eab54b591053d6dc6f3ba050348"
+  integrity sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==
+  dependencies:
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-buffer" "1.14.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/wasm-gen" "1.14.1"
+
+"@webassemblyjs/ieee754@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz#1c5eaace1d606ada2c7fd7045ea9356c59ee0dba"
+  integrity sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.13.2.tgz#57c5c3deb0105d02ce25fa3fd74f4ebc9fd0bbb0"
+  integrity sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/utf8@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.13.2.tgz#917a20e93f71ad5602966c2d685ae0c6c21f60f1"
+  integrity sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==
+
+"@webassemblyjs/wasm-edit@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz#ac6689f502219b59198ddec42dcd496b1004d597"
+  integrity sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-buffer" "1.14.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/helper-wasm-section" "1.14.1"
+    "@webassemblyjs/wasm-gen" "1.14.1"
+    "@webassemblyjs/wasm-opt" "1.14.1"
+    "@webassemblyjs/wasm-parser" "1.14.1"
+    "@webassemblyjs/wast-printer" "1.14.1"
+
+"@webassemblyjs/wasm-gen@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz#991e7f0c090cb0bb62bbac882076e3d219da9570"
+  integrity sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==
+  dependencies:
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/ieee754" "1.13.2"
+    "@webassemblyjs/leb128" "1.13.2"
+    "@webassemblyjs/utf8" "1.13.2"
+
+"@webassemblyjs/wasm-opt@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz#e6f71ed7ccae46781c206017d3c14c50efa8106b"
+  integrity sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==
+  dependencies:
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-buffer" "1.14.1"
+    "@webassemblyjs/wasm-gen" "1.14.1"
+    "@webassemblyjs/wasm-parser" "1.14.1"
+
+"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz#b3e13f1893605ca78b52c68e54cf6a865f90b9fb"
+  integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-api-error" "1.13.2"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/ieee754" "1.13.2"
+    "@webassemblyjs/leb128" "1.13.2"
+    "@webassemblyjs/utf8" "1.13.2"
+
+"@webassemblyjs/wast-printer@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz#3bb3e9638a8ae5fdaf9610e7a06b4d9f9aa6fe07"
+  integrity sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==
+  dependencies:
+    "@webassemblyjs/ast" "1.14.1"
+    "@xtuc/long" "4.2.2"
+
+"@xtuc/ieee754@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
+  integrity sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
+
+"@xtuc/long@4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
+  integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -3075,7 +3228,7 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
-acorn@^8.1.0, acorn@^8.11.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.9.0:
+acorn@^8.1.0, acorn@^8.11.0, acorn@^8.14.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.8.2, acorn@^8.9.0:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
@@ -3137,10 +3290,29 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv-keywords@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 ajv@^6.1.0, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
@@ -3152,7 +3324,7 @@ ajv@^6.1.0, ajv@^6.12.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.12.4:
+ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3161,6 +3333,16 @@ ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.9.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 anser@1.4.9:
   version "1.4.9"
@@ -3183,11 +3365,6 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-regex@^5.0.0:
   version "5.0.0"
@@ -4048,7 +4225,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4164,6 +4341,11 @@ chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+chrome-trace-event@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz#05bffd7ff928465093314708c93bdfa9bd1f0f5b"
+  integrity sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -4347,7 +4529,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.15.1, commander@~2.20.3:
+commander@2, commander@^2.15.1, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4915,14 +5097,6 @@ d3-voronoi@^1.1.2:
   resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
   integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
@@ -5364,6 +5538,14 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
+enhanced-resolve@^5.17.1:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz#91eb1db193896b9801251eeff1c6980278b1e404"
+  integrity sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -5512,6 +5694,11 @@ es-get-iterator@^1.0.2:
     is-string "^1.0.5"
     isarray "^2.0.5"
 
+es-module-lexer@^1.2.1:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
+  integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
+
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
@@ -5528,28 +5715,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
-
 es5-shim@^4.5.13:
   version "4.5.14"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.14.tgz#90009e1019d0ea327447cb523deaff8fe45697ef"
   integrity sha512-7SwlpL+2JpymWTt8sNLuC2zdhhc+wrfe5cMPI2j0o6WsPdfAiPwmFy2f0AocPB4RQVBOZ9kNTgi5YF7TdhkvEg==
-
-es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
 
 es6-object-assign@^1.1.0:
   version "1.1.0"
@@ -5560,14 +5729,6 @@ es6-shim@^0.35.5:
   version "0.35.5"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.5.tgz#46f59dc0a84a1c5029e8ff1166ca0a902077a9ab"
   integrity sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg==
-
-es6-symbol@^3.1.1, es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5911,6 +6072,11 @@ events@^3.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
   integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
 
+events@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -5987,13 +6153,6 @@ exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
-
-ext@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
-  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
-  dependencies:
-    type "^2.0.0"
 
 extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
@@ -6093,6 +6252,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-uri@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.3.tgz#892a1c91802d5d7860de728f18608a0573142241"
+  integrity sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==
 
 fastparse@^1.1.2:
   version "1.1.2"
@@ -6657,7 +6821,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@4.2.11, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@4.2.11, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -8120,6 +8284,15 @@ jest-worker@27.0.0-next.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jest-worker@^27.4.5:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
+  integrity sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest-worker@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
@@ -8262,7 +8435,7 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-parse-even-better-errors@^2.3.0:
+json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
@@ -8276,6 +8449,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -8583,6 +8761,11 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+loader-runner@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
+  integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
+
 loader-utils@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
@@ -8740,13 +8923,6 @@ log-driver@^1.2.7:
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
   integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
-log-symbols@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
-  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
-  dependencies:
-    chalk "^2.0.1"
-
 log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
@@ -8754,14 +8930,6 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
-
-loglevelnext@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
-  integrity sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==
-  dependencies:
-    es6-symbol "^3.1.1"
-    object.assign "^4.1.0"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -8957,12 +9125,24 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
+
+mime-types@^2.1.27:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -9221,10 +9401,10 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 next@^11.0.0:
   version "11.1.4"
@@ -10601,7 +10781,7 @@ ramda@^0.27:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
   integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -10634,19 +10814,22 @@ raw-loader@^4.0.0:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
 
-react-docgen-typescript-loader@3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.7.2.tgz#45cb2305652c0602767242a8700ad1ebd66bbbbd"
-  integrity sha512-fNzUayyUGzSyoOl7E89VaPKJk9dpvdSgyXg81cUkwy0u+NBvkzQG3FC5WBIlXda0k/iaxS+PWi+OC+tUiGxzPA==
+react-docgen-typescript-plugin@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.8.tgz#58f039b3063c34c7cd394fe53b75e6d79feafee6"
+  integrity sha512-r+dUkpm/dmiVvvrfOTYbbg0g7bmaeXTodQFIru8ZzCx/HNUAUNSmh1C0seXzDSLqDSXm5EiOAiJZVs4gqAZqzA==
   dependencies:
-    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
-    loader-utils "^1.2.3"
-    react-docgen-typescript "^1.15.0"
+    debug "^4.1.1"
+    find-cache-dir "^3.3.1"
+    flat-cache "^3.0.4"
+    micromatch "^4.0.2"
+    react-docgen-typescript "^2.2.2"
+    tslib "^2.6.2"
 
-react-docgen-typescript@^1.15.0:
-  version "1.16.5"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.16.5.tgz#b305563425ab370f5a3c82b42579eb5069449b87"
-  integrity sha512-guXnx6a554IDVUoVIkX/BGRTrwc2n2w/kMxo7TKLNLJW1qszhT6BRHX4qV8eWq5eaJxRxuesOW5AOLiOI9WQOA==
+react-docgen-typescript@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
+  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
 
 react-dom@18.0.0, "react-dom@^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0", react-dom@^19.0.0:
   version "18.0.0"
@@ -11098,6 +11281,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-relative@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
@@ -11318,6 +11506,25 @@ schema-utils@^2.6.5:
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
 
+schema-utils@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
+schema-utils@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.0.tgz#3b669f04f71ff2dfb5aba7ce2d5a9d79b35622c0"
+  integrity sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
 select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
@@ -11361,6 +11568,13 @@ semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
+serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
+  dependencies:
+    randombytes "^2.1.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -11524,6 +11738,14 @@ source-map-support@^0.5.9:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -11705,16 +11927,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11894,7 +12107,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11914,20 +12127,6 @@ strip-ansi@^3.0.0:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12057,6 +12256,11 @@ symbol.prototype.description@^1.0.0:
     es-abstract "^1.17.0-next.1"
     has-symbols "^1.0.1"
 
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 tar-stream@^2.1.4, tar-stream@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
@@ -12096,6 +12300,27 @@ temp-dir@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==
+
+terser-webpack-plugin@^5.3.10:
+  version "5.3.11"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz#93c21f44ca86634257cac176f884f942b7ba3832"
+  integrity sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jest-worker "^27.4.5"
+    schema-utils "^4.3.0"
+    serialize-javascript "^6.0.2"
+    terser "^5.31.1"
+
+terser@^5.31.1:
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.37.0.tgz#38aa66d1cfc43d0638fab54e43ff8a4f72a21ba3"
+  integrity sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -12327,6 +12552,11 @@ tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
+tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -12411,16 +12641,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
-  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -12702,7 +12922,7 @@ util@^0.12.0:
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
 
-uuid@^3.1.0, uuid@^3.3.2:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -12825,6 +13045,14 @@ watchpack@2.1.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+watchpack@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.2.tgz#2feeaed67412e7c33184e5a79ca738fbd38564da"
+  integrity sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -12857,16 +13085,6 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-webpack-log@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
-  integrity sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==
-  dependencies:
-    chalk "^2.1.0"
-    log-symbols "^2.1.0"
-    loglevelnext "^1.0.1"
-    uuid "^3.1.0"
-
 webpack-sources@^1.1.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -12874,6 +13092,40 @@ webpack-sources@^1.1.0:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack@^5.0.0:
+  version "5.97.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.97.1.tgz#972a8320a438b56ff0f1d94ade9e82eac155fa58"
+  integrity sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==
+  dependencies:
+    "@types/eslint-scope" "^3.7.7"
+    "@types/estree" "^1.0.6"
+    "@webassemblyjs/ast" "^1.14.1"
+    "@webassemblyjs/wasm-edit" "^1.14.1"
+    "@webassemblyjs/wasm-parser" "^1.14.1"
+    acorn "^8.14.0"
+    browserslist "^4.24.0"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.17.1"
+    es-module-lexer "^1.2.1"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.11"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.2.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.3.10"
+    watchpack "^2.4.1"
+    webpack-sources "^3.2.3"
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"
@@ -13011,16 +13263,7 @@ wordwrap@~0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR is not intended to be merged, I just wanted to write my discoveries down while I tried to fix the API docs not generating (see https://github.com/airbnb/visx/pull/1894#issuecomment-2558253214). 

What I did:
- I could not figure out why `react-docgen-typescript-loader` just did not do anything, and I could for some reason also not set any breakpoints in Next.js 13, so...
- I've replaced `react-docgen-typescript-loader` (archived, last publish 5y ago) with `react-docgen-typescript-plugin` (not archived, last publish 6 months ago). Looking at the repo it also doesn't really look maintained, so this is probably not the long-term solution anyway, but I just wanted to get the docs to work...
- I had to add `webpack` as a dependency, because `react-docgen-typescript-plugin` tries to load some files that are not available in the precompiled version distributed by next
- webpack now spams the console with hundreds of `No serializer registered for DocGenDependency`, maybe because I had to install webpack and the plugin registered the serializer in the local webpack, not the Next.js bundled webpack. (There supposedly is a `NEXT_PRIVATE_LOCAL_WEBPACK` env that should make Next.js use the local webpack, but it didn't work for me, and also isn't available in newer Next.js versions)
- `react-docgen-typescript-plugin` now actually did something, it generated invalid code `default.__docgenInfo = ` which caused Next.js to throw `SyntaxError: Unexpected token 'default'`. Somehow the plugin can't figure out component names from `export default function X()` (there is a somewhat related open issue https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/57)
- So I search/replaced all components (in the `visx-annotation` and `visx-demo` packages to instead use `export default X; function X()`, which allows the plugin to get the correct name.
- The `/docs/annotation` annotation page now compiled and showed docs 🎉, but
   - it shows all props, because the `propFilter` option used in the loader config doesn't seem available in the plugin
   - still spams the console with warnings
   - requires to not use direct default exports


Just wanted to write down what I discovered while testing `react-docgen-typescript-plugin`, I'm not sure if this is the best way forward...

@williaster 