### PR TITLE
Docs: Fix link

### DIFF
--- a/packages/visx-demo/src/pages/docs.tsx
+++ b/packages/visx-demo/src/pages/docs.tsx
@@ -11,7 +11,7 @@ export default function Docs() {
         <p>
           <code>visx</code> is a suite of several low-level standalone packages for building visual
           interfaces with <code>react</code>. Packages can be mixed and used together depending on
-          your use case, or you can simply add the umbrella <a href="/docs/visx">@visx/visx</a>{' '}
+          your use case, or you can simply add the umbrella <a href="/visx/docs/visx">@visx/visx</a>{' '}
           package to use them all.
           <br /> <br />
           Individual packages can be roughly categorized as follows:


### PR DESCRIPTION
There is a Link on https://airbnb.io/visx/docs which leads to the 404 page https://airbnb.io/docs/visx.
I think the right page would be https://airbnb.io/visx/docs/visx which is used now.

> <img width="584" alt="image" src="https://github.com/user-attachments/assets/9e5d33f2-2661-422e-80e2-8c0ca4aa52cd" />
