### PR TITLE
Apply margin to Brush

### DIFF
--- a/packages/visx-brush/src/Brush.tsx
+++ b/packages/visx-brush/src/Brush.tsx
@@ -207,8 +207,8 @@ class Brush extends Component<BrushProps> {
     if (brushRegion === 'chart') {
       left = 0;
       top = 0;
-      brushRegionWidth = width;
-      brushRegionHeight = height;
+      brushRegionWidth = width - margin.left - margin.right;
+      brushRegionHeight = height - margin.top - margin.bottom;
     } else if (brushRegion === 'yAxis') {
       top = 0;
       brushRegionHeight = height;


### PR DESCRIPTION
Fixes https://github.com/airbnb/visx/issues/1711

Applies margin to Brush so that it will shrink to fit inside the margins instead of ignoring them

#### :boom: Breaking Changes

- This probably is a breaking change as it will apply margins that were previously ignored.

#### :rocket: Enhancements

- Brush can use margin now

#### :memo: Documentation

- N/A

#### :bug: Bug Fix

- Fixes margin with Brush

