### PR TITLE
fix: tooltip with bounds top/left clip calculation

### DIFF
--- a/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/visx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -32,7 +32,7 @@ function TooltipWithBounds({
 
     if (parentBounds.width) {
       const rightPlacementClippedPx = left + offsetLeft + ownBounds.width - parentBounds.width;
-      const leftPlacementClippedPx = ownBounds.width - left - offsetLeft;
+      const leftPlacementClippedPx = ownBounds.width - left + offsetLeft;
       placeTooltipLeft =
         rightPlacementClippedPx > 0 && rightPlacementClippedPx > leftPlacementClippedPx;
     } else {
@@ -44,7 +44,7 @@ function TooltipWithBounds({
 
     if (parentBounds.height) {
       const bottomPlacementClippedPx = top + offsetTop + ownBounds.height - parentBounds.height;
-      const topPlacementClippedPx = ownBounds.height - top - offsetTop;
+      const topPlacementClippedPx = ownBounds.height - top + offsetTop;
       placeTooltipUp =
         bottomPlacementClippedPx > 0 && bottomPlacementClippedPx > topPlacementClippedPx;
     } else {


### PR DESCRIPTION

#### :bug: Bug Fix

The sign of these values has been wrong for a while.

If we consider the case where top is zero, the ownBounds.height is 100, and the offset is 50, then if the tooltip is placed up the final top will be

`0 - 100 - 50` = -150, or 150px out of bounds -> 150px of clipping.

However the current topPlacementClippedPx calculation is  `100 - 0 - 50` = 50px of calculated clipping. This isn't correct. Flipping the sign gives us `100 - 0 + 50` -> 150px, the correct value.

This seems unintuitive since now we are adding the offset in both the top and bottom clip calculation despite them being offset in different directions, but the key is that topPlacementClippedPx measures the magnitude of negative clipping while bottomPlacementClippedPx measures positive clipping. So we've got a double negative for the top and need to use addition in both cases.


