### PR TITLE
fix(push): Update node version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '18.20.8'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get yarn cache directory path


### PR DESCRIPTION
I missed this in https://github.com/airbnb/visx/pull/1935.

#### :house: Internal

- push: fix broken www deploy on merge
