### PR TITLE
docs: remove remix button from README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ to generate your visualization with the benefits of react for updating the DOM.
 
 ## Usage
 
-[![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/remix/kind-modem)
-
 Let's make a simple bar graph.
 
 First we'll install the relevant packages:


### PR DESCRIPTION
#### :memo: Documentation

- readme: removed remix button from the usage section
