### PR TITLE
Fix Yarn peer dependency warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,15 @@
 enableGlobalCache: false
 
 nodeLinker: node-modules
+
+logFilters:
+  - pattern: "* doesn't provide react (*)*"
+    level: "discard"
+  - pattern: "* doesn't provide react-dom (*)*"
+    level: "discard"
+  - pattern: "* doesn't provide @react-spring/web (*)*"
+    level: "discard"
+  - pattern: "* doesn't provide webpack (*)*"
+    level: "discard"
+  - pattern: "Some peer dependencies are incorrectly met*"
+    level: "discard"

--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -27,10 +27,12 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@babel/core": "^7.26.0",
     "@react-spring/web": "^9.7.5",
     "@types/d3-scale-chromatic": "^1.3.1",
     "@types/nprogress": "^0.2.0",
     "@types/prismjs": "^1.16.0",
+    "@types/react": "^18.3.26",
     "@visx/annotation": "workspace:*",
     "@visx/axis": "workspace:*",
     "@visx/bounds": "workspace:*",

--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -27,7 +27,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.26.0",
     "@react-spring/web": "^9.7.5",
     "@types/d3-scale-chromatic": "^1.3.1",
     "@types/nprogress": "^0.2.0",
@@ -88,6 +87,9 @@
     "react-markdown": "^9.0.1",
     "rehype-raw": "^7.0.0",
     "topojson-client": "^3.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.26.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -41,6 +41,7 @@
     "internmap": "2.0.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.22.5",
     "@babel/plugin-transform-modules-commonjs": "^7.22.5",
     "@types/rimraf": "^3.0.2",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/packages/visx-vendor/package.json
+++ b/packages/visx-vendor/package.json
@@ -41,7 +41,7 @@
     "internmap": "2.0.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.5",
+    "@babel/core": "^7.26.0",
     "@babel/plugin-transform-modules-commonjs": "^7.22.5",
     "@types/rimraf": "^3.0.2",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.26.0":
+"@babel/core@npm:^7.22.5, @babel/core@npm:^7.26.0":
   version: 7.28.5
   resolution: "@babel/core@npm:7.28.5"
   dependencies:
@@ -3561,10 +3561,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/demo@workspace:packages/visx-demo"
   dependencies:
+    "@babel/core": "npm:^7.26.0"
     "@react-spring/web": "npm:^9.7.5"
     "@types/d3-scale-chromatic": "npm:^1.3.1"
     "@types/nprogress": "npm:^0.2.0"
     "@types/prismjs": "npm:^1.16.0"
+    "@types/react": "npm:^18.3.26"
     "@visx/annotation": "workspace:*"
     "@visx/axis": "workspace:*"
     "@visx/bounds": "workspace:*"
@@ -3982,6 +3984,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/vendor@workspace:packages/visx-vendor"
   dependencies:
+    "@babel/core": "npm:^7.22.5"
     "@babel/plugin-transform-modules-commonjs": "npm:^7.22.5"
     "@types/d3-array": "npm:3.0.3"
     "@types/d3-color": "npm:3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.22.5, @babel/core@npm:^7.26.0":
+"@babel/core@npm:^7.26.0":
   version: 7.28.5
   resolution: "@babel/core@npm:7.28.5"
   dependencies:
@@ -3984,7 +3984,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/vendor@workspace:packages/visx-vendor"
   dependencies:
-    "@babel/core": "npm:^7.22.5"
+    "@babel/core": "npm:^7.26.0"
     "@babel/plugin-transform-modules-commonjs": "npm:^7.22.5"
     "@types/d3-array": "npm:3.0.3"
     "@types/d3-color": "npm:3.1.0"


### PR DESCRIPTION
#### :house: Internal

- Add missing build dependencies and suppress expected monorepo warnings:
  - Add @babel/core and @types/react to @visx/demo dependencies
  - Add @babel/core to @visx/vendor devDependencies
  - Configure logFilters in .yarnrc.yml to suppress monorepo peer dependency warnings for react, react-dom, @react-spring/web, and webpack
