### PR TITLE
OIDC trusted publishing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed for git push operations
+      id-token: write  # Required for OIDC trusted publishing
     steps:
       - uses: actions/checkout@v2 # checkout visx + this commit
         with:
@@ -55,13 +58,11 @@ jobs:
       - name: Release
         if: github.repository_owner == 'airbnb'
         # the following configurations are needed for lerna to
-        #   - have git credentials for commiting tags
-        #   - have correct npm credentials for publishing (yarn does not work)
+        #   - have git credentials for committing tags
+        #   - use OIDC trusted publishing for npm (no token required)
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          yarn npm logout
-          npm config set '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}'
           yarn build:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/visx-annotation/src/index.ts
+++ b/packages/visx-annotation/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/annotation
 export { default as Connector } from './components/Connector';
 export { default as Label } from './components/Label';
 export { default as HtmlLabel } from './components/HtmlLabel';

--- a/packages/visx-axis/src/index.ts
+++ b/packages/visx-axis/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/axis
 export { default as Axis } from './axis/Axis';
 export type { AxisProps } from './axis/Axis';
 export { default as AxisLeft } from './axis/AxisLeft';

--- a/packages/visx-bounds/src/index.ts
+++ b/packages/visx-bounds/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/bounds
 import type { WithBoundingRectsProps as WithBoundingRectsPropsType } from './enhancers/withBoundingRects';
 
 export { default as withBoundingRects } from './enhancers/withBoundingRects';

--- a/packages/visx-brush/src/index.ts
+++ b/packages/visx-brush/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/brush
 export { default as Brush } from './Brush';
 
 export type * from './types';

--- a/packages/visx-chord/src/index.ts
+++ b/packages/visx-chord/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/chord
 export { default as Chord } from './Chord';
 export { default as Ribbon } from './Ribbon';
 

--- a/packages/visx-clip-path/src/index.ts
+++ b/packages/visx-clip-path/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/clip-path
 export { default as ClipPath } from './clip-paths/ClipPath';
 export { default as CircleClipPath } from './clip-paths/CircleClipPath';
 export { default as RectClipPath } from './clip-paths/RectClipPath';

--- a/packages/visx-curve/src/index.ts
+++ b/packages/visx-curve/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/curve
 export {
   curveBasis,
   curveBasisClosed,

--- a/packages/visx-delaunay/src/index.ts
+++ b/packages/visx-delaunay/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/delaunay
 export { default as delaunay } from './delaunay';
 export { default as voronoi } from './voronoi';
 export { default as Polygon } from './components/Polygon';

--- a/packages/visx-drag/src/index.ts
+++ b/packages/visx-drag/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/drag
 export { default as Drag } from './Drag';
 export { default as useDrag } from './useDrag';
 export { default as raise } from './util/raise';

--- a/packages/visx-event/src/index.ts
+++ b/packages/visx-event/src/index.ts
@@ -1,2 +1,3 @@
+// @visx/event
 export { default as localPoint } from './localPoint';
 export { default as touchPoint } from './touchPoint';

--- a/packages/visx-geo/src/index.ts
+++ b/packages/visx-geo/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/geo
 export { default as Albers } from './projections/Albers';
 export { default as AlbersUsa } from './projections/AlbersUsa';
 export { default as Mercator } from './projections/Mercator';

--- a/packages/visx-glyph/src/index.ts
+++ b/packages/visx-glyph/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/glyph
 export { default as Glyph } from './glyphs/Glyph';
 export { default as GlyphDot } from './glyphs/GlyphDot';
 export { default as GlyphCross } from './glyphs/GlyphCross';

--- a/packages/visx-gradient/src/index.ts
+++ b/packages/visx-gradient/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/gradient
 export { default as LinearGradient } from './gradients/LinearGradient';
 export { default as RadialGradient } from './gradients/RadialGradient';
 export { default as GradientDarkgreenGreen } from './gradients/GradientDarkgreenGreen';

--- a/packages/visx-grid/src/index.ts
+++ b/packages/visx-grid/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/grid
 export { default as GridRows } from './grids/GridRows';
 export type { GridRowsProps, AllGridRowsProps } from './grids/GridRows';
 export { default as GridColumns } from './grids/GridColumns';

--- a/packages/visx-group/src/index.ts
+++ b/packages/visx-group/src/index.ts
@@ -1,1 +1,2 @@
+// @visx/group
 export { default as Group } from './Group';

--- a/packages/visx-heatmap/src/index.ts
+++ b/packages/visx-heatmap/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/heatmap
 export { default as HeatmapCircle } from './heatmaps/HeatmapCircle';
 export { default as HeatmapRect } from './heatmaps/HeatmapRect';
 

--- a/packages/visx-hierarchy/src/index.ts
+++ b/packages/visx-hierarchy/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/hierarchy
 export { default as Tree } from './hierarchies/Tree';
 export { default as Treemap } from './hierarchies/Treemap';
 export { default as Cluster } from './hierarchies/Cluster';

--- a/packages/visx-legend/src/index.ts
+++ b/packages/visx-legend/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/legend
 export { default as Legend } from './legends/Legend';
 export { default as LegendQuantile } from './legends/Quantile';
 export { default as LegendLinear } from './legends/Linear';

--- a/packages/visx-marker/src/index.ts
+++ b/packages/visx-marker/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/marker
 export { default as Marker } from './markers/Marker';
 export { default as MarkerArrow } from './markers/Arrow';
 export { default as MarkerCross } from './markers/Cross';

--- a/packages/visx-mock-data/src/index.ts
+++ b/packages/visx-mock-data/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/mock-data
 export { default as genDateValue } from './generators/genDateValue';
 export { default as genRandomNormalPoints } from './generators/genRandomNormalPoints';
 export { default as getSeededRandom } from './generators/getSeededRandom';

--- a/packages/visx-network/src/index.ts
+++ b/packages/visx-network/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/network
 export { default as Graph } from './Graph';
 export { default as Links } from './Links';
 export { default as Nodes } from './Nodes';

--- a/packages/visx-pattern/src/index.ts
+++ b/packages/visx-pattern/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/pattern
 export { default as Pattern } from './patterns/Pattern';
 export { default as PatternLines } from './patterns/Lines';
 export { default as PatternCircles } from './patterns/Circles';

--- a/packages/visx-point/src/index.ts
+++ b/packages/visx-point/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/point
 export { default as Point } from './Point';
 export { default as sumPoints } from './sumPoints';
 export { default as subtractPoints } from './subtractPoints';

--- a/packages/visx-react-spring/src/index.ts
+++ b/packages/visx-react-spring/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/react-spring
 export { default as AnimatedTicks } from './axis/AnimatedTicks';
 export { default as AnimatedAxis } from './axis/AnimatedAxis';
 export { default as AnimatedGridRows } from './grid/AnimatedGridRows';

--- a/packages/visx-responsive/src/index.ts
+++ b/packages/visx-responsive/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/responsive
 export { default as ParentSize } from './components/ParentSize';
 export { default as ScaleSVG } from './components/ScaleSVG';
 export { default as withParentSize } from './enhancers/withParentSize';

--- a/packages/visx-sankey/src/index.ts
+++ b/packages/visx-sankey/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/sankey
 export { default as Sankey } from './Sankey';
 export {
   sankey,

--- a/packages/visx-scale/src/index.ts
+++ b/packages/visx-scale/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/scale
 export { default as scaleBand } from './scales/band';
 export { default as scalePoint } from './scales/point';
 export { default as scaleLinear } from './scales/linear';

--- a/packages/visx-shape/src/index.ts
+++ b/packages/visx-shape/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/shape
 export { default as Arc } from './shapes/Arc';
 export { default as Pie } from './shapes/Pie';
 export { default as Line } from './shapes/Line';

--- a/packages/visx-stats/src/index.ts
+++ b/packages/visx-stats/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/stats
 export { default as BoxPlot } from './BoxPlot';
 export { default as ViolinPlot } from './ViolinPlot';
 export { default as computeStats } from './util/computeStats';

--- a/packages/visx-text/src/index.ts
+++ b/packages/visx-text/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/text
 export { default as Text } from './Text';
 export { default as getStringWidth } from './util/getStringWidth';
 export { default as useText } from './hooks/useText';

--- a/packages/visx-threshold/src/index.ts
+++ b/packages/visx-threshold/src/index.ts
@@ -1,1 +1,2 @@
+// @visx/threshold
 export { default as Threshold } from './Threshold';

--- a/packages/visx-tooltip/src/index.ts
+++ b/packages/visx-tooltip/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/tooltip
 export { default as withTooltip } from './enhancers/withTooltip';
 export { default as useTooltip } from './hooks/useTooltip';
 export { default as useTooltipInPortal } from './hooks/useTooltipInPortal';

--- a/packages/visx-visx/src/index.ts
+++ b/packages/visx-visx/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/visx
 import * as Annotation from '@visx/annotation';
 import * as Axis from '@visx/axis';
 import * as Bounds from '@visx/bounds';

--- a/packages/visx-voronoi/src/index.ts
+++ b/packages/visx-voronoi/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/voronoi
 export { default as voronoi } from './voronoi';
 export { default as VoronoiPolygon } from './components/VoronoiPolygon';
 

--- a/packages/visx-wordcloud/src/index.ts
+++ b/packages/visx-wordcloud/src/index.ts
@@ -1,2 +1,3 @@
+// @visx/wordcloud
 export { default as Wordcloud } from './Wordcloud';
 export { default as useWordcloud } from './useWordcloud';

--- a/packages/visx-xychart/src/index.ts
+++ b/packages/visx-xychart/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/xychart
 // components
 export { default as Annotation } from './components/annotation/Annotation';
 export { default as AnimatedAnnotation } from './components/annotation/AnimatedAnnotation';

--- a/packages/visx-zoom/src/index.ts
+++ b/packages/visx-zoom/src/index.ts
@@ -1,3 +1,4 @@
+// @visx/zoom
 export { default as Zoom } from './Zoom';
 export {
   identityMatrix,

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -45,7 +45,8 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
 
     const { stdout, stderr } = await exec(
       // --no-verify-access is needed because the CI token isn't valid for that endpoint
-      `npx lerna publish ${version} --exact --yes --dist-tag ${distTag}`,
+      // --provenance generates build attestation when using OIDC in GitHub Actions
+      `npx lerna publish ${version} --exact --yes --dist-tag ${distTag} --provenance`,
     );
     if (stdout) {
       console.log('Lerna output', stdout);


### PR DESCRIPTION
#### :house: Internal

- Enable OIDC trusted publishing with provenance for npm packages
- Add package name comments to trigger full publish for OIDC testing


**Related**
- [Strengthening npm security: Important changes to authentication and token management](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/)
- [Trusted publishing for npm packages](https://docs.npmjs.com/trusted-publishers)
- [Using OIDC trusted publishing with Lerna](https://lerna.js.org/docs/recipes/oidc-trusted-publishing)