### PR TITLE
fix(legend): render Rect shape as SVG for print compatibility

### DIFF
--- a/packages/visx-legend/src/shapes/Rect.tsx
+++ b/packages/visx-legend/src/shapes/Rect.tsx
@@ -12,14 +12,11 @@ export type ShapeRectProps = {
 };
 
 export default function ShapeRect({ fill, width, height, style }: ShapeRectProps) {
+  const cleanWidth = typeof width === 'string' || typeof width === 'undefined' ? 15 : width;
+  const cleanHeight = typeof height === 'string' || typeof height === 'undefined' ? 15 : height;
   return (
-    <div
-      style={{
-        width,
-        height,
-        background: fill,
-        ...style,
-      }}
-    />
+    <svg width={cleanWidth} height={cleanHeight}>
+      <rect width={cleanWidth} height={cleanHeight} fill={fill} style={style} />
+    </svg>
   );
 }

--- a/packages/visx-legend/test/LegendThreshold.test.tsx
+++ b/packages/visx-legend/test/LegendThreshold.test.tsx
@@ -32,7 +32,9 @@ describe('<LegendThreshold />', () => {
     range.forEach((color, index) => {
       const legendItem = thresholdLegend[index];
       const legendShape = legendItem?.querySelector('.visx-legend-shape');
-      expect(legendShape?.querySelector('div')).toHaveStyle(`background: ${color}`);
+      const rectEl = legendShape?.querySelector('rect');
+      expect(rectEl).not.toBeNull();
+      expect(rectEl).toHaveAttribute('fill', color);
     });
   });
 
@@ -55,7 +57,9 @@ describe('<LegendThreshold />', () => {
     range.forEach((color, index) => {
       const legendItem = thresholdLegend[index];
       const legendShape = legendItem?.querySelector('.visx-legend-shape');
-      expect(legendShape?.querySelector('div')).toHaveStyle(`background: ${color}`);
+      const rectEl = legendShape?.querySelector('rect');
+      expect(rectEl).not.toBeNull();
+      expect(rectEl).toHaveAttribute('fill', color);
     });
   });
 
@@ -78,7 +82,9 @@ describe('<LegendThreshold />', () => {
     range.forEach((color, index) => {
       const legendItem = thresholdLegend[index];
       const legendShape = legendItem?.querySelector('.visx-legend-shape');
-      expect(legendShape?.querySelector('div')).toHaveStyle(`background: ${color}`);
+      const rectEl = legendShape?.querySelector('rect');
+      expect(rectEl).not.toBeNull();
+      expect(rectEl).toHaveAttribute('fill', color);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1984

The `Rect` legend shape (`shape="rect"`) was implemented as a `<div>` with `background` CSS color. Browsers suppress CSS backgrounds during printing unless the user explicitly enables "Print background colors". SVG `fill` attributes are treated as document content and always print regardless of this setting.

## Changes

- **`packages/visx-legend/src/shapes/Rect.tsx`** — Changed from `<div style={{ background: fill }}>` to `<svg><rect fill={fill}></svg>`, consistent with how `Circle` and `Line` shapes are already implemented.
- **`packages/visx-legend/test/LegendThreshold.test.tsx`** — Updated assertions to query the `<rect>` element and check its `fill` attribute instead of querying `<div>` and checking `background` style.

## Before / After

| | Before | After |
|---|---|---|
| Element | `<div style={{ background: fill }}>` | `<svg><rect fill={fill}></svg>` |
| Screen | ✅ Visible | ✅ Visible |
| Print/PDF | ❌ Invisible | ✅ Visible |

## Testing

All 18 existing tests pass with the updated implementation.