### PR TITLE
fix(release): prerelease bump + reset alpha baseline to 4.0.0-alpha.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "command": {
     "publish": {
       "allowBranch": "master"

--- a/packages/visx-annotation/package.json
+++ b/packages/visx-annotation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/annotation",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx annotation",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-axis/package.json
+++ b/packages/visx-axis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/axis",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx axis",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-bounds/package.json
+++ b/packages/visx-bounds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/bounds",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "Utilities to make your life with bounding boxes better",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-brush/package.json
+++ b/packages/visx-brush/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/brush",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx brush",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-chord/package.json
+++ b/packages/visx-chord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/chord",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx group",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-clip-path/package.json
+++ b/packages/visx-clip-path/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/clip-path",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx clip-path",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-curve/package.json
+++ b/packages/visx-curve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/curve",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx curve",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-delaunay/package.json
+++ b/packages/visx-delaunay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/delaunay",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx delaunay",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/demo",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx demo",
   "repository": "https://github.com/airbnb/visx",
   "scripts": {

--- a/packages/visx-drag/package.json
+++ b/packages/visx-drag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/drag",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx drag",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-event/package.json
+++ b/packages/visx-event/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/event",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx event",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-geo/package.json
+++ b/packages/visx-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/geo",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx geo",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-glyph/package.json
+++ b/packages/visx-glyph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/glyph",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx glyph",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-gradient/package.json
+++ b/packages/visx-gradient/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/gradient",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx gradient",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-grid/package.json
+++ b/packages/visx-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/grid",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx grid",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-group/package.json
+++ b/packages/visx-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/group",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx group",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-heatmap/package.json
+++ b/packages/visx-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/heatmap",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx heatmap",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-hierarchy/package.json
+++ b/packages/visx-hierarchy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/hierarchy",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx tree",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-legend/package.json
+++ b/packages/visx-legend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/legend",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx legend",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-marker/package.json
+++ b/packages/visx-marker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/marker",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx marker",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-mock-data/package.json
+++ b/packages/visx-mock-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/mock-data",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx mock data",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-network/package.json
+++ b/packages/visx-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/network",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx network",
   "sideEffects": false,
   "repository": "https://github.com/airbnb/visx",

--- a/packages/visx-pattern/package.json
+++ b/packages/visx-pattern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/pattern",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx pattern",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-point/package.json
+++ b/packages/visx-point/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/point",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx point",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-react-spring/package.json
+++ b/packages/visx-react-spring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/react-spring",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx primitives that rely on react-spring for animation",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-responsive/package.json
+++ b/packages/visx-responsive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/responsive",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx responsive svg",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-sankey/package.json
+++ b/packages/visx-sankey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/sankey",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx sankey",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-scale/package.json
+++ b/packages/visx-scale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/scale",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx scale",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-shape/package.json
+++ b/packages/visx-shape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/shape",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx shape",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-stats/package.json
+++ b/packages/visx-stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/stats",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx stats box violin",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-text/package.json
+++ b/packages/visx-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/text",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx text",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-threshold/package.json
+++ b/packages/visx-threshold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/threshold",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx threshold",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-tooltip/package.json
+++ b/packages/visx-tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/tooltip",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx tooltip",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-visx/package.json
+++ b/packages/visx-visx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/visx",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "One stop install for all visx packages",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-voronoi/package.json
+++ b/packages/visx-voronoi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/voronoi",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx voronoi",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-wordcloud/package.json
+++ b/packages/visx-wordcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/wordcloud",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx wordcloud",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/xychart",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "Composable cartesian coordinate chart built with visx primitives",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/visx-zoom/package.json
+++ b/packages/visx-zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visx/zoom",
-  "version": "4.0.1-alpha.0",
+  "version": "4.0.0-alpha.0",
   "description": "visx zoom",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -35,9 +35,7 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
 
   // perform release
   try {
-    const version = `${isPreRelease ? 'pre' : ''}${
-      isMajor ? 'major' : isMinor ? 'minor' : 'patch'
-    }`;
+    const version = isPreRelease ? 'prerelease' : isMajor ? 'major' : isMinor ? 'minor' : 'patch';
 
     const distTag = isPreRelease ? 'next' : 'latest';
 
@@ -46,7 +44,9 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
     const { stdout, stderr } = await exec(
       // --no-verify-access is needed because the CI token isn't valid for that endpoint
       // provenance is automatically generated when using OIDC Trusted Publishers
-      `npx lerna publish ${version} --exact --yes --dist-tag ${distTag}`,
+      `npx lerna publish ${version} --exact --yes --dist-tag ${distTag}${
+        isPreRelease ? ' --preid alpha' : ''
+      }`,
     );
     if (stdout) {
       console.log('Lerna output', stdout);


### PR DESCRIPTION
## Summary

- **Fix release-script bug** that bumped patch instead of prerelease on alpha releases. The script built its lerna bump keyword by concatenating `pre` with `major|minor|patch`, which for the default alpha path produced `prepatch`. `semver.inc(v, 'prepatch', …)` bumps patch and resets the prerelease counter to `.0`, so successive alphas went `4.0.0-alpha.0 → 4.0.1-alpha.0` instead of the intended `4.0.0-alpha.0 → 4.0.0-alpha.1`. Fix passes `prerelease` as the bump keyword and adds `--preid alpha` to the `lerna publish` command.
- **Reset alpha baseline** in `lerna.json` + every `packages/*/package.json` from `4.0.1-alpha.0` back to `4.0.0-alpha.0`. Internal deps use `workspace:*`, so only each package's own `version` field changes.

## Why reset the baseline

Semver-wise, `4.0.0 < 4.0.1-alpha.0`. Continuing the alpha chain as `4.0.1-alpha.<N>` would implicitly commit us to shipping the first stable v4 as `4.0.1` (or `4.1.0`) — we'd lose `4.0.0` as a valid target forever. Resetting now preserves `4.0.0` as the first stable v4 release, which is what a major release deserves. Consumer impact is minimal: only `@visx/*@next` subscribers are affected

#### :house: Internal

- [fix: use prerelease bump with alpha preid for alpha releases](https://github.com/airbnb/visx/commit/def7aef1836a3b70b55cb800a4303700a846bbcb)
- [chore: reset alpha baseline to 4.0.0-alpha.0](https://github.com/airbnb/visx/commit/c7f4632b2ae641455ad8c40bc441ee91d5b2db57)
