### PR TITLE
refactor(types)!: @types/react as optional peer dependency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,10 +11,10 @@ React-based `@visx/*` packages now declare `@types/react` as a **peer** dependen
 bundling their own copy. That way your app supplies a single version and you avoid duplicate or
 conflicting installs.
 
-`@visx/bounds`, `@visx/tooltip`, and the `@visx/visx` meta-package all declare `@types/react-dom`
-as an optional peer directly (bounds and tooltip both type DOM-touching APIs; the umbrella matches
-the pattern of its DOM-touching members). `@visx/xychart` consumes `@visx/tooltip` transitively and
-its consumers should also install `@types/react-dom`.
+`@visx/bounds`, `@visx/tooltip`, `@visx/xychart`, and the `@visx/visx` meta-package all declare
+`@types/react-dom` as an optional peer directly (bounds and tooltip type DOM-touching APIs;
+xychart consumes tooltip and so transitively needs react-dom at runtime; the umbrella matches the
+pattern of its DOM-touching members).
 
 `@visx/brush` and `@visx/wordcloud` also declare `@types/react` as an optional peer so consumers
 installing either package directly get the same type-dependency signal as the rest of the

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,112 @@
+# Migration guide
+
+This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
+cumulative — if you're jumping several versions, apply the steps from each section in order.
+
+## 4.0.0-alpha.3
+
+### `@types/react` and `@types/react-dom` as peer dependencies
+
+React-based `@visx/*` packages now declare `@types/react` as a **peer** dependency instead of
+bundling their own copy. That way your app supplies a single version and you avoid duplicate or
+conflicting installs.
+
+`@visx/bounds`, `@visx/tooltip`, and the `@visx/visx` meta-package all declare `@types/react-dom`
+as an optional peer directly (bounds and tooltip both type DOM-touching APIs; the umbrella matches
+the pattern of its DOM-touching members). `@visx/xychart` consumes `@visx/tooltip` transitively and
+its consumers should also install `@types/react-dom`.
+
+`@visx/brush` and `@visx/wordcloud` also declare `@types/react` as an optional peer so consumers
+installing either package directly get the same type-dependency signal as the rest of the
+React-based `@visx/*` packages.
+
+The peers are marked `optional` via `peerDependenciesMeta`, so non-TypeScript consumers and React
+19+ consumers who rely on React's built-in types will not see missing-peer warnings.
+
+**What you need to do:**
+
+- **React 18 and earlier (TypeScript users):** add `@types/react` as a dev dependency matching
+  your React version:
+
+  ```bash
+  yarn add -D @types/react
+  ```
+
+  If you use `@visx/bounds`, `@visx/tooltip`, `@visx/xychart`, or the `@visx/visx` meta-package,
+  also install `@types/react-dom`:
+
+  ```bash
+  yarn add -D @types/react-dom
+  ```
+
+  Use the major versions that align with your `react` / `react-dom` versions.
+
+- **React 19+:** rely on the types shipped with `react` and `react-dom`. The optional peer means no
+  install warning either way.
+
+- **Non-TypeScript consumers:** no action needed.
+
+If you see TypeScript errors about missing `react` types after upgrading, install the appropriate
+`@types/react` (and `@types/react-dom` when using `@visx/bounds`, `@visx/tooltip`, `@visx/xychart`,
+or `@visx/visx`) in your application.
+
+## 4.0.0-alpha.2
+
+### Node ESM compatibility fix for published `esm/` output
+
+The published `esm/` output now emits explicit `.js` extensions on relative imports and a nested
+`esm/package.json` with `"type": "module"`. Strict Node ESM consumers (Vite/react-router SSR, Deno,
+edge runtimes) previously failed with `ERR_MODULE_NOT_FOUND` when resolving visx's ESM entry.
+
+**What you need to do:** nothing — this is a bugfix. If you were pinned to `4.0.0-alpha.1`
+specifically to avoid a different ESM issue, you can upgrade safely.
+
+## 4.0.0-alpha.1
+
+Release-plumbing only: prerelease bump configuration and CI permissions for release PR comments. No
+consumer-facing changes.
+
+## 4.0.0-alpha.0
+
+The React 19 cut. This is the release that drops legacy React support and modernizes the build
+targets.
+
+### React 19 support (automatic JSX transform)
+
+Every `@visx/*` package now uses the automatic JSX transform and imports React symbols as direct
+named imports or type-only imports (no more `React.ReactNode` namespace access). Peer dependency
+ranges were widened to `^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0`.
+
+**What you need to do:**
+
+- **React 19 consumers:** you should be able to upgrade with no code changes.
+- **React 18 / 17 / 16.14+ consumers:** still supported, no action needed.
+- **React ≤ 16.13:** no longer supported — upgrade React first.
+- If you import directly from deep subpaths (e.g. `@visx/shape/lib/shapes/Bar`), prefer the package
+  root (`@visx/shape`). Deep imports are no longer the blessed API surface and may break in a future
+  alpha. Every package now declares `exports` so Node's module resolver will honor the root entry.
+
+### Dropped IE11 support
+
+Babel targets were bumped to modern browsers. IE11 and other legacy browsers are no longer
+supported.
+
+**What you need to do:** if you still need IE11, stay on `3.x`.
+
+### Package `exports` field
+
+Every package now publishes an `exports` field mapping `.` to `types`, `import`, and `require`
+entries. This improves module resolution in modern bundlers and Node.js, but does restrict access to
+internal paths.
+
+**What you need to do:** replace any deep imports (`@visx/foo/lib/bar`) with root imports
+(`@visx/foo`). If a symbol you need isn't re-exported from the root, open an issue.
+
+### Lerna v9 / OIDC publishing / resolution cleanup
+
+Internal only — Lerna was upgraded to v9, publishing now uses OIDC trusted publishing, and unused
+`ansi-*` resolutions were removed from the root. No consumer impact.
+
+### `@visx/demo` (internal)
+
+Upgraded to React 19, Next.js 15, and `@react-spring/web` v10. Affects contributors only.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ to generate your visualization with the benefits of react for updating the DOM.
   </strong>
   &bull;
   <strong>
+    <a href="./MIGRATION.md">Migration</a>
+  </strong>
+  &bull;
+  <strong>
     <a href="https://medium.com/vx-code/getting-started-with-vx-1756bb661410">Getting started tutorial</a>
   </strong>
 </p>

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "@types/react-dom": "^19.0.0",
+    "caniuse-lite": "^1.0.30001787",
+    "baseline-browser-mapping": "^2.10.18"
   }
 }

--- a/packages/visx-annotation/package.json
+++ b/packages/visx-annotation/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/drag": "workspace:*",
     "@visx/group": "workspace:*",
     "@visx/text": "workspace:*",
@@ -46,9 +46,15 @@
     "react-use-measure": "^2.0.4"
   },
   "devDependencies": {
-    "@juggle/resize-observer": "^3.3.1"
+    "@juggle/resize-observer": "^3.3.1",
+    "@types/react": "^19.0.0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-axis/package.json
+++ b/packages/visx-axis/package.json
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/point": "workspace:*",
     "@visx/scale": "workspace:*",
@@ -44,9 +43,18 @@
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-bounds/package.json
+++ b/packages/visx-bounds/package.json
@@ -36,12 +36,18 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@types/react": "*",
-    "@types/react-dom": "*"
-  },
   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0",
     "react-dom": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-brush/package.json
+++ b/packages/visx-brush/package.json
@@ -30,7 +30,13 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@visx/drag": "workspace:*",
@@ -46,5 +52,8 @@
       "import": "./esm/index.js",
       "require": "./lib/index.js"
     }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-chord/package.json
+++ b/packages/visx-chord/package.json
@@ -36,15 +36,20 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
     "@types/d3-chord": "^1.0.9",
-    "@types/react": "*",
     "classnames": "^2.3.1",
     "d3-chord": "^1.0.4"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-clip-path/package.json
+++ b/packages/visx-clip-path/package.json
@@ -35,13 +35,16 @@
     "url": "https://github.com/airbnb/visx/issues"
   },
   "homepage": "https://github.com/airbnb/visx#readme",
-  "dependencies": {
-    "@types/react": "*"
-  },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-delaunay/package.json
+++ b/packages/visx-delaunay/package.json
@@ -38,11 +38,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/vendor": "workspace:*",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-demo/package.json
+++ b/packages/visx-demo/package.json
@@ -31,7 +31,6 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/nprogress": "^0.2.0",
     "@types/prismjs": "^1.16.0",
-    "@types/react": "^19.0.0",
     "@visx/annotation": "workspace:*",
     "@visx/axis": "workspace:*",
     "@visx/bounds": "workspace:*",
@@ -89,7 +88,9 @@
     "topojson-client": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.0"
+    "@babel/core": "^7.26.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/visx-drag/package.json
+++ b/packages/visx-drag/package.json
@@ -38,11 +38,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/event": "workspace:*",
     "@visx/point": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-event/package.json
+++ b/packages/visx-event/package.json
@@ -38,7 +38,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/point": "workspace:*"
+  },
+  "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-geo/package.json
+++ b/packages/visx-geo/package.json
@@ -37,19 +37,25 @@
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
     "@types/geojson": "*",
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/vendor": "workspace:*",
     "classnames": "^2.3.1"
   },
   "devDependencies": {
+    "@types/react": "^19.0.0",
     "@types/topojson-client": "^3.1.5",
     "topojson-client": "^3.1.0"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-glyph/package.json
+++ b/packages/visx-glyph/package.json
@@ -38,12 +38,20 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/vendor": "workspace:*",
     "classnames": "^2.3.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-gradient/package.json
+++ b/packages/visx-gradient/package.json
@@ -34,13 +34,16 @@
     "url": "https://github.com/airbnb/visx/issues"
   },
   "homepage": "https://github.com/airbnb/visx#readme",
-  "dependencies": {
-    "@types/react": "*"
-  },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-grid/package.json
+++ b/packages/visx-grid/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/curve": "workspace:*",
     "@visx/group": "workspace:*",
     "@visx/point": "workspace:*",
@@ -48,5 +48,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-group/package.json
+++ b/packages/visx-group/package.json
@@ -36,13 +36,18 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "classnames": "^2.3.1"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-heatmap/package.json
+++ b/packages/visx-heatmap/package.json
@@ -38,11 +38,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "classnames": "^2.3.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-hierarchy/package.json
+++ b/packages/visx-hierarchy/package.json
@@ -39,12 +39,20 @@
   },
   "dependencies": {
     "@types/d3-hierarchy": "^1.1.6",
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "classnames": "^2.3.1",
     "d3-hierarchy": "^1.1.4"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-legend/package.json
+++ b/packages/visx-legend/package.json
@@ -35,15 +35,23 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/scale": "workspace:*",
     "classnames": "^2.3.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-marker/package.json
+++ b/packages/visx-marker/package.json
@@ -35,15 +35,23 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/shape": "workspace:*",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-network/package.json
+++ b/packages/visx-network/package.json
@@ -27,14 +27,22 @@
   "author": "@andyfang_dz",
   "license": "MIT",
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-pattern/package.json
+++ b/packages/visx-pattern/package.json
@@ -35,13 +35,18 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/react": "*",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-react-spring/package.json
+++ b/packages/visx-react-spring/package.json
@@ -46,14 +46,22 @@
   },
   "peerDependencies": {
     "@react-spring/web": "^9.7.5 || ^10.0.0",
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@visx/axis": "workspace:*",
     "@visx/grid": "workspace:*",
     "@visx/scale": "workspace:*",
     "@visx/text": "workspace:*",
     "classnames": "^2.3.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-responsive/package.json
+++ b/packages/visx-responsive/package.json
@@ -36,10 +36,10 @@
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
     "@types/lodash": "^4.17.13",
-    "@types/react": "*",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "devDependencies": {
@@ -47,5 +47,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-sankey/package.json
+++ b/packages/visx-sankey/package.json
@@ -39,13 +39,21 @@
   },
   "dependencies": {
     "@types/d3-sankey": "^0.12.4",
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/vendor": "workspace:*",
     "classnames": "^2.3.1",
     "d3-sankey": "^0.12.3"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-shape/package.json
+++ b/packages/visx-shape/package.json
@@ -29,7 +29,6 @@
   "license": "MIT",
   "dependencies": {
     "@types/lodash": "^4.17.13",
-    "@types/react": "*",
     "@visx/curve": "workspace:*",
     "@visx/group": "workspace:*",
     "@visx/scale": "workspace:*",
@@ -38,6 +37,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
@@ -45,6 +45,12 @@
   },
   "devDependencies": {
     "@types/d3-hierarchy": "^1.1.6",
+    "@types/react": "^19.0.0",
     "d3-hierarchy": "^1.1.8"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-stats/package.json
+++ b/packages/visx-stats/package.json
@@ -35,16 +35,24 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/react": "*",
     "@visx/group": "workspace:*",
     "@visx/scale": "workspace:*",
     "@visx/vendor": "workspace:*",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-text/package.json
+++ b/packages/visx-text/package.json
@@ -36,15 +36,20 @@
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
     "@types/lodash": "^4.17.13",
-    "@types/react": "*",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "reduce-css-calc": "^1.3.0"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-threshold/package.json
+++ b/packages/visx-threshold/package.json
@@ -31,15 +31,23 @@
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
-    "@types/react": "*",
     "@visx/clip-path": "workspace:*",
     "@visx/shape": "workspace:*",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-tooltip/package.json
+++ b/packages/visx-tooltip/package.json
@@ -35,19 +35,30 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
-    "@types/react": "*",
     "@visx/bounds": "workspace:*",
     "classnames": "^2.3.1",
     "react-use-measure": "^2.0.4"
   },
   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0",
     "react-dom": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "devDependencies": {
-    "@juggle/resize-observer": "^3.3.1"
+    "@juggle/resize-observer": "^3.3.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-visx/package.json
+++ b/packages/visx-visx/package.json
@@ -30,7 +30,10 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0",
+    "react-dom": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
     "@visx/annotation": "workspace:*",
@@ -73,5 +76,17 @@
       "import": "./esm/index.js",
       "require": "./lib/index.js"
     }
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   }
 }

--- a/packages/visx-voronoi/package.json
+++ b/packages/visx-voronoi/package.json
@@ -39,11 +39,16 @@
   },
   "dependencies": {
     "@types/d3-voronoi": "^1.1.9",
-    "@types/react": "*",
     "classnames": "^2.3.1",
     "d3-voronoi": "^1.1.2"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-wordcloud/package.json
+++ b/packages/visx-wordcloud/package.json
@@ -36,7 +36,13 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@visx/group": "workspace:*",
@@ -44,5 +50,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -45,7 +45,9 @@
   "peerDependencies": {
     "@react-spring/web": "^9.7.5 || ^10.0.0",
     "@types/react": "*",
-    "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+    "@types/react-dom": "*",
+    "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0",
+    "react-dom": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
     "@types/lodash": "^4.17.13",
@@ -74,6 +76,9 @@
   },
   "peerDependenciesMeta": {
     "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
       "optional": true
     }
   }

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -44,11 +44,11 @@
   },
   "peerDependencies": {
     "@react-spring/web": "^9.7.5 || ^10.0.0",
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
     "@types/lodash": "^4.17.13",
-    "@types/react": "*",
     "@visx/annotation": "workspace:*",
     "@visx/axis": "workspace:*",
     "@visx/event": "workspace:*",
@@ -68,6 +68,13 @@
     "mitt": "^2.1.0"
   },
   "devDependencies": {
-    "@juggle/resize-observer": "^3.3.1"
+    "@juggle/resize-observer": "^3.3.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/visx-zoom/package.json
+++ b/packages/visx-zoom/package.json
@@ -38,11 +38,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
-    "@types/react": "*",
     "@use-gesture/react": "^10.3.1",
     "@visx/event": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,12 +5607,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.8.19":
-  version: 2.8.24
-  resolution: "baseline-browser-mapping@npm:2.8.24"
+"baseline-browser-mapping@npm:^2.10.18":
+  version: 2.10.18
+  resolution: "baseline-browser-mapping@npm:2.10.18"
   bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/8add2f6fe6312134032caa1d385d07a939e25594566672a57d2eef2a53592252b8b56348cdd991d73d78741033d16a28d3da96ef3fc9f4d0bb9ea268124a53c3
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10c0/cab0138dd70b3aefe83e27cd03013bfdea772d2329e6458178cceed34b7e3fde72b697c9e4c21fb3c796bcfb831d348bc947b017d8b64417045a34bf014c87b7
   languageName: node
   linkType: hard
 
@@ -5840,10 +5840,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001751":
-  version: 1.0.30001753
-  resolution: "caniuse-lite@npm:1.0.30001753"
-  checksum: 10c0/730344b6c54769f544f1d4bd7f99a122cd5f6e964e482adbcb18b63cda56e9c40aca1e3ab47c7154098803c9ba3772cca0aba936d1c924e67e8db8345712e5a8
+"caniuse-lite@npm:^1.0.30001787":
+  version: 1.0.30001787
+  resolution: "caniuse-lite@npm:1.0.30001787"
+  checksum: 10c0/93a6975afbf07f49c9077b348948bbc25b6a82596ccd07b4b6503e48f6f968e1a1e057cc25004db8a2d1d4f35f0c792739e33634edfcefc88ff184c9a2f7a036
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,9 +4972,13 @@ __metadata:
   peerDependencies:
     "@react-spring/web": ^9.7.5 || ^10.0.0
     "@types/react": "*"
+    "@types/react-dom": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+    react-dom: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
   peerDependenciesMeta:
     "@types/react":
+      optional: true
+    "@types/react-dom":
       optional: true
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -4193,14 +4193,18 @@ __metadata:
   resolution: "@visx/annotation@workspace:packages/visx-annotation"
   dependencies:
     "@juggle/resize-observer": "npm:^3.3.1"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/drag": "workspace:*"
     "@visx/group": "workspace:*"
     "@visx/text": "workspace:*"
     classnames: "npm:^2.3.1"
     react-use-measure: "npm:^2.0.4"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4208,7 +4212,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/axis@workspace:packages/visx-axis"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     "@visx/point": "workspace:*"
     "@visx/scale": "workspace:*"
@@ -4216,19 +4220,27 @@ __metadata:
     "@visx/text": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
 "@visx/bounds@workspace:*, @visx/bounds@workspace:packages/visx-bounds":
   version: 0.0.0-use.local
   resolution: "@visx/bounds@workspace:packages/visx-bounds"
-  dependencies:
-    "@types/react": "npm:*"
-    "@types/react-dom": "npm:*"
   peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
     react-dom: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4236,6 +4248,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/brush@workspace:packages/visx-brush"
   dependencies:
+    "@types/react": "npm:^19.0.0"
     "@visx/drag": "workspace:*"
     "@visx/event": "workspace:*"
     "@visx/group": "workspace:*"
@@ -4243,7 +4256,11 @@ __metadata:
     "@visx/shape": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4252,21 +4269,26 @@ __metadata:
   resolution: "@visx/chord@workspace:packages/visx-chord"
   dependencies:
     "@types/d3-chord": "npm:^1.0.9"
-    "@types/react": "npm:*"
     classnames: "npm:^2.3.1"
     d3-chord: "npm:^1.0.4"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
 "@visx/clip-path@workspace:*, @visx/clip-path@workspace:packages/visx-clip-path":
   version: 0.0.0-use.local
   resolution: "@visx/clip-path@workspace:packages/visx-clip-path"
-  dependencies:
-    "@types/react": "npm:*"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4282,11 +4304,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/delaunay@workspace:packages/visx-delaunay"
   dependencies:
-    "@types/react": "npm:*"
     "@visx/vendor": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4300,6 +4325,7 @@ __metadata:
     "@types/nprogress": "npm:^0.2.0"
     "@types/prismjs": "npm:^1.16.0"
     "@types/react": "npm:^19.0.0"
+    "@types/react-dom": "npm:^19.0.0"
     "@visx/annotation": "workspace:*"
     "@visx/axis": "workspace:*"
     "@visx/bounds": "workspace:*"
@@ -4362,11 +4388,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/drag@workspace:packages/visx-drag"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/event": "workspace:*"
     "@visx/point": "workspace:*"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4374,8 +4404,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/event@workspace:packages/visx-event"
   dependencies:
-    "@types/react": "npm:*"
     "@visx/point": "workspace:*"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4384,14 +4419,18 @@ __metadata:
   resolution: "@visx/geo@workspace:packages/visx-geo"
   dependencies:
     "@types/geojson": "npm:*"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@types/topojson-client": "npm:^3.1.5"
     "@visx/group": "workspace:*"
     "@visx/vendor": "workspace:*"
     classnames: "npm:^2.3.1"
     topojson-client: "npm:^3.1.0"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4399,22 +4438,28 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/glyph@workspace:packages/visx-glyph"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     "@visx/vendor": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
 "@visx/gradient@workspace:*, @visx/gradient@workspace:packages/visx-gradient":
   version: 0.0.0-use.local
   resolution: "@visx/gradient@workspace:packages/visx-gradient"
-  dependencies:
-    "@types/react": "npm:*"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4422,7 +4467,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/grid@workspace:packages/visx-grid"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/curve": "workspace:*"
     "@visx/group": "workspace:*"
     "@visx/point": "workspace:*"
@@ -4430,7 +4475,11 @@ __metadata:
     "@visx/shape": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4438,10 +4487,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/group@workspace:packages/visx-group"
   dependencies:
-    "@types/react": "npm:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4449,11 +4501,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/heatmap@workspace:packages/visx-heatmap"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4462,12 +4518,16 @@ __metadata:
   resolution: "@visx/hierarchy@workspace:packages/visx-hierarchy"
   dependencies:
     "@types/d3-hierarchy": "npm:^1.1.6"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     classnames: "npm:^2.3.1"
     d3-hierarchy: "npm:^1.1.4"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4475,12 +4535,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/legend@workspace:packages/visx-legend"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     "@visx/scale": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4488,12 +4552,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/marker@workspace:packages/visx-marker"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     "@visx/shape": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4510,11 +4578,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/network@workspace:packages/visx-network"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4522,10 +4594,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/pattern@workspace:packages/visx-pattern"
   dependencies:
-    "@types/react": "npm:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4539,7 +4614,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/react-spring@workspace:packages/visx-react-spring"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/axis": "workspace:*"
     "@visx/grid": "workspace:*"
     "@visx/scale": "workspace:*"
@@ -4547,7 +4622,11 @@ __metadata:
     classnames: "npm:^2.3.1"
   peerDependencies:
     "@react-spring/web": ^9.7.5 || ^10.0.0
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4557,10 +4636,13 @@ __metadata:
   dependencies:
     "@juggle/resize-observer": "npm:^3.3.1"
     "@types/lodash": "npm:^4.17.13"
-    "@types/react": "npm:*"
     lodash: "npm:^4.17.21"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4621,13 +4703,17 @@ __metadata:
   resolution: "@visx/sankey@workspace:packages/visx-sankey"
   dependencies:
     "@types/d3-sankey": "npm:^0.12.4"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     "@visx/vendor": "workspace:*"
     classnames: "npm:^2.3.1"
     d3-sankey: "npm:^0.12.3"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4645,7 +4731,7 @@ __metadata:
   dependencies:
     "@types/d3-hierarchy": "npm:^1.1.6"
     "@types/lodash": "npm:^4.17.13"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/curve": "workspace:*"
     "@visx/group": "workspace:*"
     "@visx/scale": "workspace:*"
@@ -4654,7 +4740,11 @@ __metadata:
     d3-hierarchy: "npm:^1.1.8"
     lodash: "npm:^4.17.21"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4662,13 +4752,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/stats@workspace:packages/visx-stats"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     "@visx/scale": "workspace:*"
     "@visx/vendor": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4677,12 +4771,15 @@ __metadata:
   resolution: "@visx/text@workspace:packages/visx-text"
   dependencies:
     "@types/lodash": "npm:^4.17.13"
-    "@types/react": "npm:*"
     classnames: "npm:^2.3.1"
     lodash: "npm:^4.17.21"
     reduce-css-calc: "npm:^1.3.0"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4690,12 +4787,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/threshold@workspace:packages/visx-threshold"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@visx/clip-path": "workspace:*"
     "@visx/shape": "workspace:*"
     classnames: "npm:^2.3.1"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4704,13 +4805,21 @@ __metadata:
   resolution: "@visx/tooltip@workspace:packages/visx-tooltip"
   dependencies:
     "@juggle/resize-observer": "npm:^3.3.1"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
+    "@types/react-dom": "npm:^19.0.0"
     "@visx/bounds": "workspace:*"
     classnames: "npm:^2.3.1"
     react-use-measure: "npm:^2.0.4"
   peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
     react-dom: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4755,6 +4864,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/visx@workspace:packages/visx-visx"
   dependencies:
+    "@types/react": "npm:^19.0.0"
+    "@types/react-dom": "npm:^19.0.0"
     "@visx/annotation": "workspace:*"
     "@visx/axis": "workspace:*"
     "@visx/bounds": "workspace:*"
@@ -4789,7 +4900,15 @@ __metadata:
     "@visx/xychart": "workspace:*"
     "@visx/zoom": "workspace:*"
   peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+    react-dom: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4798,11 +4917,14 @@ __metadata:
   resolution: "@visx/voronoi@workspace:packages/visx-voronoi"
   dependencies:
     "@types/d3-voronoi": "npm:^1.1.9"
-    "@types/react": "npm:*"
     classnames: "npm:^2.3.1"
     d3-voronoi: "npm:^1.1.2"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4810,10 +4932,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/wordcloud@workspace:packages/visx-wordcloud"
   dependencies:
+    "@types/react": "npm:^19.0.0"
     "@visx/group": "workspace:*"
     d3-cloud: "npm:^1.2.7"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4823,7 +4950,8 @@ __metadata:
   dependencies:
     "@juggle/resize-observer": "npm:^3.3.1"
     "@types/lodash": "npm:^4.17.13"
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
+    "@types/react-dom": "npm:^19.0.0"
     "@visx/annotation": "workspace:*"
     "@visx/axis": "workspace:*"
     "@visx/event": "workspace:*"
@@ -4843,7 +4971,11 @@ __metadata:
     mitt: "npm:^2.1.0"
   peerDependencies:
     "@react-spring/web": ^9.7.5 || ^10.0.0
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4851,11 +4983,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/zoom@workspace:packages/visx-zoom"
   dependencies:
-    "@types/react": "npm:*"
+    "@types/react": "npm:^19.0.0"
     "@use-gesture/react": "npm:^10.3.1"
     "@visx/event": "workspace:*"
   peerDependencies:
+    "@types/react": "*"
     react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### :boom: Breaking Changes

- Strict TypeScript consumers on React ≤18 who don't already install `@types/react` in their own app will see type errors after upgrading.

Fixes #1918 

## Summary

- Moves `@types/react` (and `@types/react-dom` where appropriate) from `dependencies` → `peerDependencies` across 31 published React-based `@visx/*` packages, marked `optional` via `peerDependenciesMeta` so React 19+ and non-TypeScript consumers don't see missing-peer warnings.
- Adds `MIGRATION.md` with per-alpha sections (4.0.0-alpha.0 → current) and links it from the README.
- Pins `caniuse-lite` and `baseline-browser-mapping` in root `resolutions` to silence ~30 lines of data-staleness warnings per `yarn build`.

## Why

Every visx package previously pulled its own copy of `@types/react`, producing duplicate and sometimes conflicting installs. Making it a peer lets a consumer's single version satisfy the whole graph. React 19 ships types natively, so an unconditional dependency is no longer appropriate — the `optional` flag on the peer ensures 19+ users see no install warnings either.

## Scope

### Peer migration (31 published packages)

- **All React-based packages** now declare `@types/react: "*"` as an `optional` peer: annotation, axis, bounds, brush, chord, clip-path, delaunay, drag, event, geo, glyph, gradient, grid, group, heatmap, hierarchy, legend, marker, network, pattern, react-spring, responsive, sankey, shape, stats, text, threshold, tooltip, visx, voronoi, wordcloud, xychart, zoom.
- **`@visx/bounds`, `@visx/tooltip`, `@visx/visx`** additionally declare `@types/react-dom: "*"` as an `optional` peer (they directly type DOM-touching APIs).
- **`@visx/visx`** umbrella also declares `react-dom` as a peer
- **`@visx/event`** gets a fresh `peerDependencies` block seeded with the standard `react` range (it had none before).
- **`@visx/demo`** moves `@types/react` to `devDependencies` and adds `@types/react-dom`.

### Yarn 4 workspace satisfaction

22 consumer workspaces get `@types/react` in `devDependencies` (and 3 — tooltip, xychart, visx — also get `@types/react-dom`) so Yarn 4's per-workspace peer check stays clean. Root `resolutions` pins `@types/react@^19.0.0` for the dev install.

### Build noise fix

`caniuse-lite` and `baseline-browser-mapping` bundled data was >2 months old, producing warnings on every package build. Pinned in root `resolutions`.

### Docs

New [`MIGRATION.md`](./MIGRATION.md) with per-alpha sections:
- **4.0.0-alpha.3** — this PR's peer change
- **4.0.0-alpha.2** — Node ESM compatibility fix
- **4.0.0-alpha.1** — release-plumbing only
- **4.0.0-alpha.0** — React 19 cut, IE11 drop, package `exports` field

## Breaking change

Strict TypeScript consumers on React ≤18 who don't already install `@types/react` in their own app will see type errors after upgrading.

**What to do:**

- **React 18 and earlier (TS users):** `yarn add -D @types/react @types/react-dom`
- **React 19+:** no action — rely on the types shipped with `react` / `react-dom`.
- **Non-TS consumers:** no action.
- **Consumers of `@visx/bounds`, `@visx/tooltip`, `@visx/xychart`, or `@visx/visx`:** also install `@types/react-dom`.

See [MIGRATION.md](./MIGRATION.md#400-alpha3) for the full guide.

## Test plan

- [x] `yarn install` — clean, no YN0002 peer warnings
- [x] `yarn build:vendor && yarn type` — full `tsc --build` passes across all 39 workspaces
- [x] `yarn build` — passes; caniuse/baseline warnings gone
- [x] `tsc --noEmit` spot-check on 11 representative packages (group, event, bounds, legend, tooltip, drag, annotation, responsive, visx, brush, wordcloud) — all clean
- [x] Audit: every React-based package declares the peer; no non-React package does; `react-dom` / `@types/react-dom` peer coverage matches which packages import from `react-dom` directly