### PR TITLE
fix(xychart)!: tighten BaseAxis empty-data guard, add tests

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,28 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
+## 4.0.0-alpha.5
+
+### `@visx/xychart` axis rendering fix (breaking)
+
+`BaseAxis` no longer renders until at least one data series with non-empty `data` has been registered
+in `DataContext`. Previously, on initial render the axis could use the fallback `scaleLinear()`
+domain `[0, 1]`, causing `tickFormat` to receive incorrect intermediate values before real data
+loaded ([#1975](https://github.com/airbnb/visx/issues/1975)).
+
+This is a behavior change: axes that previously rendered immediately (showing `0`–`1` ticks while
+data was loading) will now render `null` until real data is available.
+
+**What you need to do:**
+
+- **Most consumers:** nothing — this is a bugfix. If you were working around stale tick labels on
+  first render, you can remove that workaround.
+- **If you relied on the axis being visible before data loaded** (e.g., to display a skeleton axis):
+  render a placeholder `<Axis />` from `@visx/axis` directly with your own scale until your data is
+  ready, then switch to the xychart `<Axis />`.
+
+Thank you [wildseansy](https://github.com/wildseansy) for the fix [#1979](https://github.com/airbnb/visx/pull/1979)
+
 ## 4.0.0-alpha.4
 
 Internal only: replaced `ts-node` with `tsx` (esbuild-based) for faster TypeScript script execution.

--- a/packages/visx-xychart/src/components/axis/BaseAxis.tsx
+++ b/packages/visx-xychart/src/components/axis/BaseAxis.tsx
@@ -75,8 +75,7 @@ export default function BaseAxis<Scale extends AxisScale>({
   // Don't render axis until data is registered with non-empty data, otherwise the
   // fallback scaleLinear() with domain [0,1] will cause tickFormat to receive
   // incorrect intermediate values.
-  const hasRegisteredData =
-    dataRegistry?.entries().some((entry) => entry.data.length > 0) ?? false;
+  const hasRegisteredData = dataRegistry?.entries().some((entry) => entry.data.length > 0) ?? false;
 
   return scale && hasRegisteredData ? (
     <AxisComponent

--- a/packages/visx-xychart/src/components/axis/BaseAxis.tsx
+++ b/packages/visx-xychart/src/components/axis/BaseAxis.tsx
@@ -72,9 +72,12 @@ export default function BaseAxis<Scale extends AxisScale>({
     | Scale
     | undefined;
 
-  // Don't render axis until data is registered, otherwise the fallback scaleLinear()
-  // with domain [0,1] will cause tickFormat to receive incorrect intermediate values.
-  const hasRegisteredData = dataRegistry && dataRegistry.keys().length > 0;
+  // Don't render axis until data is registered with non-empty data, otherwise the
+  // fallback scaleLinear() with domain [0,1] will cause tickFormat to receive
+  // incorrect intermediate values.
+  const hasRegisteredData =
+    (dataRegistry?.keys().length ?? 0) > 0 &&
+    dataRegistry!.entries().some((entry) => entry.data.length > 0);
 
   return scale && hasRegisteredData ? (
     <AxisComponent

--- a/packages/visx-xychart/src/components/axis/BaseAxis.tsx
+++ b/packages/visx-xychart/src/components/axis/BaseAxis.tsx
@@ -76,8 +76,7 @@ export default function BaseAxis<Scale extends AxisScale>({
   // fallback scaleLinear() with domain [0,1] will cause tickFormat to receive
   // incorrect intermediate values.
   const hasRegisteredData =
-    (dataRegistry?.keys().length ?? 0) > 0 &&
-    dataRegistry!.entries().some((entry) => entry.data.length > 0);
+    dataRegistry?.entries().some((entry) => entry.data.length > 0) ?? false;
 
   return scale && hasRegisteredData ? (
     <AxisComponent

--- a/packages/visx-xychart/test/components/Axis.test.tsx
+++ b/packages/visx-xychart/test/components/Axis.test.tsx
@@ -8,6 +8,7 @@ import getDataContext from '../mocks/getDataContext';
 import { addMock, removeMock } from '../mocks/svgMock';
 
 const series = { key: 'visx', data: [{}], xAccessor: () => 4, yAccessor: () => 7 };
+const emptySeries = { key: 'visx', data: [] as object[], xAccessor: () => 4, yAccessor: () => 7 };
 
 function setup(
   children: React.ReactNode,
@@ -127,5 +128,40 @@ describe('<BaseAxis />', () => {
     expect(VisxAxisTick).toHaveAttribute('stroke-width', `${tickLineProps.strokeWidth}`);
     expect(VisxAxisTick).toHaveAttribute('stroke', `${tickLineProps.stroke}`);
     expect(VisxAxisTick).toHaveAttribute('opacity', `${tickLineProps.opacity}`);
+  });
+
+  it('should not render when dataRegistry is empty', () => {
+    const { container } = setup(
+      <BaseAxis orientation="bottom" AxisComponent={() => <Axis orientation="bottom" />} />,
+      getDataContext(), // no entries registered
+    );
+    expect(container.querySelectorAll('.visx-axis')).toHaveLength(0);
+  });
+
+  it('should not render when all registered entries have empty data', () => {
+    const { container } = setup(
+      <BaseAxis orientation="bottom" AxisComponent={() => <Axis orientation="bottom" />} />,
+      getDataContext(emptySeries),
+    );
+    expect(container.querySelectorAll('.visx-axis')).toHaveLength(0);
+  });
+
+  it('should not call tickFormat when dataRegistry has no data', () => {
+    const tickFormat = vi.fn((v: number) => String(v));
+    setup(
+      <BaseAxis
+        orientation="bottom"
+        AxisComponent={() => <Axis orientation="bottom" tickFormat={tickFormat} />}
+      />,
+      getDataContext(), // no entries registered
+    );
+    expect(tickFormat).not.toHaveBeenCalled();
+  });
+
+  it('should render when registered entries have non-empty data', () => {
+    const { container } = setup(
+      <BaseAxis orientation="bottom" AxisComponent={() => <Axis orientation="bottom" />} />,
+    );
+    expect(container.querySelectorAll('.visx-axis')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary                                                                                                                           
                                                            
  Follow-up to #1979 — addresses Copilot review feedback and adds test coverage.

  - **Optional chaining:** replaced `dataRegistry && dataRegistry.keys().length > 0` with `(dataRegistry?.keys().length ?? 0) > 0` for a clean boolean expression
  - **Tightened guard:** `BaseAxis` now checks that at least one registered entry has non-empty `data`, not just that registry keys exist. This prevents rendering with the fallback `scaleLinear()` domain `[0, 1]` when entries are registered but contain empty data arrays
  - **Tests:** added 4 test cases covering empty registry, empty data arrays, `tickFormat` not called, and the positive render case    
  - **MIGRATION.md:** added `4.0.0-alpha.5` entry noting this as a breaking behavior change with migration guidance                    
                                                                                                                                       
  ## Test plan                                                                                                                         
                                                                                                                                       
  - [x] `vitest run packages/visx-xychart/test/components/Axis.test.tsx` — 14 tests pass                                               
  - [x] `tsc --noEmit` — no type errors

#### :boom: Breaking Changes                                                                                                         
                                                                                                                                       
  - `BaseAxis` now returns `null` until at least one registered data entry has non-empty `data`. Axes that previously rendered immediately with fallback `[0, 1]` ticks while data was loading will no longer appear until real data is available.                                                                                                                         
                                                            
  #### :memo: Documentation                                                                                                            
                                                            
  - Added `4.0.0-alpha.5` entry to MIGRATION.md with migration guidance for the rendering behavior change.                             
   
  #### :bug: Bug Fix                                                                                                                   
                                                            
  - Tightened `BaseAxis` empty-data guard to also check `entry.data.length > 0`, preventing `tickFormat` from receiving incorrect intermediate values when entries are registered with empty data arrays. Follow-up to #1979.
  - Used optional chaining (`dataRegistry?.keys().length`) for cleaner boolean expression.                                             
                                                            
  #### :house: Internal

  - Added 4 test cases for `BaseAxis`: empty registry, empty data arrays, `tickFormat` not called, and positive render case.