### PR TITLE
fix(responsive): use callback ref in useParentSize to fix 0×0 stuck dimensions (#1816)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,32 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
+## 4.0.0-alpha.6
+
+### `@visx/responsive` useParentSize callback ref fix
+
+`useParentSize` now uses a callback ref internally instead of `useRef`. This fixes a bug where the
+hook could permanently report 0×0 dimensions because `parentRef.current` was null when the
+`useEffect` first ran, and the dependency array never re-fired once the ref attached to the DOM
+([#1816](https://github.com/airbnb/visx/issues/1816)).
+
+The returned `parentRef` is now a callback ref (`(node: T | null) => void`) instead of a
+`RefObject<T | null>`. A new `node` property is also returned for direct access to the observed
+DOM element.
+
+**What you need to do:**
+
+- **Most consumers:** nothing — `<div ref={parentRef}>` works with both `RefObject` and callback
+  refs, and `ParentSize` component users are unaffected.
+- **If you access `parentRef.current` directly:** replace with the new `node` return value.
+
+  ```diff
+  - const { parentRef, width, height } = useParentSize();
+  - console.log(parentRef.current);
+  + const { parentRef, node, width, height } = useParentSize();
+  + console.log(node);
+  ```
+
 ## 4.0.0-alpha.5
 
 ### `@visx/xychart` axis rendering fix (breaking)

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -33,7 +33,7 @@ export default function ParentSize({
   resizeObserverPolyfill,
   ...restProps
 }: ParentSizeProps & Omit<HTMLAttributes<HTMLDivElement>, keyof ParentSizeProps>) {
-  const { parentRef, resize, ...dimensions } = useParentSize({
+  const { parentRef, node, resize, ...dimensions } = useParentSize({
     initialSize,
     debounceTime,
     ignoreDimensions,
@@ -45,7 +45,7 @@ export default function ParentSize({
     <div style={parentSizeStyles} ref={parentRef} className={className} {...restProps}>
       {children({
         ...dimensions,
-        ref: parentRef.current,
+        ref: node,
         resize,
       })}
     </div>

--- a/packages/visx-responsive/src/hooks/useParentSize.ts
+++ b/packages/visx-responsive/src/hooks/useParentSize.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/extensions -- explicit .js required for strict Node ESM
 import debounce from 'lodash/debounce.js';
-import type { RefObject } from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DebounceSettings, PrivateWindow, ResizeObserverPolyfill } from '../types';
 
 export type ParentSizeState = {
@@ -20,8 +19,9 @@ export type UseParentSizeConfig = {
   ignoreDimensions?: keyof ParentSizeState | (keyof ParentSizeState)[];
 } & DebounceSettings;
 
-type UseParentSizeResult<T extends HTMLElement = HTMLDivElement> = ParentSizeState & {
-  parentRef: RefObject<T | null>;
+export type UseParentSizeResult<T extends HTMLElement = HTMLDivElement> = ParentSizeState & {
+  parentRef: (node: T | null) => void;
+  node: T | null;
   resize: (state: ParentSizeState) => void;
 };
 
@@ -40,7 +40,10 @@ export default function useParentSize<T extends HTMLElement = HTMLDivElement>({
   enableDebounceLeadingCall = true,
   resizeObserverPolyfill,
 }: UseParentSizeConfig = {}): UseParentSizeResult<T> {
-  const parentRef = useRef<T>(null);
+  const [node, setNode] = useState<T | null>(null);
+  const parentRef = useCallback((el: T | null) => {
+    setNode(el);
+  }, []);
   const animationFrameID = useRef(0);
 
   const [state, setState] = useState<ParentSizeState>({ ...defaultInitialSize, ...initialSize });
@@ -64,6 +67,11 @@ export default function useParentSize<T extends HTMLElement = HTMLDivElement>({
   }, [debounceTime, enableDebounceLeadingCall, ignoreDimensions]);
 
   useEffect(() => {
+    if (!node) {
+      resize.cancel();
+      return;
+    }
+
     const LocalResizeObserver =
       resizeObserverPolyfill || (window as unknown as PrivateWindow).ResizeObserver;
 
@@ -75,14 +83,14 @@ export default function useParentSize<T extends HTMLElement = HTMLDivElement>({
         });
       });
     });
-    if (parentRef.current) observer.observe(parentRef.current);
+    observer.observe(node);
 
     return () => {
       window.cancelAnimationFrame(animationFrameID.current);
       observer.disconnect();
       resize.cancel();
     };
-  }, [resize, resizeObserverPolyfill]);
+  }, [node, resize, resizeObserverPolyfill]);
 
-  return { parentRef, resize, ...state };
+  return { parentRef, node, resize, ...state };
 }

--- a/packages/visx-responsive/src/index.ts
+++ b/packages/visx-responsive/src/index.ts
@@ -6,7 +6,11 @@ export type { WithParentSizeProvidedProps } from './enhancers/withParentSize';
 export { default as withScreenSize } from './enhancers/withScreenSize';
 export type { WithScreenSizeProvidedProps } from './enhancers/withScreenSize';
 export { default as useParentSize } from './hooks/useParentSize';
-export type { UseParentSizeConfig, UseParentSizeResult, ParentSizeState } from './hooks/useParentSize';
+export type {
+  UseParentSizeConfig,
+  UseParentSizeResult,
+  ParentSizeState,
+} from './hooks/useParentSize';
 export { default as useScreenSize } from './hooks/useScreenSize';
 export type { UseScreenSizeConfig } from './hooks/useScreenSize';
 

--- a/packages/visx-responsive/src/index.ts
+++ b/packages/visx-responsive/src/index.ts
@@ -6,7 +6,7 @@ export type { WithParentSizeProvidedProps } from './enhancers/withParentSize';
 export { default as withScreenSize } from './enhancers/withScreenSize';
 export type { WithScreenSizeProvidedProps } from './enhancers/withScreenSize';
 export { default as useParentSize } from './hooks/useParentSize';
-export type { UseParentSizeConfig, ParentSizeState } from './hooks/useParentSize';
+export type { UseParentSizeConfig, UseParentSizeResult, ParentSizeState } from './hooks/useParentSize';
 export { default as useScreenSize } from './hooks/useScreenSize';
 export type { UseScreenSizeConfig } from './hooks/useScreenSize';
 

--- a/packages/visx-responsive/test/ParentSize.test.tsx
+++ b/packages/visx-responsive/test/ParentSize.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ResizeObserver } from '@juggle/resize-observer';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { ParentSize } from '../src';
 
 describe('<ParentSize />', () => {
@@ -14,5 +15,49 @@ describe('<ParentSize />', () => {
       </ParentSize>,
     );
     expect(wrapper.findByTestId('test')).not.toBeNull();
+  });
+
+  it('should report dimensions to children after ResizeObserver fires', () => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    type ROEntry = { contentRect: { left: number; top: number; width: number; height: number } };
+    type ROCallback = (entries: ROEntry[]) => void;
+    let observerCallback: ROCallback | null = null;
+
+    class MockResizeObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      constructor(cb: ROCallback) {
+        observerCallback = cb;
+      }
+    }
+
+    let reportedDimensions = { width: -1, height: -1, top: -1, left: -1 };
+
+    render(
+      <ParentSize resizeObserverPolyfill={MockResizeObserver as any}>
+        {({ width, height, top, left }) => {
+          reportedDimensions = { width, height, top, left };
+          return <div data-testid="child" />;
+        }}
+      </ParentSize>,
+    );
+
+    // Simulate the ResizeObserver firing with dimensions
+    act(() => {
+      observerCallback?.([{ contentRect: { width: 800, height: 600, top: 0, left: 0 } }]);
+    });
+
+    expect(reportedDimensions.width).toBe(800);
+    expect(reportedDimensions.height).toBe(600);
+
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 });

--- a/packages/visx-responsive/test/ParentSize.test.tsx
+++ b/packages/visx-responsive/test/ParentSize.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { act, render } from '@testing-library/react';
 import { ParentSize } from '../src';
 
 describe('<ParentSize />', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it('should be defined', () => {
     expect(ParentSize).toBeDefined();
   });
@@ -56,8 +61,5 @@ describe('<ParentSize />', () => {
 
     expect(reportedDimensions.width).toBe(800);
     expect(reportedDimensions.height).toBe(600);
-
-    vi.useRealTimers();
-    vi.restoreAllMocks();
   });
 });

--- a/packages/visx-responsive/test/ParentSize.test.tsx
+++ b/packages/visx-responsive/test/ParentSize.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { vi, describe, it, expect, afterEach } from 'vitest';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { act, render } from '@testing-library/react';
 import { ParentSize } from '../src';
+import type { ResizeObserverPolyfill } from '../src/types';
 
 describe('<ParentSize />', () => {
   afterEach(() => {
@@ -46,7 +46,7 @@ describe('<ParentSize />', () => {
     let reportedDimensions = { width: -1, height: -1, top: -1, left: -1 };
 
     render(
-      <ParentSize resizeObserverPolyfill={MockResizeObserver as any}>
+      <ParentSize resizeObserverPolyfill={MockResizeObserver as unknown as ResizeObserverPolyfill}>
         {({ width, height, top, left }) => {
           reportedDimensions = { width, height, top, left };
           return <div data-testid="child" />;

--- a/packages/visx-responsive/test/useParentSize.test.tsx
+++ b/packages/visx-responsive/test/useParentSize.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import useParentSize from '../src/hooks/useParentSize';
+
+// --- Mock ResizeObserver class (newable) ---
+type ROEntry = { contentRect: { left: number; top: number; width: number; height: number } };
+type ROCallback = (entries: ROEntry[]) => void;
+
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = [];
+  callback: ROCallback;
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(cb: ROCallback) {
+    this.callback = cb;
+    MockResizeObserver.instances.push(this);
+  }
+
+  /** Helper: simulate the observer firing */
+  trigger(rect: { width: number; height: number; top?: number; left?: number }) {
+    this.callback([{ contentRect: { left: 0, top: 0, ...rect } }]);
+  }
+}
+
+// --- Tests ---
+
+describe('useParentSize', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Make rAF execute synchronously for predictable tests
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    MockResizeObserver.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('should return initial dimensions of 0x0 by default', () => {
+    const { result } = renderHook(() =>
+      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+    );
+
+    expect(result.current.width).toBe(0);
+    expect(result.current.height).toBe(0);
+    expect(result.current.top).toBe(0);
+    expect(result.current.left).toBe(0);
+  });
+
+  it('should respect initialSize', () => {
+    const { result } = renderHook(() =>
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as any,
+        initialSize: { width: 100, height: 50 },
+      }),
+    );
+
+    expect(result.current.width).toBe(100);
+    expect(result.current.height).toBe(50);
+  });
+
+  it('should observe the element when parentRef callback is called', () => {
+    const { result } = renderHook(() =>
+      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+    );
+
+    const div = document.createElement('div');
+
+    // Attach the ref — this should trigger observation
+    act(() => {
+      result.current.parentRef(div);
+    });
+
+    const observer = MockResizeObserver.instances.at(-1)!;
+    expect(observer.observe).toHaveBeenCalledWith(div);
+  });
+
+  it('should update dimensions when ResizeObserver fires', () => {
+    const { result } = renderHook(() =>
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as any,
+        enableDebounceLeadingCall: true,
+      }),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.parentRef(div);
+    });
+
+    const observer = MockResizeObserver.instances.at(-1)!;
+
+    // Simulate a resize observation
+    act(() => {
+      observer.trigger({ width: 400, height: 300, top: 10, left: 20 });
+    });
+
+    expect(result.current.width).toBe(400);
+    expect(result.current.height).toBe(300);
+    expect(result.current.top).toBe(10);
+    expect(result.current.left).toBe(20);
+  });
+
+  it('should disconnect observer on unmount', () => {
+    const { result, unmount } = renderHook(() =>
+      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.parentRef(div);
+    });
+
+    const observer = MockResizeObserver.instances.at(-1)!;
+
+    unmount();
+
+    expect(observer.disconnect).toHaveBeenCalled();
+  });
+
+  it('should re-observe when node changes', () => {
+    const { result } = renderHook(() =>
+      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+    );
+
+    const div1 = document.createElement('div');
+    const div2 = document.createElement('div');
+
+    // Attach first element
+    act(() => {
+      result.current.parentRef(div1);
+    });
+
+    const firstObserver = MockResizeObserver.instances.at(-1)!;
+    expect(firstObserver.observe).toHaveBeenCalledWith(div1);
+
+    // Detach then attach second element — simulates remount
+    act(() => {
+      result.current.parentRef(null);
+    });
+    act(() => {
+      result.current.parentRef(div2);
+    });
+
+    expect(firstObserver.disconnect).toHaveBeenCalled();
+    const lastObserver = MockResizeObserver.instances.at(-1)!;
+    expect(lastObserver.observe).toHaveBeenCalledWith(div2);
+  });
+
+  it('should return the current node', () => {
+    const { result } = renderHook(() =>
+      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+    );
+
+    expect(result.current.node).toBeNull();
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.parentRef(div);
+    });
+
+    expect(result.current.node).toBe(div);
+  });
+});

--- a/packages/visx-responsive/test/useParentSize.test.tsx
+++ b/packages/visx-responsive/test/useParentSize.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import useParentSize from '../src/hooks/useParentSize';
+import type { ResizeObserverPolyfill } from '../src/types';
 
 // --- Mock ResizeObserver class (newable) ---
 type ROEntry = { contentRect: { left: number; top: number; width: number; height: number } };
@@ -46,7 +46,9 @@ describe('useParentSize', () => {
 
   it('should return initial dimensions of 0x0 by default', () => {
     const { result } = renderHook(() =>
-      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+      }),
     );
 
     expect(result.current.width).toBe(0);
@@ -58,7 +60,7 @@ describe('useParentSize', () => {
   it('should respect initialSize', () => {
     const { result } = renderHook(() =>
       useParentSize({
-        resizeObserverPolyfill: MockResizeObserver as any,
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
         initialSize: { width: 100, height: 50 },
       }),
     );
@@ -69,7 +71,9 @@ describe('useParentSize', () => {
 
   it('should observe the element when parentRef callback is called', () => {
     const { result } = renderHook(() =>
-      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+      }),
     );
 
     const div = document.createElement('div');
@@ -86,7 +90,7 @@ describe('useParentSize', () => {
   it('should update dimensions when ResizeObserver fires', () => {
     const { result } = renderHook(() =>
       useParentSize({
-        resizeObserverPolyfill: MockResizeObserver as any,
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
         enableDebounceLeadingCall: true,
       }),
     );
@@ -111,7 +115,9 @@ describe('useParentSize', () => {
 
   it('should disconnect observer on unmount', () => {
     const { result, unmount } = renderHook(() =>
-      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+      }),
     );
 
     const div = document.createElement('div');
@@ -128,7 +134,9 @@ describe('useParentSize', () => {
 
   it('should re-observe when node changes', () => {
     const { result } = renderHook(() =>
-      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+      }),
     );
 
     const div1 = document.createElement('div');
@@ -157,7 +165,9 @@ describe('useParentSize', () => {
 
   it('should return the current node', () => {
     const { result } = renderHook(() =>
-      useParentSize({ resizeObserverPolyfill: MockResizeObserver as any }),
+      useParentSize({
+        resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+      }),
     );
 
     expect(result.current.node).toBeNull();


### PR DESCRIPTION
## Summary

- `useParentSize` could permanently report 0×0 because `parentRef.current` was null when the `useEffect` first ran, and the dependency array `[resize, resizeObserverPolyfill]` never re-fired once the ref attached to the DOM
- Replace `useRef` with `useState` + `useCallback` callback ref so the ResizeObserver attaches reactively when the DOM node mounts
- Add `node` to the hook return value for direct access to the observed element
- Export `UseParentSizeResult` type

Fixes #1816

## Test plan

- [x] New `useParentSize` unit tests (7): observer attachment, dimension updates, cleanup, remount, initial state
- [x] New `ParentSize` integration test: dimensions propagate to children after ResizeObserver fires
- [x] Existing tests pass unchanged

#### :boom: Breaking Changes

- `useParentSize` `parentRef` is now a callback ref (`(node: T | null) => void`) instead of a `RefObject`. `<div ref={parentRef}>` usage is unchanged — both are valid React ref types.

#### :rocket: Enhancements

- `useParentSize` now returns `node: T | null` for direct access to the observed DOM element
- Export `UseParentSizeResult` type from `@visx/responsive`

#### :bug: Bug Fix

- `useParentSize` could permanently report 0×0 because `parentRef.current` was null when the `useEffect` first ran, and the dependency array `[resize, resizeObserverPolyfill]` never re-fired once the ref attached to the DOM. Replaced `useRef` with `useState` + `useCallback` callback ref so the ResizeObserver attaches reactively when the DOM node mounts. Fixes #1816

#### :house: Internal

- Added 7 unit tests for `useParentSize` (observer attachment, dimension updates, cleanup, remount, initial state)
- Added `ParentSize` integration test verifying dimensions propagate to children after ResizeObserver fires