### PR TITLE
fix(responsive): prevent infinite height growth in flex/grid layouts (#881, #1014)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,37 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
+## 4.0.0-alpha.7
+
+### `@visx/responsive` ParentSize flex/grid infinite growth fix
+
+`ParentSize` and `withParentSize` now render a two-div structure to prevent infinite height growth
+in flex and grid layouts ([#881](https://github.com/airbnb/visx/issues/881),
+[#1014](https://github.com/airbnb/visx/issues/1014)).
+
+Previously, the component rendered a single wrapper `<div style="width: 100%; height: 100%">`. In
+flex or grid containers, a child SVG's intrinsic height could grow the wrapper, triggering
+ResizeObserver in a feedback loop.
+
+The new structure uses an outer `<div style="width: 100%; height: 100%; position: relative">` and
+an inner `<div style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; overflow: hidden">`
+that holds the ResizeObserver and children. Since the inner div is absolutely positioned, children's
+intrinsic sizes cannot grow the outer container.
+
+**What you need to do:**
+
+- **Most consumers:** nothing — the component API is unchanged and the visual result should be
+  identical or better (no more infinite growth).
+- **If you rely on the wrapper div's exact DOM structure** (e.g., querying it in tests or applying
+  CSS that targets a single wrapper div): the wrapper is now two nested divs. `className`, `style`,
+  and all other HTML attributes still apply to the outer div.
+- **If you use the deprecated `parentSizeStyles` prop:** it still works and applies to the outer div,
+  but `position: relative` is prepended to ensure the inner absolutely-positioned measurement div
+  works correctly. If you explicitly set `position` in your custom styles, your value takes
+  precedence.
+- **If you use `withParentSize`:** the same two-div structure applies. The container div is no longer
+  a single `<div style="width: 100%; height: 100%">`.
+
 ## 4.0.0-alpha.6
 
 ### `@visx/responsive` useParentSize callback ref fix

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -20,7 +20,16 @@ export type ParentSizeProps = {
   children: (args: ParentSizeProvidedProps) => ReactNode;
 } & UseParentSizeConfig;
 
-const defaultParentSizeStyles = { width: '100%', height: '100%' };
+const defaultOuterStyles: CSSProperties = { width: '100%', height: '100%', position: 'relative' };
+
+const measurementStyles: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  overflow: 'hidden',
+};
 
 export default function ParentSize({
   className,
@@ -28,9 +37,10 @@ export default function ParentSize({
   debounceTime,
   ignoreDimensions,
   initialSize,
-  parentSizeStyles = defaultParentSizeStyles,
+  parentSizeStyles,
   enableDebounceLeadingCall = true,
   resizeObserverPolyfill,
+  style,
   ...restProps
 }: ParentSizeProps & Omit<HTMLAttributes<HTMLDivElement>, keyof ParentSizeProps>) {
   const { parentRef, node, resize, ...dimensions } = useParentSize({
@@ -41,13 +51,19 @@ export default function ParentSize({
     resizeObserverPolyfill,
   });
 
+  const outerStyle: CSSProperties = parentSizeStyles
+    ? { position: 'relative', ...parentSizeStyles }
+    : { ...defaultOuterStyles, ...style };
+
   return (
-    <div style={parentSizeStyles} ref={parentRef} className={className} {...restProps}>
-      {children({
-        ...dimensions,
-        ref: node,
-        resize,
-      })}
+    <div style={outerStyle} className={className} {...restProps}>
+      <div style={measurementStyles} ref={parentRef}>
+        {children({
+          ...dimensions,
+          ref: node,
+          resize,
+        })}
+      </div>
     </div>
   );
 }

--- a/packages/visx-responsive/src/components/ParentSize.tsx
+++ b/packages/visx-responsive/src/components/ParentSize.tsx
@@ -8,12 +8,13 @@ export type ParentSizeProvidedProps = ParentSizeState & {
 };
 
 export type ParentSizeProps = {
-  /** Optional `className` to add to the parent `div` wrapper used for size measurement. */
+  /** Optional `className` to add to the outer wrapper `div`. */
   className?: string;
   /**
-   * @deprecated - use `style` prop as all other props are passed directly to the parent `div`.
+   * @deprecated - use `style` prop as all other props are passed directly to the outer `div`.
    * @TODO remove in the next major version.
-   * Optional `style` object to apply to the parent `div` wrapper used for size measurement.
+   * Optional `style` object to apply to the outer wrapper `div`. Merged with default styles
+   * (`width: 100%; height: 100%; position: relative`); your values take precedence.
    * */
   parentSizeStyles?: CSSProperties;
   /** Child render function `({ width, height, top, left, ref, resize }) => ReactNode`. */
@@ -52,7 +53,7 @@ export default function ParentSize({
   });
 
   const outerStyle: CSSProperties = parentSizeStyles
-    ? { position: 'relative', ...parentSizeStyles }
+    ? { position: 'relative', ...parentSizeStyles, ...style }
     : { ...defaultOuterStyles, ...style };
 
   return (

--- a/packages/visx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/visx-responsive/src/enhancers/withParentSize.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/extensions -- explicit .js required for strict Node ESM
 import debounce from 'lodash/debounce.js';
 import { Component } from 'react';
-import type { ComponentType } from 'react';
+import type { ComponentType, CSSProperties } from 'react';
 import type {
   DebounceSettings,
   Simplify,
@@ -10,7 +10,20 @@ import type {
   ResizeObserver,
 } from '../types';
 
-const CONTAINER_STYLES = { width: '100%', height: '100%' };
+const CONTAINER_STYLES: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  position: 'relative',
+};
+
+const MEASUREMENT_STYLES: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  overflow: 'hidden',
+};
 
 /**
  * @deprecated
@@ -98,14 +111,16 @@ export default function withParentSize<P extends WithParentSizeProvidedProps>(
       const { initialWidth, initialHeight } = this.props;
       const { parentWidth = initialWidth, parentHeight = initialHeight } = this.state;
       return (
-        <div style={CONTAINER_STYLES} ref={this.setRef}>
-          {parentWidth != null && parentHeight != null && (
-            <BaseComponent
-              parentWidth={parentWidth}
-              parentHeight={parentHeight}
-              {...(this.props as P)}
-            />
-          )}
+        <div style={CONTAINER_STYLES}>
+          <div style={MEASUREMENT_STYLES} ref={this.setRef}>
+            {parentWidth != null && parentHeight != null && (
+              <BaseComponent
+                parentWidth={parentWidth}
+                parentHeight={parentHeight}
+                {...(this.props as P)}
+              />
+            )}
+          </div>
         </div>
       );
     }

--- a/packages/visx-responsive/test/ParentSize.test.tsx
+++ b/packages/visx-responsive/test/ParentSize.test.tsx
@@ -62,4 +62,114 @@ describe('<ParentSize />', () => {
     expect(reportedDimensions.width).toBe(800);
     expect(reportedDimensions.height).toBe(600);
   });
+
+  describe('two-div structure', () => {
+    it('renders an outer div with position: relative and 100% dimensions', () => {
+      const { container } = render(
+        <ParentSize resizeObserverPolyfill={ResizeObserver}>
+          {() => <div data-testid="child" />}
+        </ParentSize>,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.style.position).toBe('relative');
+      expect(outer.style.width).toBe('100%');
+      expect(outer.style.height).toBe('100%');
+    });
+
+    it('renders an inner measurement div with position: absolute and full coverage', () => {
+      const { container } = render(
+        <ParentSize resizeObserverPolyfill={ResizeObserver}>
+          {() => <div data-testid="child" />}
+        </ParentSize>,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      const inner = outer.firstElementChild as HTMLElement;
+      expect(inner.style.position).toBe('absolute');
+      expect(inner.style.top).toBe('0px');
+      expect(inner.style.right).toBe('0px');
+      expect(inner.style.bottom).toBe('0px');
+      expect(inner.style.left).toBe('0px');
+      expect(inner.style.overflow).toBe('hidden');
+    });
+
+    it('attaches parentRef to the inner measurement div', () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0);
+        return 0;
+      });
+      vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+      let observedElement: Element | null = null;
+
+      class MockResizeObserver {
+        callback: unknown;
+        observe = vi.fn((el: Element) => {
+          observedElement = el;
+        });
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+        constructor(cb: unknown) {
+          this.callback = cb;
+        }
+      }
+
+      const { container } = render(
+        <ParentSize
+          resizeObserverPolyfill={MockResizeObserver as unknown as ResizeObserverPolyfill}
+        >
+          {() => <div />}
+        </ParentSize>,
+      );
+
+      const outer = container.firstElementChild as HTMLElement;
+      const inner = outer.firstElementChild as HTMLElement;
+      expect(observedElement).toBe(inner);
+    });
+
+    it('applies className and restProps to the outer div', () => {
+      const { container } = render(
+        <ParentSize
+          resizeObserverPolyfill={ResizeObserver}
+          className="my-class"
+          data-testid="parent-wrapper"
+          id="outer"
+        >
+          {() => <div />}
+        </ParentSize>,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.className).toBe('my-class');
+      expect(outer.getAttribute('data-testid')).toBe('parent-wrapper');
+      expect(outer.id).toBe('outer');
+    });
+
+    it('merges custom style prop into the outer div styles', () => {
+      const { container } = render(
+        <ParentSize resizeObserverPolyfill={ResizeObserver} style={{ background: 'red' }}>
+          {() => <div />}
+        </ParentSize>,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.style.position).toBe('relative');
+      expect(outer.style.width).toBe('100%');
+      expect(outer.style.background).toBe('red');
+    });
+
+    it('allows parentSizeStyles to override the outer div styles', () => {
+      const { container } = render(
+        <ParentSize
+          resizeObserverPolyfill={ResizeObserver}
+          parentSizeStyles={{ width: '50%', height: '300px' }}
+        >
+          {() => <div />}
+        </ParentSize>,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.style.width).toBe('50%');
+      expect(outer.style.height).toBe('300px');
+      // position: relative is still applied so inner absolute div works
+      expect(outer.style.position).toBe('relative');
+    });
+  });
 });

--- a/packages/visx-responsive/test/ParentSize.test.tsx
+++ b/packages/visx-responsive/test/ParentSize.test.tsx
@@ -171,5 +171,22 @@ describe('<ParentSize />', () => {
       // position: relative is still applied so inner absolute div works
       expect(outer.style.position).toBe('relative');
     });
+
+    it('merges style with parentSizeStyles when both are provided', () => {
+      const { container } = render(
+        <ParentSize
+          resizeObserverPolyfill={ResizeObserver}
+          parentSizeStyles={{ width: '50%', height: '300px' }}
+          style={{ background: 'blue' }}
+        >
+          {() => <div />}
+        </ParentSize>,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.style.width).toBe('50%');
+      expect(outer.style.height).toBe('300px');
+      expect(outer.style.background).toBe('blue');
+      expect(outer.style.position).toBe('relative');
+    });
   });
 });

--- a/packages/visx-responsive/test/withParentSize.test.tsx
+++ b/packages/visx-responsive/test/withParentSize.test.tsx
@@ -1,8 +1,8 @@
+import { vi, describe, it, test, expect, afterEach } from 'vitest';
 import { ResizeObserver } from '@juggle/resize-observer';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
-import React from 'react';
-import type { WithParentSizeProvidedProps } from '../src';
+import type { WithParentSizeProvidedProps, ResizeObserverPolyfill } from '../src';
 import { withParentSize } from '../src';
 
 interface ComponentProps extends WithParentSizeProvidedProps {
@@ -17,6 +17,11 @@ function Component({ parentWidth, parentHeight, role }: ComponentProps) {
 }
 
 describe('withParentSize', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   test('it should be defined', () => {
     expect(withParentSize).toBeDefined();
   });
@@ -33,5 +38,61 @@ describe('withParentSize', () => {
 
     const RenderedComponent = getByTestId('Component');
     expect(RenderedComponent).toHaveStyle('width: 200px; height: 200px');
+  });
+
+  describe('two-div structure', () => {
+    it('renders an outer div with position: relative and 100% dimensions', () => {
+      const WrappedComponent = withParentSize(Component, ResizeObserver);
+      const { container } = render(
+        <WrappedComponent role="img" initialWidth={200} initialHeight={200} />,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.style.position).toBe('relative');
+      expect(outer.style.width).toBe('100%');
+      expect(outer.style.height).toBe('100%');
+    });
+
+    it('renders an inner measurement div with position: absolute and full coverage', () => {
+      const WrappedComponent = withParentSize(Component, ResizeObserver);
+      const { container } = render(
+        <WrappedComponent role="img" initialWidth={200} initialHeight={200} />,
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      const inner = outer.firstElementChild as HTMLElement;
+      expect(inner.style.position).toBe('absolute');
+      expect(inner.style.top).toBe('0px');
+      expect(inner.style.right).toBe('0px');
+      expect(inner.style.bottom).toBe('0px');
+      expect(inner.style.left).toBe('0px');
+      expect(inner.style.overflow).toBe('hidden');
+    });
+
+    it('attaches ResizeObserver to the inner measurement div', () => {
+      let observedElement: Element | null = null;
+
+      class MockResizeObserver {
+        callback: unknown;
+        observe = vi.fn((el: Element) => {
+          observedElement = el;
+        });
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+        constructor(cb: unknown) {
+          this.callback = cb;
+        }
+      }
+
+      const WrappedComponent = withParentSize(
+        Component,
+        MockResizeObserver as unknown as ResizeObserverPolyfill,
+      );
+      const { container } = render(
+        <WrappedComponent role="img" initialWidth={200} initialHeight={200} />,
+      );
+
+      const outer = container.firstElementChild as HTMLElement;
+      const inner = outer.firstElementChild as HTMLElement;
+      expect(observedElement).toBe(inner);
+    });
   });
 });


### PR DESCRIPTION
### Summary

- ParentSize and withParentSize now render a two-div structure (outer position: relative, inner position: absolute with overflow: hidden) so that children's intrinsic sizes can no longer grow the measurement container and trigger a ResizeObserver feedback loop
- className, style, and all HTML attributes still apply to the outer div; the inner measurement div is an implementation detail
- parentSizeStyles (deprecated) still works — position: relative is prepended so the inner absolute div always has a positioning context

Fixes #881, fixes #1014

### Breaking change

The wrapper div is now two nested divs instead of one. Consumers who target the wrapper's exact DOM structure in tests or CSS may need to adjust. See the 4.0.0-alpha.7 section in MIGRATION.md for details.

### Test plan

- New tests for two-div structure (outer styles, inner styles, ref attachment, className/restProps placement, style merging, parentSizeStyles backward compat)
- Existing tests still pass (dimension reporting, hook behavior)
- ESLint, Prettier, TypeScript all clean
- Visual check: run yarn dev:demo and verify /gallery page (50+ ParentSize instances in flex containers), /responsive demo, and flex-heavy sandboxes (/chord, /bars, /zoom-i, /wordcloud)

#### :boom: Breaking Changes

- ParentSize and withParentSize now render two nested divs (outer position: relative, inner position: absolute; overflow: hidden) instead of a single wrapper div. Consumers targeting the wrapper's exact DOM structure in tests or CSS may need to adjust. See the 4.0.0-alpha.7 section in MIGRATION.md.

#### :memo: Documentation

- Added 4.0.0-alpha.7 migration guide section in MIGRATION.md covering the new two-div structure, parentSizeStyles backward compat, and withParentSize changes.

#### :bug: Bug Fix

- ParentSize and withParentSize no longer trigger an infinite ResizeObserver feedback loop in flex/grid layouts. The inner absolutely-positioned measurement div decouples children's intrinsic sizes from the container, breaking the growth cycle. Fixes #881, fixes #1014.

#### :house: Internal

- Added tests for two-div DOM structure, ref attachment to inner div, className/restProps placement on outer div, style merging, and parentSizeStyles backward compat.
