### PR TITLE
feat(responsive): support custom ref in useParentSize

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,14 +7,13 @@ cumulative — if you're jumping several versions, apply the steps from each sec
 
 ### `@visx/responsive` useParentSize external ref support
 
-`useParentSize` now accepts an optional `ref` in its config object. If provided, the hook forwards
-the observed DOM node to both its internal state and the external ref, eliminating the need for a
-wrapper div when you already have a ref on the container element
-([#485](https://github.com/airbnb/visx/issues/485)).
+`useParentSize` now accepts an optional `externalRef` in its config object. If provided, the hook
+forwards the observed DOM node to both its internal state and the external ref, eliminating the need
+for a wrapper div when you already have a ref on the container element.
 
 ```tsx
 const myRef = useRef<HTMLDivElement>(null);
-const { parentRef, width, height } = useParentSize({ ref: myRef });
+const { parentRef, width, height } = useParentSize({ externalRef: myRef });
 
 return <div ref={parentRef}>...</div>;
 // myRef.current is also set to the div element
@@ -24,10 +23,10 @@ Both `RefObject` and callback refs are supported.
 
 **What you need to do:**
 
-- **Most consumers:** nothing — this is an additive, non-breaking change. Existing usage without a
-  `ref` argument is unchanged.
+- **Most consumers:** nothing — this is an additive, non-breaking change. Existing usage without an
+  `externalRef` argument is unchanged.
 - **If you were adding a wrapper div to combine your own ref with `parentRef`:** you can now remove
-  the wrapper and pass your ref directly via the `ref` option.
+  the wrapper and pass your ref directly via the `externalRef` option.
 
 ## 4.0.0-alpha.7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,32 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
+## 4.0.0-alpha.8
+
+### `@visx/responsive` useParentSize external ref support
+
+`useParentSize` now accepts an optional `ref` in its config object. If provided, the hook forwards
+the observed DOM node to both its internal state and the external ref, eliminating the need for a
+wrapper div when you already have a ref on the container element
+([#485](https://github.com/airbnb/visx/issues/485)).
+
+```tsx
+const myRef = useRef<HTMLDivElement>(null);
+const { parentRef, width, height } = useParentSize({ ref: myRef });
+
+return <div ref={parentRef}>...</div>;
+// myRef.current is also set to the div element
+```
+
+Both `RefObject` and callback refs are supported.
+
+**What you need to do:**
+
+- **Most consumers:** nothing — this is an additive, non-breaking change. Existing usage without a
+  `ref` argument is unchanged.
+- **If you were adding a wrapper div to combine your own ref with `parentRef`:** you can now remove
+  the wrapper and pass your ref directly via the `ref` option.
+
 ## 4.0.0-alpha.7
 
 ### `@visx/responsive` ParentSize flex/grid infinite growth fix

--- a/packages/visx-responsive/src/hooks/useParentSize.ts
+++ b/packages/visx-responsive/src/hooks/useParentSize.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/extensions -- explicit .js required for strict Node ESM
 import debounce from 'lodash/debounce.js';
+import type { Ref } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DebounceSettings, PrivateWindow, ResizeObserverPolyfill } from '../types';
 
@@ -10,13 +11,15 @@ export type ParentSizeState = {
   left: number;
 };
 
-export type UseParentSizeConfig = {
+export type UseParentSizeConfig<T extends HTMLElement = HTMLDivElement> = {
   /** Initial size before measuring the parent. */
   initialSize?: Partial<ParentSizeState>;
   /** Optionally inject a ResizeObserver polyfill, else this *must* be globally available. */
   resizeObserverPolyfill?: ResizeObserverPolyfill;
   /** Optional dimensions provided won't trigger a state change when changed. */
   ignoreDimensions?: keyof ParentSizeState | (keyof ParentSizeState)[];
+  /** Optional external ref that also receives the measured DOM node. */
+  ref?: Ref<T>;
 } & DebounceSettings;
 
 export type UseParentSizeResult<T extends HTMLElement = HTMLDivElement> = ParentSizeState & {
@@ -33,17 +36,29 @@ const defaultInitialSize: ParentSizeState = {
   left: 0,
 };
 
-export default function useParentSize<T extends HTMLElement = HTMLDivElement>({
-  initialSize = defaultInitialSize,
-  debounceTime = 300,
-  ignoreDimensions = defaultIgnoreDimensions,
-  enableDebounceLeadingCall = true,
-  resizeObserverPolyfill,
-}: UseParentSizeConfig = {}): UseParentSizeResult<T> {
+export default function useParentSize<T extends HTMLElement = HTMLDivElement>(
+  {
+    initialSize = defaultInitialSize,
+    debounceTime = 300,
+    ignoreDimensions = defaultIgnoreDimensions,
+    enableDebounceLeadingCall = true,
+    resizeObserverPolyfill,
+    ref: externalRef,
+  }: UseParentSizeConfig<T> = {} as UseParentSizeConfig<T>,
+): UseParentSizeResult<T> {
   const [node, setNode] = useState<T | null>(null);
-  const parentRef = useCallback((el: T | null) => {
-    setNode(el);
-  }, []);
+  const parentRef = useCallback(
+    (el: T | null) => {
+      setNode(el);
+      if (typeof externalRef === 'function') {
+        externalRef(el);
+      } else if (externalRef != null) {
+        // eslint-disable-next-line no-param-reassign -- standard ref-merging pattern
+        (externalRef as { current: T | null }).current = el;
+      }
+    },
+    [externalRef],
+  );
   const animationFrameID = useRef(0);
 
   const [state, setState] = useState<ParentSizeState>({ ...defaultInitialSize, ...initialSize });

--- a/packages/visx-responsive/src/hooks/useParentSize.ts
+++ b/packages/visx-responsive/src/hooks/useParentSize.ts
@@ -19,7 +19,7 @@ export type UseParentSizeConfig<T extends HTMLElement = HTMLDivElement> = {
   /** Optional dimensions provided won't trigger a state change when changed. */
   ignoreDimensions?: keyof ParentSizeState | (keyof ParentSizeState)[];
   /** Optional external ref that also receives the measured DOM node. */
-  ref?: Ref<T>;
+  externalRef?: Ref<T>;
 } & DebounceSettings;
 
 export type UseParentSizeResult<T extends HTMLElement = HTMLDivElement> = ParentSizeState & {
@@ -36,16 +36,14 @@ const defaultInitialSize: ParentSizeState = {
   left: 0,
 };
 
-export default function useParentSize<T extends HTMLElement = HTMLDivElement>(
-  {
-    initialSize = defaultInitialSize,
-    debounceTime = 300,
-    ignoreDimensions = defaultIgnoreDimensions,
-    enableDebounceLeadingCall = true,
-    resizeObserverPolyfill,
-    ref: externalRef,
-  }: UseParentSizeConfig<T> = {} as UseParentSizeConfig<T>,
-): UseParentSizeResult<T> {
+export default function useParentSize<T extends HTMLElement = HTMLDivElement>({
+  initialSize = defaultInitialSize,
+  debounceTime = 300,
+  ignoreDimensions = defaultIgnoreDimensions,
+  enableDebounceLeadingCall = true,
+  resizeObserverPolyfill,
+  externalRef,
+}: UseParentSizeConfig<T> = {}): UseParentSizeResult<T> {
   const [node, setNode] = useState<T | null>(null);
   const parentRef = useCallback(
     (el: T | null) => {

--- a/packages/visx-responsive/test/useParentSize.test.tsx
+++ b/packages/visx-responsive/test/useParentSize.test.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import useParentSize from '../src/hooks/useParentSize';
@@ -178,5 +179,152 @@ describe('useParentSize', () => {
     });
 
     expect(result.current.node).toBe(div);
+  });
+
+  describe('external ref support', () => {
+    it('should forward the node to an external RefObject', () => {
+      const externalRef = { current: null } satisfies RefObject<HTMLDivElement | null>;
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: externalRef,
+        }),
+      );
+
+      const div = document.createElement('div');
+      act(() => {
+        result.current.parentRef(div);
+      });
+
+      expect(externalRef.current).toBe(div);
+    });
+
+    it('should clear external RefObject when parentRef is called with null', () => {
+      const externalRef = { current: null } satisfies RefObject<HTMLDivElement | null>;
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: externalRef,
+        }),
+      );
+
+      const div = document.createElement('div');
+      act(() => {
+        result.current.parentRef(div);
+      });
+      act(() => {
+        result.current.parentRef(null);
+      });
+
+      expect(externalRef.current).toBeNull();
+    });
+
+    it('should call an external callback ref with the node', () => {
+      const callbackRef = vi.fn();
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: callbackRef,
+        }),
+      );
+
+      const div = document.createElement('div');
+      act(() => {
+        result.current.parentRef(div);
+      });
+
+      expect(callbackRef).toHaveBeenCalledWith(div);
+    });
+
+    it('should call external callback ref with null on detach', () => {
+      const callbackRef = vi.fn();
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: callbackRef,
+        }),
+      );
+
+      const div = document.createElement('div');
+      act(() => {
+        result.current.parentRef(div);
+      });
+      act(() => {
+        result.current.parentRef(null);
+      });
+
+      expect(callbackRef).toHaveBeenCalledWith(null);
+    });
+
+    it('should still set the internal node when an external ref is provided', () => {
+      const externalRef = { current: null } satisfies RefObject<HTMLDivElement | null>;
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: externalRef,
+        }),
+      );
+
+      const div = document.createElement('div');
+      act(() => {
+        result.current.parentRef(div);
+      });
+
+      expect(result.current.node).toBe(div);
+    });
+
+    it('should still observe the element and report dimensions with an external ref', () => {
+      const externalRef = { current: null } satisfies RefObject<HTMLDivElement | null>;
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: externalRef,
+          enableDebounceLeadingCall: true,
+        }),
+      );
+
+      const div = document.createElement('div');
+      act(() => {
+        result.current.parentRef(div);
+      });
+
+      const observer = MockResizeObserver.instances.at(-1)!;
+      act(() => {
+        observer.trigger({ width: 500, height: 400 });
+      });
+
+      expect(result.current.width).toBe(500);
+      expect(result.current.height).toBe(400);
+    });
+
+    it('should not throw when ref is null', () => {
+      const { result } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: null,
+        }),
+      );
+
+      const div = document.createElement('div');
+      expect(() => {
+        act(() => {
+          result.current.parentRef(div);
+        });
+      }).not.toThrow();
+    });
+
+    it('should return a stable parentRef when the external ref is a stable RefObject', () => {
+      const externalRef = { current: null } satisfies RefObject<HTMLDivElement | null>;
+      const { result, rerender } = renderHook(() =>
+        useParentSize({
+          resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
+          ref: externalRef,
+        }),
+      );
+
+      const firstParentRef = result.current.parentRef;
+      rerender();
+      expect(result.current.parentRef).toBe(firstParentRef);
+    });
   });
 });

--- a/packages/visx-responsive/test/useParentSize.test.tsx
+++ b/packages/visx-responsive/test/useParentSize.test.tsx
@@ -187,7 +187,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: externalRef,
+          externalRef,
         }),
       );
 
@@ -204,7 +204,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: externalRef,
+          externalRef,
         }),
       );
 
@@ -224,7 +224,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: callbackRef,
+          externalRef: callbackRef,
         }),
       );
 
@@ -241,7 +241,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: callbackRef,
+          externalRef: callbackRef,
         }),
       );
 
@@ -261,7 +261,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: externalRef,
+          externalRef,
         }),
       );
 
@@ -278,7 +278,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: externalRef,
+          externalRef,
           enableDebounceLeadingCall: true,
         }),
       );
@@ -301,7 +301,7 @@ describe('useParentSize', () => {
       const { result } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: null,
+          externalRef: null,
         }),
       );
 
@@ -318,7 +318,7 @@ describe('useParentSize', () => {
       const { result, rerender } = renderHook(() =>
         useParentSize({
           resizeObserverPolyfill: MockResizeObserver as unknown as ResizeObserverPolyfill,
-          ref: externalRef,
+          externalRef,
         }),
       );
 


### PR DESCRIPTION
#### :rocket: Enhancements

- useParentSize accepts an optional externalRef in its config object. If provided, the hook forwards the observed DOM node to both its internal state and the external ref (RefObject or callback ref), eliminating the need for a wrapper div when users already have a ref on their container element.

#### :memo: Documentation

- Add 4.0.0-alpha.8 entry to MIGRATION.md
  
#### :house: Internal

- 8 new tests covering RefObject forwarding, callback ref forwarding, null safety, internal state preservation, ResizeObserver compatibility, and stable parentRef identity
