### PR TITLE
fix(release): force-publish all packages during alpha releases

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,13 +16,10 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4.3.0
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,13 +24,10 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4.3.0
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,18 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
+## 4.0.0-alpha.9
+
+### ESM fix now published for all packages
+
+Five packages (`@visx/vendor`, `@visx/point`, `@visx/scale`, `@visx/curve`, `@visx/mock-data`) were
+stuck on pre-alpha.2 versions and still shipped ESM output without `.js` extensions or the
+`esm/package.json` `"type": "module"` marker. This release force-publishes every package so the
+alpha.2 ESM fix ([#1976](https://github.com/airbnb/visx/issues/1976)) is present across the board.
+
+**What you need to do:** if you hit `ERR_MODULE_NOT_FOUND` in strict ESM environments (Vite SSR,
+Deno, edge runtimes) with any of those five packages, upgrading to this release resolves it.
+
 ## 4.0.0-alpha.8
 
 ### `@visx/responsive` useParentSize external ref support

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -42,8 +42,6 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
     console.log(`Attempting to publish a '${version}' release.`);
 
     const { stdout, stderr } = await exec(
-      // --no-verify-access is needed because the CI token isn't valid for that endpoint
-      // provenance is automatically generated when using OIDC Trusted Publishers
       `npx lerna publish ${version} --exact --yes --dist-tag ${distTag}${
         isPreRelease ? ' --preid alpha --force-publish' : ''
       }`,

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -45,7 +45,7 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
       // --no-verify-access is needed because the CI token isn't valid for that endpoint
       // provenance is automatically generated when using OIDC Trusted Publishers
       `npx lerna publish ${version} --exact --yes --dist-tag ${distTag}${
-        isPreRelease ? ' --preid alpha' : ''
+        isPreRelease ? ' --preid alpha --force-publish' : ''
       }`,
     );
     if (stdout) {


### PR DESCRIPTION
#### :memo: Documentation

- Updates MIGRATION.md with alpha.9 ESM fix notes

#### :bug: Bug Fix

- Adds --force-publish to alpha releases so all packages are published, not just those with source changes. 5 packages (@visx/vendor, @visx/point, @visx/scale, @visx/curve, @visx/mock-data) were stuck on pre-alpha.2 versions with broken ESM output (missing .js extensions, missing esm/package.json). Fixes #1976.

#### :house: Internal

- Stable (non-prerelease) publishes are unchanged
