### PR TITLE
fix(release): republish alpha.12 as alpha.13

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,8 +5,8 @@ cumulative — if you're jumping several versions, apply the steps from each sec
 
 ## 4.0.0-alpha.13
 
-Re-publish of alpha.12, which partially failed (see below). No intended code changes — all packages
-are now published at the same version.
+Re-publish of alpha.12, which partially failed (see below). No intended code changes relative to
+alpha.12 — all packages are now published at the same version.
 
 **What you need to do:** if you installed any `@visx/*` packages at `4.0.0-alpha.12`, upgrade to
 `alpha.13` to ensure all packages are in sync.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,7 +3,13 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
-## 4.0.0-alpha.12
+## 4.0.0-alpha.13
+
+Re-publish of alpha.12, which partially failed (see below). No intended code changes — all packages
+are now published at the same version.
+
+**What you need to do:** if you installed any `@visx/*` packages at `4.0.0-alpha.12`, upgrade to
+`alpha.13` to ensure all packages are in sync.
 
 ### Lodash removed from package dependencies
 
@@ -21,6 +27,12 @@ the existing debounce options in `@visx/responsive`.
 
 This release also fixes the XYChart docs/demo example so it passes its known `width` into
 `XYChart`. No consumer code changes are needed for that docs-only fix.
+
+## 4.0.0-alpha.12 (broken)
+
+⚠️ **Do not use this release.** An npm provenance transparency log conflict caused `lerna publish`
+to fail partway through. Some packages were never published at this version while the rest were,
+resulting in a version mismatch across the monorepo. Use `alpha.13` instead.
 
 ## 4.0.0-alpha.11
 

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -41,11 +41,22 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
 
     console.log(`Attempting to publish a '${version}' release.`);
 
-    const { stdout, stderr } = await exec(
-      `npx lerna publish ${version} --exact --yes --dist-tag ${distTag}${
-        isPreRelease ? ' --preid alpha --force-publish' : ''
-      }`,
-    );
+    const publishCommand = [
+      'npx lerna publish',
+      version,
+      '--exact',
+      '--yes',
+      `--dist-tag ${distTag}`,
+      '--concurrency 1',
+      '--throttle',
+      '--throttle-size 1',
+      '--throttle-delay 5',
+      isPreRelease ? '--preid alpha --force-publish' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const { stdout, stderr } = await exec(publishCommand);
     if (stdout) {
       console.log('Lerna output', stdout);
     }

--- a/scripts/performRelease/performLernaRelease.ts
+++ b/scripts/performRelease/performLernaRelease.ts
@@ -42,7 +42,7 @@ export default async function performLernaRelease(prsSinceLastTag: PR[]) {
     console.log(`Attempting to publish a '${version}' release.`);
 
     const publishCommand = [
-      'npx lerna publish',
+      'yarn lerna publish',
       version,
       '--exact',
       '--yes',


### PR DESCRIPTION
#### :boom: Breaking Changes

- None

#### :rocket: Enhancements

- None

#### :memo: Documentation

- Mark `4.0.0-alpha.12` as broken in the migration guide and document `4.0.0-alpha.13` as the re-publish.

#### :bug: Bug Fix

- Re-publish the partially failed `4.0.0-alpha.12` release as `4.0.0-alpha.13` so all packages are available at the same version.
- Publish packages serially with a small throttle delay to reduce the chance of npm provenance transparency log conflicts during monorepo releases.

#### :house: Internal

- Add `--concurrency 1`, `--throttle`, `--throttle-size 1`, and `--throttle-delay 5` to the Lerna publish command.
- Verified the release script loads with `node --require tsx/cjs`.