### PR TITLE
Resolve brace-expansion Dependabot alert

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,11 @@
 This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
 cumulative — if you're jumping several versions, apply the steps from each section in order.
 
+## 4.0.0-alpha.17
+
+Internal only: updated transitive `brace-expansion` lockfile entries to resolve a Dependabot
+security alert. No consumer-facing visx API changes are expected.
+
 ## 4.0.0-alpha.16
 
 Internal only: updated demo, test, release, and build-tool dependencies to resolve Dependabot

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,25 +5832,16 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.15
+  resolution: "brace-expansion@npm:1.1.15"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.2":
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
   version: 2.1.1
   resolution: "brace-expansion@npm:2.1.1"
   dependencies:


### PR DESCRIPTION
#### :boom: Breaking Changes

- None.

#### :rocket: Enhancements

- None.

#### :memo: Documentation

- Add a `4.0.0-alpha.17` entry to `MIGRATION.md` for the brace-expansion security update.

#### :bug: Bug Fix

- Resolve Dependabot alert by updating the vulnerable `brace-expansion@2.0.2` lockfile entry to a patched version.

#### :house: Internal

- Verified with `yarn install --immutable`, `yarn test`, and `yarn npm audit --recursive --environment all --json`.
