### PR TITLE
visx 4 stable release

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,208 @@
-# Migration guide
+# Upgrading to visx 4
 
-This document tracks consumer-facing changes for each `4.0.0-alpha.*` release. Upgrades are
-cumulative — if you're jumping several versions, apply the steps from each section in order.
+visx 4 is the current major release. It modernizes React support, package entry points, browser
+targets, and the published ESM output. For most apps, the upgrade is:
+
+1. Upgrade all `@visx/*` packages together to `^4.0.0`.
+2. Use React 18 or 19.
+3. Replace deep imports like `@visx/shape/lib/shapes/Bar` with package-root imports like
+   `@visx/shape`.
+4. If you use TypeScript, install `@types/react` and, when needed, `@types/react-dom` using the
+   major version that matches your React version.
+5. If you use `withBoundingRects`, attach its injected `nodeRef` to the DOM element you want
+   measured.
+6. If you rely on generated runtime `propTypes`, migrate those checks into your app.
+7. If you still need IE11, stay on visx 3.
+
+## From visx 3.x
+
+Upgrade every visx package in your application at the same time. Mixing visx 3 and visx 4 packages
+is not recommended because package entry points, peer dependency ranges, and internal package
+dependencies changed together.
+
+```bash
+npm install @visx/shape@^4 @visx/scale@^4
+```
+
+With Yarn, upgrade the visx packages your app depends on to the same major:
+
+```bash
+yarn up "@visx/*@^4.0.0"
+```
+
+### React 18 or 19 is required
+
+React-based `@visx/*` packages declare `react` peer dependencies as `^18.0.0 || ^19.0.0`. Packages
+that depend on `react-dom` declare the same supported range for their `react-dom` peer dependency.
+
+**What you need to do:**
+
+- **React 18 or 19 consumers:** no runtime code changes are expected for this peer dependency
+  update.
+- **React 16 or 17 consumers:** stay on visx 3 or upgrade your app to React 18+ before installing
+  visx 4.
+- **Preact consumers:** continue aliasing `react` and `react-dom` to `preact/compat`, and configure
+  your package manager to satisfy the React 18/19 peer dependency range.
+
+### TypeScript React types are peer dependencies
+
+React-based `@visx/*` packages now declare `@types/react` as an optional peer dependency instead of
+bundling their own copy. Packages that touch React DOM APIs also declare optional `@types/react-dom`
+peer dependencies.
+
+**What you need to do:**
+
+- **TypeScript consumers:** install `@types/react` and, when needed, `@types/react-dom` using the
+  major version that matches your React version.
+- **Non-TypeScript consumers:** no action needed.
+
+### Runtime PropTypes were removed
+
+visx packages no longer depend on `prop-types`, and the build no longer generates runtime
+`Component.propTypes` from TypeScript definitions.
+
+**What you need to do:**
+
+- Most consumers do not need to change code.
+- If your app imported `prop-types` only because a visx package installed it transitively, add
+  `prop-types` as a direct dependency.
+- If your app inspects visx component `propTypes` at runtime, migrate that validation into your app
+  or use TypeScript/static checks instead.
+
+### Package root imports are the supported API surface
+
+Every package now publishes an `exports` field mapping package-root imports to `types`, `import`,
+and `require` entries. This improves module resolution in modern bundlers and Node.js, but it also
+restricts access to internal paths.
+
+**What you need to do:** replace deep imports like `@visx/foo/lib/bar` with package-root imports
+like `@visx/foo`. If a symbol you need is not exported from the package root, open an issue.
+
+Most common component prop types are now exported from package roots as TypeScript-only exports. For
+example, prefer importing `AxisProps` from `@visx/axis` instead of reaching into internal files.
+
+### Modern browser targets
+
+Babel targets were bumped to modern browsers. IE11 and other legacy browsers are no longer
+supported.
+
+**What you need to do:** if you still need IE11, stay on visx 3.
+
+### Published ESM output works in strict ESM environments
+
+The published `esm/` output now emits explicit `.js` extensions on relative imports and a nested
+`esm/package.json` with `"type": "module"`. Strict Node ESM consumers such as Vite SSR, Deno, and
+edge runtimes should no longer hit `ERR_MODULE_NOT_FOUND` from extensionless visx ESM imports.
+
+**What you need to do:** nothing, unless you previously pinned to an older alpha to work around ESM
+issues. Upgrade all visx packages to `^4.0.0`.
+
+### D3 shape and path dependencies were upgraded
+
+visx packages now use `d3-shape` v3 and `d3-path` v3 through `@visx/vendor`. visx preserves its
+existing package-level behavior where compatibility shims were needed, but direct D3 imports are now
+your app's responsibility.
+
+**What you need to do:**
+
+- Most consumers do not need to change code.
+- If your app imports `d3-shape` or `d3-path` without declaring them in your own `package.json`, add
+  them as direct dependencies.
+- If your app imports from `@visx/vendor/d3-shape` or `@visx/vendor/d3-path`, review the D3 v3 API
+  and type changes.
+
+### `@visx/bounds` `withBoundingRects` requires `nodeRef`
+
+`withBoundingRects` no longer falls back to `ReactDOM.findDOMNode`. The wrapped component receives a
+`nodeRef` prop and must attach it to the DOM element that should be measured. This keeps
+`@visx/bounds` compatible with React 19 and React strict-mode expectations.
+
+**What you need to do:**
+
+- If you use `withBoundingRects`, make sure the wrapped component accepts `nodeRef` and passes it to
+  the measured DOM element.
+- If you use TypeScript, type `nodeRef` as a React ref for the element you measure.
+- If you already attach `nodeRef`, no action is needed.
+
+```diff
+- function Tooltip({ rect, parentRect, children }) {
+-   return <div>{children}</div>;
++ type TooltipProps = Omit<WithBoundingRectsProps, 'nodeRef'> & {
++   nodeRef?: React.Ref<HTMLDivElement>;
++ };
++
++ function Tooltip({ rect, parentRect, nodeRef, children }: TooltipProps) {
++   return <div ref={nodeRef}>{children}</div>;
+  }
+```
+
+### `@visx/responsive` measurement fixes
+
+`ParentSize` and `withParentSize` now render a two-div structure to prevent infinite height growth
+in flex and grid layouts. `useParentSize` now uses a callback ref internally and also accepts an
+optional `externalRef`.
+
+**What you need to do:**
+
+- Most consumers do not need to change code.
+- If you access `parentRef.current` from `useParentSize`, replace it with the returned `node`.
+- If tests or CSS rely on the exact `ParentSize` wrapper DOM structure, update them for the nested
+  measurement div.
+
+### `@visx/xychart` axis loading behavior
+
+`BaseAxis` no longer renders until at least one data series with non-empty `data` has been
+registered in `DataContext`. Previously, on initial render the axis could use the fallback
+`scaleLinear()` domain `[0, 1]`, causing `tickFormat` to receive incorrect intermediate values
+before real data loaded.
+
+**What you need to do:**
+
+- Most consumers do not need to change code.
+- If you relied on the axis being visible before data loaded, render a placeholder `<Axis />` from
+  `@visx/axis` directly with your own scale until your data is ready, then switch to the xychart
+  `<Axis />`.
+
+### `@visx/xychart` `withRegisteredData` was removed
+
+The internal `withRegisteredData` enhancer was removed from `@visx/xychart`. Series components now
+register their data directly instead of using that higher-order component.
+
+**What you need to do:** most consumers do not need to change code. If you imported
+`@visx/xychart/lib/enhancers/withRegisteredData` directly, migrate to the public xychart series
+components and package-root exports.
+
+### Lodash is no longer a transitive implementation dependency
+
+`@visx/responsive`, `@visx/text`, `@visx/xychart`, and `@visx/shape` no longer declare direct
+`lodash` or `@types/lodash` dependencies. Internal `debounce`, `memoize`, and `chunk` usage has been
+replaced with small local helpers. Public visx APIs are intended to behave the same.
+
+**What you need to do:** if your app imported `lodash` without declaring it in your own
+`package.json`, add `lodash` as a direct dependency. It may have worked before only because a visx
+package installed it transitively.
+
+### Building visx from source requires newer tooling
+
+This note is for contributors or consumers building the visx repo itself. The repository now uses
+Yarn 4 via Corepack and requires Node 24 or newer.
+
+**What you need to do:** if you only install published `@visx/*` packages, no action is needed. If
+you build the repo locally, use Node 24+ and run Yarn through Corepack.
+
+## From 4.0.0 alpha releases
+
+Upgrade all `@visx/*` packages to `^4.0.0`. The stable release includes all alpha changes listed
+below, plus the final React 18/19 peer dependency range and Dependabot cleanup from the final alpha
+publishes.
+
+If you installed `4.0.0-alpha.10`, `4.0.0-alpha.12`, or `4.0.0-alpha.13`, upgrade immediately. Those
+alpha releases partially failed and left some packages unpublished or out of sync.
+
+## Alpha release history
+
+The notes below are preserved for users who tested the v4 alpha series. Stable upgrade guidance
+above supersedes any older alpha-specific instructions.
 
 ## 4.0.0-alpha.17
 
@@ -17,10 +218,10 @@ security alerts. No consumer-facing visx API changes are expected.
 
 ### React 18 or 19 is now required
 
-React-based `@visx/*` packages now declare `react` peer dependencies as
-`^18.0.0 || ^19.0.0`. Packages that depend on `react-dom` declare the same supported range for
-their `react-dom` peer dependency. Optional `@types/react` and, where applicable,
-`@types/react-dom` peer dependencies use the same supported major-version range.
+React-based `@visx/*` packages now declare `react` peer dependencies as `^18.0.0 || ^19.0.0`.
+Packages that depend on `react-dom` declare the same supported range for their `react-dom` peer
+dependency. Optional `@types/react` and, where applicable, `@types/react-dom` peer dependencies use
+the same supported major-version range.
 
 **What you need to do:**
 
@@ -44,19 +245,19 @@ relative to alpha.12 — all packages are now published at the same version.
 ### Lodash removed from package dependencies
 
 `@visx/responsive`, `@visx/text`, `@visx/xychart`, and `@visx/shape` no longer declare direct
-`lodash` or `@types/lodash` dependencies. Internal `debounce`, `memoize`, and `chunk` usage has
-been replaced with small local helpers. Public visx APIs are intended to behave the same, including
-the existing debounce options in `@visx/responsive`.
+`lodash` or `@types/lodash` dependencies. Internal `debounce`, `memoize`, and `chunk` usage has been
+replaced with small local helpers. Public visx APIs are intended to behave the same, including the
+existing debounce options in `@visx/responsive`.
 
 **What you need to do:**
 
 - **Most consumers:** nothing — this removes an implementation dependency from visx packages.
-- **If your app imported `lodash` without declaring it in your own `package.json`:** add `lodash`
-  as a direct dependency. It may have worked before only because a visx package installed it
+- **If your app imported `lodash` without declaring it in your own `package.json`:** add `lodash` as
+  a direct dependency. It may have worked before only because a visx package installed it
   transitively.
 
-This release also fixes the XYChart docs/demo example so it passes its known `width` into
-`XYChart`. No consumer code changes are needed for that docs-only fix.
+This release also fixes the XYChart docs/demo example so it passes its known `width` into `XYChart`.
+No consumer code changes are needed for that docs-only fix.
 
 ## 4.0.0-alpha.13 (broken)
 
@@ -133,8 +334,8 @@ Previously, the component rendered a single wrapper `<div style="width: 100%; he
 flex or grid containers, a child SVG's intrinsic height could grow the wrapper, triggering
 ResizeObserver in a feedback loop.
 
-The new structure uses an outer `<div style="width: 100%; height: 100%; position: relative">` and
-an inner `<div style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; overflow: hidden">`
+The new structure uses an outer `<div style="width: 100%; height: 100%; position: relative">` and an
+inner `<div style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; overflow: hidden">`
 that holds the ResizeObserver and children. Since the inner div is absolutely positioned, children's
 intrinsic sizes cannot grow the outer container.
 
@@ -145,12 +346,12 @@ intrinsic sizes cannot grow the outer container.
 - **If you rely on the wrapper div's exact DOM structure** (e.g., querying it in tests or applying
   CSS that targets a single wrapper div): the wrapper is now two nested divs. `className`, `style`,
   and all other HTML attributes still apply to the outer div.
-- **If you use the deprecated `parentSizeStyles` prop:** it still works and applies to the outer div,
-  but `position: relative` is prepended to ensure the inner absolutely-positioned measurement div
-  works correctly. If you explicitly set `position` in your custom styles, your value takes
+- **If you use the deprecated `parentSizeStyles` prop:** it still works and applies to the outer
+  div, but `position: relative` is prepended to ensure the inner absolutely-positioned measurement
+  div works correctly. If you explicitly set `position` in your custom styles, your value takes
   precedence.
-- **If you use `withParentSize`:** the same two-div structure applies. The container div is no longer
-  a single `<div style="width: 100%; height: 100%">`.
+- **If you use `withParentSize`:** the same two-div structure applies. The container div is no
+  longer a single `<div style="width: 100%; height: 100%">`.
 
 ## 4.0.0-alpha.6
 
@@ -162,8 +363,8 @@ hook could permanently report 0×0 dimensions because `parentRef.current` was nu
 ([#1816](https://github.com/airbnb/visx/issues/1816)).
 
 The returned `parentRef` is now a callback ref (`(node: T | null) => void`) instead of a
-`RefObject<T | null>`. A new `node` property is also returned for direct access to the observed
-DOM element.
+`RefObject<T | null>`. A new `node` property is also returned for direct access to the observed DOM
+element.
 
 **What you need to do:**
 
@@ -182,10 +383,10 @@ DOM element.
 
 ### `@visx/xychart` axis rendering fix (breaking)
 
-`BaseAxis` no longer renders until at least one data series with non-empty `data` has been registered
-in `DataContext`. Previously, on initial render the axis could use the fallback `scaleLinear()`
-domain `[0, 1]`, causing `tickFormat` to receive incorrect intermediate values before real data
-loaded ([#1975](https://github.com/airbnb/visx/issues/1975)).
+`BaseAxis` no longer renders until at least one data series with non-empty `data` has been
+registered in `DataContext`. Previously, on initial render the axis could use the fallback
+`scaleLinear()` domain `[0, 1]`, causing `tickFormat` to receive incorrect intermediate values
+before real data loaded ([#1975](https://github.com/airbnb/visx/issues/1975)).
 
 This is a behavior change: axes that previously rendered immediately (showing `0`–`1` ticks while
 data was loading) will now render `null` until real data is available.
@@ -198,7 +399,8 @@ data was loading) will now render `null` until real data is available.
   render a placeholder `<Axis />` from `@visx/axis` directly with your own scale until your data is
   ready, then switch to the xychart `<Axis />`.
 
-Thank you [wildseansy](https://github.com/wildseansy) for the fix [#1979](https://github.com/airbnb/visx/pull/1979)
+Thank you [wildseansy](https://github.com/wildseansy) for the fix
+[#1979](https://github.com/airbnb/visx/pull/1979)
 
 ## 4.0.0-alpha.4
 
@@ -214,16 +416,16 @@ bundling their own copy. That way your app supplies a single version and you avo
 conflicting installs.
 
 `@visx/bounds`, `@visx/tooltip`, `@visx/xychart`, and the `@visx/visx` meta-package all declare
-`@types/react-dom` as an optional peer directly (bounds and tooltip type DOM-touching APIs;
-xychart consumes tooltip and so transitively needs react-dom at runtime; the umbrella matches the
-pattern of its DOM-touching members).
+`@types/react-dom` as an optional peer directly (bounds and tooltip type DOM-touching APIs; xychart
+consumes tooltip and so transitively needs react-dom at runtime; the umbrella matches the pattern of
+its DOM-touching members).
 
 `@visx/brush` and `@visx/wordcloud` also declare `@types/react` as an optional peer so consumers
 installing either package directly get the same type-dependency signal as the rest of the
 React-based `@visx/*` packages.
 
-The peers are marked `optional` via `peerDependenciesMeta`, so non-TypeScript consumers will not
-see missing-peer warnings.
+The peers are marked `optional` via `peerDependenciesMeta`, so non-TypeScript consumers will not see
+missing-peer warnings.
 
 **What you need to do:**
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@
 visx is a collection of reusable low-level visualization components. visx combines the power of d3
 to generate your visualization with the benefits of react for updating the DOM.
 
+<!-- prettier-ignore -->
 > [!IMPORTANT]
-> **visx v4 is in alpha** and requires React 18 or 19. Install with the `@next` tag:
+> **visx v4 is the current stable release** and requires React 18 or 19.
 >
 > ```bash
-> npm install @visx/shape@next
+> npm install @visx/shape
 > ```
 >
-> v3 remains the `latest` stable release. See the [migration guide](./MIGRATION.md) and [changelog](./CHANGELOG.md) for details.
+> Upgrading from v3? See the [visx 4 migration guide](./MIGRATION.md).
 
 <br />
 
@@ -177,8 +178,8 @@ visualization charts or library without having to learn d3. No more selections o
 
 1. Does visx work with [preact](https://preactjs.com/)?
 
-   > yup! alias `react` + `react-dom` to `preact/compat`. For visx v4, configure your
-   > package manager to satisfy the React 18/19 peer dependency range.
+   > yup! alias `react` + `react-dom` to `preact/compat`. For visx v4, configure your package
+   > manager to satisfy the React 18/19 peer dependency range.
 
 1. I like using d3.
 

--- a/packages/visx-axis/test/AxisSsr.test.tsx
+++ b/packages/visx-axis/test/AxisSsr.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment node
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { scaleLinear } from '@visx/scale';
+import { AxisBottom } from '../src';
+
+describe('<AxisBottom /> SSR', () => {
+  it('renders without warning when SVG text measurement is unavailable', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const html = renderToString(
+        <svg>
+          <AxisBottom
+            scale={scaleLinear({
+              domain: [0, 10],
+              range: [0, 100],
+            })}
+          />
+        </svg>,
+      );
+
+      expect(html).toContain('visx-axis');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/visx-bounds/Readme.md
+++ b/packages/visx-bounds/Readme.md
@@ -25,13 +25,21 @@ Example usage with a `<Tooltip />` component
 import React from 'react';
 import { withBoundingRects, WithBoundingRectsProps } from '@visx/bounds';
 
-type TooltipProps = WithBoundingRectsProps & {
+type TooltipProps = Omit<WithBoundingRectsProps, 'nodeRef'> & {
   left: number;
   top: number;
+  nodeRef?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
 };
 
-function Tooltip({ left: initialLeft, top: initialTop, rect, parentRect, children }: TooltipProps) {
+function Tooltip({
+  left: initialLeft,
+  top: initialTop,
+  rect,
+  parentRect,
+  nodeRef,
+  children,
+}: TooltipProps) {
   let left = initialLeft;
   let top = initialTop;
 
@@ -40,7 +48,11 @@ function Tooltip({ left: initialLeft, top: initialTop, rect, parentRect, childre
     top = rect.bottom > parentRect.bottom ? top - rect.height : top;
   }
 
-  return <div style={{ top, left, ...myTheme }}>{children}</div>;
+  return (
+    <div ref={nodeRef} style={{ top, left, ...myTheme }}>
+      {children}
+    </div>
+  );
 }
 
 export default withBoundingRects(Tooltip);

--- a/packages/visx-demo/src/pages/docs.tsx
+++ b/packages/visx-demo/src/pages/docs.tsx
@@ -14,6 +14,12 @@ export default function Docs() {
           your use case, or you can simply add the umbrella <a href="/visx/docs/visx">@visx/visx</a>{' '}
           package to use them all.
           <br /> <br />
+          Upgrading from visx 3? Read the{' '}
+          <a href="https://github.com/airbnb/visx/blob/master/MIGRATION.md">
+            visx 4 migration guide
+          </a>{' '}
+          for upgrade steps.
+          <br /> <br />
           Individual packages can be roughly categorized as follows:
         </p>
         <PackageList grid />

--- a/packages/visx-text/src/util/getStringWidth.ts
+++ b/packages/visx-text/src/util/getStringWidth.ts
@@ -3,6 +3,8 @@ import memoize from './memoize';
 const MEASUREMENT_ELEMENT_ID = '__react_svg_text_measurement_id';
 
 function getStringWidth(str: string, style?: object) {
+  if (typeof document === 'undefined') return null;
+
   try {
     // Calculate length of each word to be used to determine number of words per line
     let textEl = document.getElementById(MEASUREMENT_ELEMENT_ID) as SVGTextElement | null;
@@ -23,8 +25,7 @@ function getStringWidth(str: string, style?: object) {
     Object.assign(textEl.style, style);
     textEl.textContent = str;
     return textEl.getComputedTextLength();
-  } catch (e) {
-    console.warn(e);
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
**Upgrade guide:** [`MIGRATION.md`](./MIGRATION.md) is the canonical visx 4 upgrade guide for existing visx users. The PR sections below summarize the stable-release prep work; they are not meant to duplicate every migration note.

#### :boom: Breaking Changes

- Prepares the stable visx 4 release, which requires React 18 or 19 and treats package-root imports as the supported API surface.
- Points v3 users to the canonical v4 migration guide for deep import, browser support, TypeScript peer dependency, runtime PropTypes, d3-shape/path, `@visx/bounds`, responsive, and xychart behavior changes.

#### :rocket: Enhancements

- Adds a docs landing page pointer for users upgrading from visx 3.

#### :memo: Documentation

- Reworks `MIGRATION.md` into the canonical visx 4 upgrade guide for v3 and alpha users.
- Adds missing migration callouts from the v4 milestone audit, including `withBoundingRects` `nodeRef`, removed generated `propTypes`, d3-shape/path v3, removed xychart `withRegisteredData`, and source-build tooling requirements.
- Updates the README stable-release callout to remove `@next` / alpha language and point upgrade traffic at `MIGRATION.md`.
- Updates the `@visx/bounds` README example to attach the injected `nodeRef` after the `findDOMNode` fallback removal.

#### :bug: Bug Fix

- Restores the quiet no-DOM fallback in `@visx/text` during SSR.
- Adds an SSR smoke test for `renderToString(<AxisBottom ... />)` to verify unavailable SVG text measurement does not warn.

#### :house: Internal

- Release setup: this PR should keep `major-release` and should not receive `alpha-release`; merging should publish stable `4.0.0` to `latest`.
- Validation run locally:
  - `yarn install --immutable`
  - `yarn build`
  - `yarn prettier --check README.md MIGRATION.md packages/visx-demo/src/pages/docs.tsx packages/visx-text/src/util/getStringWidth.ts packages/visx-axis/test/AxisSsr.test.tsx`
  - `yarn prettier --check MIGRATION.md packages/visx-bounds/Readme.md`
  - `yarn vitest run packages/visx-axis/test/AxisSsr.test.tsx --config packages/visx-axis/vitest.config.ts`
  - `yarn vitest run --config packages/visx-axis/vitest.config.ts`
  - `yarn vitest run --config packages/visx-text/vitest.config.ts`
  - `yarn docs:generate`
  - `yarn lint`
  - `yarn type:update-refs`
  - `(cd packages/visx-demo && yarn build)`
  - `git diff --check`
- Release state checked: latest master push is green, all 39 public `@visx/*` packages have `latest === 3.12.0` and `next === 4.0.0-alpha.17`, and GitHub reports 0 open Dependabot alerts.
