### PR TITLE
Throttle release GitHub requests

### DIFF
--- a/scripts/performRelease/fetchPRsForCommits.ts
+++ b/scripts/performRelease/fetchPRsForCommits.ts
@@ -1,5 +1,8 @@
 import type { GithubClient } from '../utils/getGitHubClient';
 import getRepoContext from '../utils/getRepoContext';
+import runGithubRequestWithRetries, {
+  pauseBetweenGitHubRequests,
+} from './runGithubRequestWithRetries';
 import type { PR } from './types';
 
 export default async function fetchPRsForCommits(
@@ -9,34 +12,38 @@ export default async function fetchPRsForCommits(
   const { owner, repo } = getRepoContext();
   const prs: PR[] = [];
 
-  await Promise.all(
-    shas.map(async (sha) => {
-      console.log('Fetching PRs associated with commit', sha);
+  for (let index = 0; index < shas.length; index += 1) {
+    const sha = shas[index];
 
-      const prsForCommit = await client.request(
-        'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
-        {
-          owner,
-          repo,
-          commit_sha: sha,
-          // special header needed https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-          mediaType: {
-            previews: ['groot'],
-          },
+    console.log('Fetching PRs associated with commit', sha);
+
+    const prsForCommit = await runGithubRequestWithRetries(`Fetch PRs for commit ${sha}`, () =>
+      client.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
+        owner,
+        repo,
+        commit_sha: sha,
+        // special header needed https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
+        mediaType: {
+          previews: ['groot'],
         },
-      );
-      if (prsForCommit.data.length === 0) {
-        console.log('Ignoring commit with no PRs', sha);
-        return;
-      }
+      }),
+    );
+
+    if (prsForCommit.data.length === 0) {
+      console.log('Ignoring commit with no PRs', sha);
+    } else {
       if (prsForCommit.data.length > 1) {
         console.warn('Multiple PRs associated with commit, only considering the first', sha);
       }
 
       const prForCommit = prsForCommit.data[0] as PR;
       prs.push(prForCommit);
-    }),
-  );
+    }
+
+    if (index < shas.length - 1) {
+      await pauseBetweenGitHubRequests();
+    }
+  }
 
   return prs;
 }

--- a/scripts/performRelease/postReleaseOnPrs.ts
+++ b/scripts/performRelease/postReleaseOnPrs.ts
@@ -1,5 +1,8 @@
 import type { GithubClient } from '../utils/getGitHubClient';
 import getRepoContext from '../utils/getRepoContext';
+import runGithubRequestWithRetries, {
+  pauseBetweenGitHubRequests,
+} from './runGithubRequestWithRetries';
 import type { PR } from './types';
 
 export default async function postReleaseOnPrs(client: GithubClient, prs: PR[], tagName: string) {
@@ -7,16 +10,22 @@ export default async function postReleaseOnPrs(client: GithubClient, prs: PR[], 
   const { owner, repo } = getRepoContext();
   const message = `🎉 This PR is included in version \`${tagName}\` of the packages modified 🎉`;
 
-  await Promise.all(
-    prs.map(async (pr) => {
-      console.log('Posting release on PR #', pr.number);
+  for (let index = 0; index < prs.length; index += 1) {
+    const pr = prs[index];
 
-      await client.issues.createComment({
+    console.log('Posting release on PR #', pr.number);
+
+    await runGithubRequestWithRetries(`Post release on PR #${pr.number}`, () =>
+      client.issues.createComment({
         issue_number: pr.number,
         owner,
         repo,
         body: message,
-      });
-    }),
-  );
+      }),
+    );
+
+    if (index < prs.length - 1) {
+      await pauseBetweenGitHubRequests();
+    }
+  }
 }

--- a/scripts/performRelease/runGithubRequestWithRetries.ts
+++ b/scripts/performRelease/runGithubRequestWithRetries.ts
@@ -1,0 +1,57 @@
+const REQUEST_DELAY_MS = 1000;
+const RETRY_DELAYS_MS = [60_000, 120_000];
+
+function wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function isRateLimitError(error: unknown) {
+  const status =
+    typeof error === 'object' && error !== null && 'status' in error ? error.status : null;
+
+  return status === 429 || /rate limit|secondary limit/i.test(getErrorMessage(error));
+}
+
+export async function pauseBetweenGitHubRequests() {
+  await wait(REQUEST_DELAY_MS);
+}
+
+export default async function runGithubRequestWithRetries<T>(
+  label: string,
+  request: () => Promise<T>,
+  attempt = 0,
+): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    const delayMs = RETRY_DELAYS_MS[attempt];
+
+    if (!isRateLimitError(error) || delayMs === undefined) {
+      throw error;
+    }
+
+    console.warn(
+      `${label} hit a GitHub rate limit. Retrying in ${delayMs / 1000}s: ${getErrorMessage(error)}`,
+    );
+    await wait(delayMs);
+    return runGithubRequestWithRetries(label, request, attempt + 1);
+  }
+}


### PR DESCRIPTION
#### :boom: Breaking Changes

- N/A

#### :rocket: Enhancements

- N/A

#### :memo: Documentation

- N/A

#### :bug: Bug Fix

- Prevent the release workflow from hitting GitHub secondary rate limits while resolving PR metadata for the v4 changelog.

#### :house: Internal

- Fetch release PR metadata and post release comments sequentially with a 1s pause between GitHub requests.
- Retry GitHub rate-limit responses before failing the release workflow.
- Does not change release label selection, Lerna version selection, npm dist-tags, changelog formatting, or GitHub release creation.