### PR TITLE
feat(registry): add shadcn-compatible chart registry

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,5 +84,16 @@ module.exports = {
         'react/state-in-constructor': 'off',
       },
     },
+    {
+      files: './packages/visx-registry/registry/**',
+      rules: {
+        'import/no-unresolved': [
+          'error',
+          {
+            ignore: ['^@visx/(a11y|scale|theme)/react$'],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -86,7 +86,12 @@ visx 4.1 adds the first hook and helper APIs used to build primitive charts for 
 registry. These APIs are additive and live in package roots or explicit React subpaths:
 
 ```tsx
-import { useChartDimensions } from '@visx/chart';
+import {
+  getPositiveDomain,
+  getResponsiveWidth,
+  getZeroBaselineDomain,
+  useChartDimensions,
+} from '@visx/chart';
 import { useAxis } from '@visx/axis/react';
 import { useScale } from '@visx/scale/react';
 import { arcPath, areaPath, linePath } from '@visx/shape';
@@ -102,6 +107,23 @@ non-React code.
 
 **What you need to do:** nothing unless you want to author hook-based primitive charts. Continue
 using existing components as before, or opt into the new hooks from the import paths above.
+
+### The visx chart registry adds shadcn-compatible chart starters
+
+visx 4.1 introduces a source-first chart registry for installing themed, responsive, accessible
+primitive chart components into application code with the shadcn CLI.
+
+```sh
+npx shadcn@latest add airbnb/visx/line-chart
+```
+
+Registry items are copied into your app as editable source files and depend on public visx packages
+such as `@visx/a11y`, `@visx/chart`, `@visx/responsive`, and `@visx/theme`. The registry itself is
+distribution infrastructure and is not a runtime package your app imports.
+
+**What you need to do:** nothing unless you want drop-in primitive chart starters. Existing visx
+charts continue to work. Use registry installs only after the referenced 4.1 visx packages are
+published.
 
 ## From visx 3.x
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "test:watch": "yarn run vitest watch",
     "vitest": "vitest",
     "vitest:ui": "vitest --ui",
+    "registry:smoke": "yarn workspace @visx/registry smoke:install",
+    "registry:validate": "yarn workspace @visx/registry validate",
     "ts": "tsx --tsconfig ./tsconfig.node.json",
     "type": "yarn type:clean && yarn type:build",
     "type:build": "lerna exec -- 'tsc --build'",

--- a/packages/visx-a11y/Readme.md
+++ b/packages/visx-a11y/Readme.md
@@ -106,7 +106,7 @@ export function RevenueChart({ data }) {
 
   return (
     <>
-      <svg {...a11y.svgProps}>
+      <svg {...a11y.svgProps} id={a11y.id}>
         <desc id={a11y.descriptionId}>{a11y.description}</desc>
         {/* chart marks */}
       </svg>
@@ -139,7 +139,7 @@ const a11y = useChartA11y({
 
 return (
   <>
-    <svg {...a11y.svgProps}>
+    <svg {...a11y.svgProps} id={a11y.id}>
       <desc id={a11y.descriptionId}>{a11y.description}</desc>
       <g>
         {data.map((datum) => (
@@ -174,7 +174,7 @@ const a11y = useChartA11y({
 
 return (
   <>
-    <svg {...a11y.svgProps}>
+    <svg {...a11y.svgProps} id={a11y.id}>
       <desc id={a11y.descriptionId}>{a11y.description}</desc>
       <g {...a11y.getSeriesProps(0)}>
         {data.map((datum, index) => (
@@ -216,7 +216,7 @@ const a11y = useChartA11y({
 });
 
 return (
-  <svg {...a11y.svgProps}>
+  <svg {...a11y.svgProps} id={a11y.id}>
     <desc id={a11y.descriptionId}>{a11y.description}</desc>
     <g {...a11y.getSeriesProps(0)}>
       {data.map((datum, index) => (
@@ -236,9 +236,10 @@ still wants the same roving-focus behavior, point focus state, and `onPointFocus
 
 ## Keyboard interaction model
 
-`useChartA11y` starts in chart mode. The chart root is tabbable, and data marks become tabbable only
-while keyboard exploration is active. Navigation is enabled by default for charts with at least one
-point and no more than `pointDescriptionThreshold` points.
+When keyboard navigation is enabled, `useChartA11y` starts in chart mode. The chart root is
+tabbable, and data marks become tabbable only while keyboard exploration is active. Navigation is
+enabled by default for charts with at least one point and no more than `pointDescriptionThreshold`
+points.
 
 | Key                | Result                                                                                       |
 | ------------------ | -------------------------------------------------------------------------------------------- |
@@ -264,7 +265,7 @@ rects, clipping helpers, and other non-data elements should usually be rendered 
 table.
 
 ```tsx
-<svg {...a11y.svgProps}>
+<svg {...a11y.svgProps} id={a11y.id}>
   <rect aria-hidden="true" width={width} height={height} />
   <GridRows aria-hidden="true" scale={yScale} width={innerWidth} />
   <AxisBottom aria-hidden="true" scale={xScale} />

--- a/packages/visx-a11y/src/useChartA11y.tsx
+++ b/packages/visx-a11y/src/useChartA11y.tsx
@@ -10,6 +10,7 @@ import { generateChartDescription } from './generators/description';
 import type { ChartA11yMode, ChartA11yPointFocus } from './keyboard/stateMachine';
 import type {
   ChartA11yConfig,
+  ChartA11yIds,
   ChartA11yPointProps,
   ChartA11ySeriesProps,
   ChartA11ySvgProps,
@@ -35,6 +36,8 @@ export type UseChartA11yDataTableProps<Datum> = Pick<
 export type UseChartA11yAnnouncerProps = Omit<ChartA11yAnnouncerProps, 'message'>;
 
 export type UseChartA11yResult<Datum> = {
+  id: string;
+  ids: ChartA11yIds;
   svgProps: UseChartA11ySvgProps;
   getSeriesProps: (seriesIndex: number) => ChartA11ySeriesProps;
   getPointProps: (seriesIndex: number, index: number) => UseChartA11yPointProps;
@@ -127,6 +130,8 @@ export function useChartA11y<Datum>(config: ChartA11yConfig<Datum>): UseChartA11
   const announce = useCallback((message: string) => setAnnouncement(message), []);
 
   return {
+    id: ariaProps.ids.rootId,
+    ids: ariaProps.ids,
     svgProps,
     getSeriesProps,
     getPointProps,

--- a/packages/visx-a11y/test/useChartA11y.test.tsx
+++ b/packages/visx-a11y/test/useChartA11y.test.tsx
@@ -29,6 +29,12 @@ describe('useChartA11y', () => {
   it('returns chart semantics and generated description metadata', () => {
     const { result } = renderHook(() => useChartA11y(lineConfig));
 
+    expect(result.current.id).toBe('revenue-chart');
+    expect(result.current.ids).toEqual({
+      rootId: 'revenue-chart',
+      descriptionId: 'revenue-chart-description',
+      tableId: 'revenue-chart-table',
+    });
     expect(result.current.descriptionId).toBe('revenue-chart-description');
     expect(result.current.description).toBe(
       'line chart of Revenue over 2 data points. Values start at $10 for Jan, end at $25 for Feb, range from $10 at Jan to $25 at Feb.',
@@ -66,6 +72,8 @@ describe('useChartA11y', () => {
       useChartA11y({ ...lineConfig, id: undefined, idPrefix: 'chart' }),
     );
 
+    expect(result.current.id).toMatch(/^chart-[\w-]+$/);
+    expect(result.current.ids.rootId).toBe(result.current.id);
     expect(result.current.descriptionId).toMatch(/^chart-[\w-]+-description$/);
     expect(result.current.descriptionId).not.toBe('chart-revenue-description');
   });

--- a/packages/visx-chart/Readme.md
+++ b/packages/visx-chart/Readme.md
@@ -1,8 +1,8 @@
 # @visx/chart
 
-Chart-level React hooks for building primitive visx charts without adopting a chart framework. The
-package starts with shared layout helpers that registry-style charts can use before composing
-`@visx/axis`, `@visx/scale`, `@visx/shape`, and other low-level primitives.
+Chart-level React hooks and helpers for building primitive visx charts without adopting a chart
+framework. The package starts with shared layout and domain helpers that registry-style charts can
+use before composing `@visx/axis`, `@visx/scale`, `@visx/shape`, and other low-level primitives.
 
 ## Installation
 
@@ -20,6 +20,8 @@ is the point, but every primitive chart still tends to rebuild the same chart-le
 - margin defaults
 - inner drawable width and height
 - `xMax` and `yMax` aliases used throughout visx examples
+- common numeric domains for primitive chart scales
+- responsive width fallbacks while parent measurement initializes
 - stable layout objects for downstream hooks and components
 
 Those details are small, but they become repetitive in examples, dashboards, and registry items.
@@ -65,6 +67,92 @@ export function ChartFrame({ width, height, children }) {
 
 The hook fills missing margin sides with `0`, treats non-finite dimensions as `0`, and clamps the
 inner drawing area to `0` so marks never receive negative layout space.
+
+## Numeric domains
+
+Use the domain helpers when a primitive chart needs the usual safe defaults for empty, invalid, or
+single-value data.
+
+```tsx
+import { getPositiveDomain, getZeroBaselineDomain } from '@visx/chart';
+
+const yDomain = getZeroBaselineDomain(data.map((datum) => datum.value));
+const stackedYDomain = getPositiveDomain(
+  data.map((datum) => datum.desktop + datum.mobile + datum.tablet),
+);
+```
+
+`getZeroBaselineDomain` includes zero and expands equal domains. `getPositiveDomain` returns a
+positive `[0, max]` domain with an empty fallback of `[0, 1]`. `getPaddedDomain` is available for
+plots such as scatter charts where the domain should wrap finite values with proportional padding.
+
+## Axis ticks
+
+Use the tick helpers when a chart axis may become too dense in responsive layouts.
+`getVisibleTickValues` thins explicit category tick values while preserving the first and last tick
+by default, and `getAxisTickCount` computes a conservative numeric tick count from the available
+axis length.
+
+```tsx
+import { getAxisTickCount, getVisibleTickValues } from '@visx/chart';
+
+const xTickValues = getVisibleTickValues(months, {
+  axisLength: dimensions.innerWidth,
+  minTickSpacing: 48,
+});
+const yNumTicks = getAxisTickCount({
+  axisLength: dimensions.innerHeight,
+  maxTicks: 5,
+  minTickSpacing: 48,
+});
+```
+
+The helpers only choose visible axis labels. They do not remove data points, bars, bins, or table
+fallback rows.
+
+## Responsive width fallback
+
+Use `getResponsiveWidth` when a responsive container may report `0`, `NaN`, or another
+non-renderable width while layout measurement initializes.
+
+```tsx
+import { getResponsiveWidth } from '@visx/chart';
+
+const chartWidth = getResponsiveWidth(measuredWidth, 640);
+```
+
+The helper returns the measured width only when it is finite and greater than `0`; otherwise it
+returns the fallback width.
+
+## Chart config
+
+Use `ChartConfig` when labels, colors, icons, and theme-specific tokens should live outside the
+chart data. This mirrors the way registry charts are usually copied into app code: the data can come
+from an API while chart presentation stays colocated with the component.
+
+```tsx
+import { getChartConfigColor, getChartConfigLabel, type ChartConfig } from '@visx/chart';
+
+const chartConfig = {
+  bookings: {
+    label: 'Bookings',
+    color: 'var(--chart-1)',
+  },
+  revenue: {
+    label: 'Revenue',
+    theme: {
+      light: 'oklch(0.646 0.222 41.116)',
+      dark: 'oklch(0.488 0.243 264.376)',
+    },
+  },
+} satisfies ChartConfig;
+
+const label = getChartConfigLabel(chartConfig, 'bookings');
+const color = getChartConfigColor(chartConfig, 'bookings', 'currentColor');
+```
+
+`getChartCssVariables` can turn a config into `--color-*` CSS variables for chart shells that want
+the same token style as copied registry components.
 
 ## Working with scales
 
@@ -162,12 +250,15 @@ export function RevenueBars({ data, width, height }) {
 `@visx/responsive` when a chart should fill available space.
 
 ```tsx
+import { getResponsiveWidth } from '@visx/chart';
 import { ParentSize } from '@visx/responsive';
 
 export function ResponsiveRevenueBars({ data }) {
   return (
     <ParentSize>
-      {({ width, height }) => <RevenueBars data={data} width={width} height={height} />}
+      {({ width }) => (
+        <RevenueBars data={data} width={getResponsiveWidth(width, 640)} height={320} />
+      )}
     </ParentSize>
   );
 }

--- a/packages/visx-chart/src/config.ts
+++ b/packages/visx-chart/src/config.ts
@@ -1,0 +1,50 @@
+import type { ComponentType } from 'react';
+
+export type ChartTheme = 'light' | 'dark';
+
+export type ChartConfigItem = {
+  label?: string;
+  color?: string;
+  theme?: Partial<Record<ChartTheme, string>>;
+  icon?: ComponentType<{ className?: string }>;
+};
+
+export type ChartConfig = Record<string, ChartConfigItem>;
+
+export function getChartConfigEntry(config: ChartConfig | undefined, key: string) {
+  return config?.[key];
+}
+
+export function getChartConfigLabel(config: ChartConfig | undefined, key: string, fallback = key) {
+  return getChartConfigEntry(config, key)?.label ?? fallback;
+}
+
+export function getChartConfigColor(
+  config: ChartConfig | undefined,
+  key: string,
+  fallback?: string,
+  theme?: ChartTheme,
+) {
+  const entry = getChartConfigEntry(config, key);
+
+  return (theme ? entry?.theme?.[theme] : undefined) ?? entry?.color ?? fallback;
+}
+
+export function getChartConfigIcon(config: ChartConfig | undefined, key: string) {
+  return getChartConfigEntry(config, key)?.icon;
+}
+
+export function getChartCssVariableName(key: string) {
+  return `--color-${key.replace(/[^\w-]/g, '-')}`;
+}
+
+export function getChartCssVariables(config: ChartConfig | undefined, theme?: ChartTheme) {
+  return Object.fromEntries(
+    Object.keys(config ?? {})
+      .map((key) => [
+        getChartCssVariableName(key),
+        getChartConfigColor(config, key, undefined, theme),
+      ])
+      .filter((entry): entry is [string, string] => entry[1] != null),
+  );
+}

--- a/packages/visx-chart/src/domains.ts
+++ b/packages/visx-chart/src/domains.ts
@@ -1,0 +1,47 @@
+export type NumericDomain = [number, number];
+
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function getFiniteValues(values: readonly number[]) {
+  return values.filter(isFiniteNumber);
+}
+
+export function getZeroBaselineDomain(values: readonly number[]): NumericDomain {
+  const finiteValues = getFiniteValues(values);
+
+  if (finiteValues.length === 0) {
+    return [0, 1];
+  }
+
+  const min = Math.min(0, ...finiteValues);
+  const max = Math.max(0, ...finiteValues);
+
+  return min === max ? [min - 1, max + 1] : [min, max];
+}
+
+export function getPositiveDomain(values: readonly number[]): NumericDomain {
+  const max = Math.max(0, ...getFiniteValues(values));
+
+  return max === 0 ? [0, 1] : [0, max];
+}
+
+export function getPaddedDomain(values: readonly number[], paddingRatio = 0.08): NumericDomain {
+  const finiteValues = getFiniteValues(values);
+
+  if (finiteValues.length === 0) {
+    return [0, 1];
+  }
+
+  const min = Math.min(...finiteValues);
+  const max = Math.max(...finiteValues);
+
+  if (min === max) {
+    return [min - 1, max + 1];
+  }
+
+  const padding = (max - min) * Math.max(0, paddingRatio);
+
+  return [min - padding, max + padding];
+}

--- a/packages/visx-chart/src/index.ts
+++ b/packages/visx-chart/src/index.ts
@@ -1,6 +1,30 @@
 // @visx/chart
+export {
+  getChartConfigColor,
+  getChartConfigEntry,
+  getChartConfigIcon,
+  getChartConfigLabel,
+  getChartCssVariableName,
+  getChartCssVariables,
+} from './config';
+export {
+  getPaddedDomain,
+  getPositiveDomain,
+  getZeroBaselineDomain,
+  isFiniteNumber,
+} from './domains';
+export { getResponsiveWidth } from './responsive';
+export { getAxisTickCount, getVisibleTickValues } from './ticks';
 export { default as useChartDimensions } from './useChartDimensions';
 
+export type { ChartConfig, ChartConfigItem, ChartTheme } from './config';
+export type { NumericDomain } from './domains';
+export type {
+  AxisTickFormatter,
+  AxisTickValue,
+  GetAxisTickCountOptions,
+  GetVisibleTickValuesOptions,
+} from './ticks';
 export type {
   ChartDimensions,
   MarginShape,

--- a/packages/visx-chart/src/responsive.ts
+++ b/packages/visx-chart/src/responsive.ts
@@ -1,0 +1,3 @@
+export function getResponsiveWidth(measuredWidth: number, fallbackWidth: number) {
+  return Number.isFinite(measuredWidth) && measuredWidth > 0 ? measuredWidth : fallbackWidth;
+}

--- a/packages/visx-chart/src/ticks.ts
+++ b/packages/visx-chart/src/ticks.ts
@@ -1,0 +1,90 @@
+export type AxisTickValue = string | number | Date;
+
+export type AxisTickFormatter<TickValue extends AxisTickValue> = (
+  value: TickValue,
+  index: number,
+) => string;
+
+export type GetAxisTickCountOptions = {
+  axisLength: number;
+  maxTicks?: number;
+  minTicks?: number;
+  minTickSpacing?: number;
+};
+
+export type GetVisibleTickValuesOptions = {
+  axisLength: number;
+  minTickSpacing?: number;
+  preserveEndTicks?: boolean;
+};
+
+const DEFAULT_MIN_TICK_SPACING = 48;
+
+function getFiniteLength(value: number) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function getPositiveInteger(value: number | undefined, fallback: number) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.floor(value));
+}
+
+export function getAxisTickCount({
+  axisLength,
+  maxTicks = 5,
+  minTicks = 2,
+  minTickSpacing = DEFAULT_MIN_TICK_SPACING,
+}: GetAxisTickCountOptions) {
+  const length = getFiniteLength(axisLength);
+  const spacing = Math.max(1, getFiniteLength(minTickSpacing));
+  const minimum = getPositiveInteger(minTicks, 2);
+  const maximum = Math.max(minimum, getPositiveInteger(maxTicks, 5));
+  const count = length === 0 ? minimum : Math.floor(length / spacing);
+
+  return Math.min(maximum, Math.max(minimum, count));
+}
+
+export function getVisibleTickValues<TickValue extends AxisTickValue>(
+  values: readonly TickValue[],
+  { axisLength, minTickSpacing, preserveEndTicks = true }: GetVisibleTickValuesOptions,
+) {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const maxVisibleTicks = getAxisTickCount({
+    axisLength,
+    maxTicks: values.length,
+    minTicks: preserveEndTicks && values.length > 1 ? 2 : 1,
+    minTickSpacing,
+  });
+
+  if (values.length <= maxVisibleTicks) {
+    return [...values];
+  }
+
+  if (!preserveEndTicks) {
+    const step = Math.ceil(values.length / maxVisibleTicks);
+
+    return values.filter((_, index) => index % step === 0).slice(0, maxVisibleTicks);
+  }
+
+  if (maxVisibleTicks <= 1) {
+    return [values[0]];
+  }
+
+  const lastIndex = values.length - 1;
+  const step = Math.ceil(lastIndex / (maxVisibleTicks - 1));
+  const indices = new Set<number>();
+
+  for (let index = 0; index < lastIndex && indices.size < maxVisibleTicks - 1; index += step) {
+    indices.add(index);
+  }
+
+  indices.add(lastIndex);
+
+  return [...indices].sort((a, b) => a - b).map((index) => values[index]);
+}

--- a/packages/visx-chart/test/config.test.ts
+++ b/packages/visx-chart/test/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getChartConfigColor,
+  getChartConfigEntry,
+  getChartConfigIcon,
+  getChartConfigLabel,
+  getChartCssVariableName,
+  getChartCssVariables,
+  type ChartConfig,
+} from '../src';
+
+function Icon() {
+  return null;
+}
+
+const config = {
+  desktop: {
+    label: 'Desktop',
+    color: 'var(--chart-1)',
+    icon: Icon,
+  },
+  mobile: {
+    label: 'Mobile',
+    theme: {
+      light: 'oklch(0.6 0.1 184)',
+      dark: 'oklch(0.7 0.1 162)',
+    },
+  },
+} satisfies ChartConfig;
+
+describe('chart config helpers', () => {
+  it('returns labels, colors, icons, and fallbacks for chart config entries', () => {
+    expect(getChartConfigEntry(config, 'desktop')).toEqual(config.desktop);
+    expect(getChartConfigLabel(config, 'desktop')).toBe('Desktop');
+    expect(getChartConfigLabel(config, 'tablet', 'Tablet')).toBe('Tablet');
+    expect(getChartConfigColor(config, 'desktop')).toBe('var(--chart-1)');
+    expect(getChartConfigColor(config, 'mobile', undefined, 'dark')).toBe('oklch(0.7 0.1 162)');
+    expect(getChartConfigColor(config, 'mobile', 'fallback')).toBe('fallback');
+    expect(getChartConfigIcon(config, 'desktop')).toBe(Icon);
+  });
+
+  it('creates stable CSS variables from chart config keys', () => {
+    expect(getChartCssVariableName('desktop visitors')).toBe('--color-desktop-visitors');
+    expect(getChartCssVariables(config, 'light')).toEqual({
+      '--color-desktop': 'var(--chart-1)',
+      '--color-mobile': 'oklch(0.6 0.1 184)',
+    });
+  });
+});

--- a/packages/visx-chart/test/domains.test.ts
+++ b/packages/visx-chart/test/domains.test.ts
@@ -1,0 +1,40 @@
+import {
+  getPaddedDomain,
+  getPositiveDomain,
+  getResponsiveWidth,
+  getZeroBaselineDomain,
+  isFiniteNumber,
+} from '../src';
+
+describe('chart helpers', () => {
+  it('filters finite numbers', () => {
+    expect([1, Number.NaN, Infinity, 2].filter(isFiniteNumber)).toEqual([1, 2]);
+  });
+
+  it('computes zero-baseline domains', () => {
+    expect(getZeroBaselineDomain([4, 8])).toEqual([0, 8]);
+    expect(getZeroBaselineDomain([-4, 8])).toEqual([-4, 8]);
+    expect(getZeroBaselineDomain([5, Number.NaN])).toEqual([0, 5]);
+    expect(getZeroBaselineDomain([])).toEqual([0, 1]);
+    expect(getZeroBaselineDomain([0])).toEqual([-1, 1]);
+  });
+
+  it('computes positive domains', () => {
+    expect(getPositiveDomain([4, 8])).toEqual([0, 8]);
+    expect(getPositiveDomain([-4, 0])).toEqual([0, 1]);
+    expect(getPositiveDomain([])).toEqual([0, 1]);
+  });
+
+  it('computes padded domains', () => {
+    expect(getPaddedDomain([10, 20])).toEqual([9.2, 20.8]);
+    expect(getPaddedDomain([10, 20], 0.1)).toEqual([9, 21]);
+    expect(getPaddedDomain([10])).toEqual([9, 11]);
+    expect(getPaddedDomain([])).toEqual([0, 1]);
+  });
+
+  it('falls back to the configured width until measurement is available', () => {
+    expect(getResponsiveWidth(0, 640)).toBe(640);
+    expect(getResponsiveWidth(Number.NaN, 640)).toBe(640);
+    expect(getResponsiveWidth(320, 640)).toBe(320);
+  });
+});

--- a/packages/visx-chart/test/ssr.test.tsx
+++ b/packages/visx-chart/test/ssr.test.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { useChartDimensions } from '../src';
+import { getPositiveDomain, getResponsiveWidth, useChartDimensions } from '../src';
 
 function ChartProbe() {
   const { innerWidth, innerHeight } = useChartDimensions({
@@ -17,5 +17,7 @@ function ChartProbe() {
 describe('@visx/chart SSR', () => {
   it('renders without touching browser globals', () => {
     expect(renderToString(<ChartProbe />)).toContain('80x50');
+    expect(getPositiveDomain([1, 2])).toEqual([0, 2]);
+    expect(getResponsiveWidth(0, 100)).toBe(100);
   });
 });

--- a/packages/visx-chart/test/ticks.test.ts
+++ b/packages/visx-chart/test/ticks.test.ts
@@ -1,0 +1,55 @@
+import { getAxisTickCount, getVisibleTickValues } from '../src';
+
+describe('tick helpers', () => {
+  it('computes responsive tick counts from axis length', () => {
+    expect(getAxisTickCount({ axisLength: 240, minTickSpacing: 48 })).toBe(5);
+    expect(getAxisTickCount({ axisLength: 120, minTickSpacing: 48 })).toBe(2);
+    expect(getAxisTickCount({ axisLength: 500, maxTicks: 6, minTickSpacing: 48 })).toBe(6);
+  });
+
+  it('preserves end ticks while thinning dense tick values', () => {
+    expect(
+      getVisibleTickValues(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'], {
+        axisLength: 160,
+        minTickSpacing: 48,
+      }),
+    ).toEqual(['Jan', 'Apr', 'Jul']);
+  });
+
+  it('avoids adjacent visible ticks when rounding could crowd labels', () => {
+    expect(
+      getVisibleTickValues(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'], {
+        axisLength: 240,
+        minTickSpacing: 48,
+      }),
+    ).toEqual(['Jan', 'Mar', 'May', 'Jul']);
+  });
+
+  it('preserves the final tick without exceeding the visible tick budget', () => {
+    expect(
+      getVisibleTickValues(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'], {
+        axisLength: 144,
+        minTickSpacing: 48,
+      }),
+    ).toEqual(['A', 'F', 'J']);
+  });
+
+  it('allows callers to thin without preserving end ticks', () => {
+    expect(
+      getVisibleTickValues(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'], {
+        axisLength: 160,
+        minTickSpacing: 48,
+        preserveEndTicks: false,
+      }),
+    ).toEqual(['Jan', 'Apr', 'Jul']);
+  });
+
+  it('returns all tick values when they fit', () => {
+    expect(
+      getVisibleTickValues(['Jan', 'Feb', 'Mar'], {
+        axisLength: 240,
+        minTickSpacing: 48,
+      }),
+    ).toEqual(['Jan', 'Feb', 'Mar']);
+  });
+});

--- a/packages/visx-registry/Readme.md
+++ b/packages/visx-registry/Readme.md
@@ -1,0 +1,110 @@
+# @visx/registry
+
+Source files and validation scripts for the visx shadcn registry. This package is private and has no
+runtime API; it exists to ship drop-in chart components through GitHub registry installs.
+
+## Motivation
+
+visx is intentionally low level: primitives take props, compose freely, and stay out of your app's
+state model. That is what makes visx useful for unusual charts, custom dashboards, and product
+interfaces that do not fit a fixed charting API.
+
+The tradeoff is that teams often need a good starting point before they can customize. A line chart,
+bar chart, heatmap chart, or treemap chart usually needs the same surrounding work:
+
+- responsive SVG sizing
+- theme token usage
+- axis and grid styling
+- accessible SVG labels and descriptions
+- hidden data table fallbacks
+- live region wiring
+- installable dependency metadata
+
+That work is valuable, but it is repetitive. `@visx/registry` packages those starting points as
+copyable registry items while keeping the installed output plain React and visx primitives.
+
+## Registry-first design
+
+The registry package is distribution infrastructure, not a chart framework.
+
+- Registry items install into user projects as source files.
+- Installed charts depend on public visx packages, not `@visx/registry`.
+- Source files live under `registry/charts`.
+- The repository root `registry.json` is the public GitHub registry entrypoint.
+- The source registries are committed, but generated `public/r` item JSON is not.
+- Each chart remains editable after install.
+
+This keeps the installed result compatible with the rest of visx: users can change scales, marks,
+themes, accessibility labels, data accessors, and layout directly in their app.
+
+## Local development
+
+Add or edit chart source in `registry/charts`, then update `registry.json` with the item metadata,
+dependencies, source path, and install target.
+
+```sh
+yarn registry:validate
+```
+
+This validates both the root GitHub registry entrypoint and the package source registry with the
+shadcn CLI.
+
+Run the focused registry test suite when changing chart source, metadata, or build scripts:
+
+```sh
+yarn vitest run --project @visx/registry
+```
+
+Run the install smoke when changing public item names, file targets, dependencies, or exported
+component names:
+
+```sh
+yarn registry:smoke
+```
+
+The smoke test installs every registry item into fresh Next and Vite fixtures with the real shadcn
+CLI and typechecks the installed source.
+
+## Item structure
+
+Each registry item should have a stable install name and a matching component export.
+
+```txt
+registry/charts/line-chart/line-chart.tsx
+components/charts/line-chart.tsx
+export function LineChart()
+```
+
+Use the `-chart` suffix for chart item names, source files, targets, and exported components. This
+keeps registry install names, file names, and generated import names predictable.
+
+## GitHub installs
+
+The public registry entrypoint is the repository root `registry.json`, which includes this package's
+source registry:
+
+```txt
+registry.json
+packages/visx-registry/registry.json
+```
+
+After the registry branch lands on the default branch and the referenced visx packages are
+published, items can be installed with the shadcn CLI by GitHub address:
+
+```sh
+npx shadcn@latest add airbnb/visx/line-chart
+```
+
+The local smoke test builds registry item JSON into a temporary directory only so unpublished branch
+changes can still be installed into fresh fixtures.
+
+## Accessibility and theming
+
+Registry charts should ship with live accessibility wiring from `@visx/a11y` and theme token usage
+from `@visx/theme`.
+
+Use `showLiveRegion={false}` when rendering multiple charts on a page that owns a single shared
+announcer. The chart should still render its SVG semantics and hidden data table fallback.
+
+Charts should read theme values through visx theme hooks and CSS-ready variables, rather than
+hard-coding light and dark mode branches.

--- a/packages/visx-registry/package.json
+++ b/packages/visx-registry/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@visx/registry",
+  "version": "4.0.0",
+  "private": true,
+  "description": "visx chart registry source files",
+  "sideEffects": false,
+  "scripts": {
+    "build": "yarn run validate",
+    "smoke:install": "tsx scripts/smokeInstallRegistryItem.ts",
+    "test": "vitest run",
+    "validate": "yarn run validate:root && yarn run validate:source",
+    "validate:root": "shadcn registry validate registry.json --cwd ../..",
+    "validate:source": "shadcn registry validate"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/airbnb/visx.git"
+  },
+  "keywords": [
+    "visx",
+    "react",
+    "visualizations",
+    "charts",
+    "registry"
+  ],
+  "author": "@hshoff",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/airbnb/visx/issues"
+  },
+  "homepage": "https://github.com/airbnb/visx#readme",
+  "dependencies": {
+    "@visx/a11y": "workspace:*",
+    "@visx/axis": "workspace:*",
+    "@visx/chart": "workspace:*",
+    "@visx/grid": "workspace:*",
+    "@visx/heatmap": "workspace:*",
+    "@visx/hierarchy": "workspace:*",
+    "@visx/responsive": "workspace:*",
+    "@visx/scale": "workspace:*",
+    "@visx/shape": "workspace:*",
+    "@visx/theme": "workspace:*",
+    "@visx/threshold": "workspace:*",
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.0",
+    "shadcn": "4.11.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "vitest": "4.1.8"
+  }
+}

--- a/packages/visx-registry/registry.json
+++ b/packages/visx-registry/registry.json
@@ -1,0 +1,511 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "visx",
+  "homepage": "https://github.com/airbnb/visx",
+  "items": [
+    {
+      "name": "line-chart",
+      "type": "registry:block",
+      "title": "Line Chart",
+      "description": "Themed, responsive, accessible line chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/line-chart/line-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/line-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "bar-chart",
+      "type": "registry:block",
+      "title": "Bar Chart",
+      "description": "Themed, responsive, accessible bar chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/bar-chart/bar-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/bar-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "area-chart",
+      "type": "registry:block",
+      "title": "Area Chart",
+      "description": "Themed, responsive, accessible area chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/area-chart/area-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/area-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "scatter-chart",
+      "type": "registry:block",
+      "title": "Scatter Chart",
+      "description": "Themed, responsive, accessible scatter chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/scatter-chart/scatter-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/scatter-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "stacked-bar-chart",
+      "type": "registry:block",
+      "title": "Stacked Bar Chart",
+      "description": "Themed, responsive, accessible stacked bar chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/stacked-bar-chart/stacked-bar-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/stacked-bar-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "multi-series-line-chart",
+      "type": "registry:block",
+      "title": "Multi-series Line Chart",
+      "description": "Themed, responsive, accessible multi-series line chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/multi-series-line-chart/multi-series-line-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/multi-series-line-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "pie-chart",
+      "type": "registry:block",
+      "title": "Pie Chart",
+      "description": "Themed, responsive, accessible pie chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/chart",
+        "@visx/responsive",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/pie-chart/pie-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/pie-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "histogram-chart",
+      "type": "registry:block",
+      "title": "Histogram Chart",
+      "description": "Themed, responsive, accessible histogram chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/histogram-chart/histogram-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/histogram-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "core"
+      }
+    },
+    {
+      "name": "grouped-bar-chart",
+      "type": "registry:block",
+      "title": "Grouped Bar Chart",
+      "description": "Themed, responsive, accessible grouped bar chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/grouped-bar-chart/grouped-bar-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/grouped-bar-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "horizontal-stacked-bar-chart",
+      "type": "registry:block",
+      "title": "Horizontal Stacked Bar Chart",
+      "description": "Themed, responsive, accessible horizontal stacked bar chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/horizontal-stacked-bar-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "stacked-area-chart",
+      "type": "registry:block",
+      "title": "Stacked Area Chart",
+      "description": "Themed, responsive, accessible stacked area chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/stacked-area-chart/stacked-area-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/stacked-area-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "threshold-chart",
+      "type": "registry:block",
+      "title": "Threshold Chart",
+      "description": "Themed, responsive, accessible threshold chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/axis",
+        "@visx/chart",
+        "@visx/grid",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/threshold",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/threshold-chart/threshold-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/threshold-chart.tsx"
+        },
+        {
+          "path": "registry/charts/bar-chart/chart-ui.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-ui.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "heatmap-chart",
+      "type": "registry:block",
+      "title": "Heatmap Chart",
+      "description": "Themed, responsive, accessible heatmap chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/chart",
+        "@visx/heatmap",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/heatmap-chart/heatmap-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/heatmap-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "radar-chart",
+      "type": "registry:block",
+      "title": "Radar Chart",
+      "description": "Themed, responsive, accessible radar chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/chart",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/radar-chart/radar-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/radar-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "radial-bar-chart",
+      "type": "registry:block",
+      "title": "Radial Bar Chart",
+      "description": "Themed, responsive, accessible radial bar chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/chart",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/shape",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/radial-bar-chart/radial-bar-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/radial-bar-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    },
+    {
+      "name": "treemap-chart",
+      "type": "registry:block",
+      "title": "Treemap Chart",
+      "description": "Themed, responsive, accessible treemap chart built from visx primitives.",
+      "dependencies": [
+        "@visx/a11y",
+        "@visx/chart",
+        "@visx/hierarchy",
+        "@visx/responsive",
+        "@visx/scale",
+        "@visx/theme"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/charts/treemap-chart/treemap-chart.tsx",
+          "type": "registry:component",
+          "target": "components/charts/treemap-chart.tsx"
+        }
+      ],
+      "meta": {
+        "a11y": true,
+        "client": true,
+        "ssr": true,
+        "tier": "extended"
+      }
+    }
+  ]
+}

--- a/packages/visx-registry/registry/charts/area-chart/area-chart.tsx
+++ b/packages/visx-registry/registry/charts/area-chart/area-chart.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  getZeroBaselineDomain,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { AreaClosed, LinePath } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useGridStyle } from '@visx/theme/react';
+
+export type AreaChartDatum = {
+  x: string;
+  y: number;
+};
+
+export type AreaChartMargin = MarginShape;
+
+export type AreaChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: AreaChartDatum[];
+  height?: number;
+  margin?: AreaChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type AreaChartSvgProps = Required<
+  Pick<
+    AreaChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    AreaChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: AreaChartDatum[] = [
+  { x: 'Jan', y: 18 },
+  { x: 'Feb', y: 28 },
+  { x: 'Mar', y: 34 },
+  { x: 'Apr', y: 46 },
+  { x: 'May', y: 52 },
+  { x: 'Jun', y: 61 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function getYDomain(data: readonly AreaChartDatum[]): [number, number] {
+  return getZeroBaselineDomain(data.map((datum) => datum.y));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function AreaChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: AreaChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data), [data]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const xScale = useScale({
+    type: 'point',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.35,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const areaColor = useColor(0);
+  const pointColor = useColor('background');
+  const a11y = useChartA11y<AreaChartDatum>({
+    id,
+    title,
+    chartType: 'area',
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+          <GridRows
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={gridStyle.stroke}
+            strokeWidth={gridStyle.strokeWidth}
+            tickValues={yTickValues}
+            width={dimensions.innerWidth}
+          />
+          <AxisLeft
+            label={yLabel}
+            labelOffset={yAxisStyle.labelOffset}
+            labelProps={yAxisStyle.labelProps}
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={yAxisStyle.stroke}
+            strokeWidth={yAxisStyle.strokeWidth}
+            tickFormat={
+              yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+            }
+            tickLabelProps={yAxisStyle.tickLabelProps}
+            tickLength={yAxisStyle.tickLength}
+            tickStroke={yAxisStyle.tickStroke}
+            tickValues={yTickValues}
+          />
+          <AxisBottom
+            label={xLabel}
+            labelOffset={xAxisStyle.labelOffset}
+            labelProps={xAxisStyle.labelProps}
+            scale={xScale}
+            stroke={xAxisStyle.stroke}
+            strokeWidth={xAxisStyle.strokeWidth}
+            tickFormat={xTickFormat}
+            tickLabelProps={xAxisStyle.tickLabelProps}
+            tickLength={xAxisStyle.tickLength}
+            tickStroke={xAxisStyle.tickStroke}
+            tickValues={visibleXTickValues}
+            top={dimensions.innerHeight}
+          />
+          {data.length > 1 && (
+            <>
+              <AreaClosed
+                data={data}
+                defined={(datum) => Number.isFinite(datum.y) && xScale(datum.x) != null}
+                fill={areaColor}
+                fillOpacity={0.18}
+                stroke="none"
+                x={(datum) => xScale(datum.x) ?? 0}
+                y={(datum) => yScale(datum.y) ?? dimensions.innerHeight}
+                yScale={yScale}
+              />
+              <LinePath
+                data={data}
+                defined={(datum) => Number.isFinite(datum.y) && xScale(datum.x) != null}
+                fill="none"
+                stroke={areaColor}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                x={(datum) => xScale(datum.x) ?? 0}
+                y={(datum) => yScale(datum.y) ?? dimensions.innerHeight}
+              />
+            </>
+          )}
+          <g {...a11y.getSeriesProps(0)}>
+            {data.map((datum, index) => {
+              const cx = xScale(datum.x);
+              const cy = yScale(datum.y);
+
+              if (cx == null || cy == null || !Number.isFinite(datum.y)) {
+                return null;
+              }
+
+              return (
+                <circle
+                  key={`${datum.x}-${index}`}
+                  cx={cx}
+                  cy={cy}
+                  r={4}
+                  fill={pointColor}
+                  stroke={areaColor}
+                  strokeWidth={2}
+                  data-area-chart-point=""
+                  {...a11y.getPointProps(0, index)}
+                />
+              );
+            })}
+          </g>
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function AreaChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: AreaChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <AreaChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Area chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/bar-chart/bar-chart.tsx
+++ b/packages/visx-registry/registry/charts/bar-chart/bar-chart.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo, useState } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getChartConfigColor,
+  getChartConfigIcon,
+  getChartConfigLabel,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  getZeroBaselineDomain,
+  type AxisTickFormatter,
+  type ChartConfig,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { BarRounded } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useGridStyle } from '@visx/theme/react';
+import { ChartLegend, ChartTooltip } from './chart-ui';
+
+export type BarChartDatum = {
+  x: string;
+  y: number;
+};
+
+export type BarChartMargin = MarginShape;
+
+export type BarChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  config?: ChartConfig;
+  data?: BarChartDatum[];
+  formatValue?: (value: number, datum: BarChartDatum) => string;
+  height?: number;
+  margin?: BarChartMargin;
+  seriesKey?: string;
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  showTooltip?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type BarChartSvgProps = Required<
+  Pick<
+    BarChartProps,
+    | 'data'
+    | 'height'
+    | 'margin'
+    | 'seriesKey'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'showTooltip'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Pick<BarChartProps, 'config' | 'formatValue'> &
+  Omit<
+    BarChartProps,
+    | 'config'
+    | 'data'
+    | 'formatValue'
+    | 'height'
+    | 'margin'
+    | 'seriesKey'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'showTooltip'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+type BarChartTooltipState = {
+  index: number;
+  x: number;
+  y: number;
+};
+
+const defaultData: BarChartDatum[] = [
+  { x: 'Jan', y: 32 },
+  { x: 'Feb', y: 48 },
+  { x: 'Mar', y: 41 },
+  { x: 'Apr', y: 64 },
+  { x: 'May', y: 58 },
+  { x: 'Jun', y: 72 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function getYDomain(data: readonly BarChartDatum[]): [number, number] {
+  return getZeroBaselineDomain(data.map((datum) => datum.y));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function BarChartSvg({
+  className,
+  config,
+  data,
+  formatValue,
+  height,
+  id,
+  margin,
+  seriesKey,
+  showLegend,
+  showLiveRegion,
+  showTooltip,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: BarChartSvgProps) {
+  const [tooltip, setTooltip] = useState<BarChartTooltipState | null>(null);
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data), [data]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const xScale = useScale({
+    type: 'band',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.28,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const barColor = useColor(0);
+  const seriesColor = getChartConfigColor(config, seriesKey, barColor);
+  const seriesLabel = getChartConfigLabel(config, seriesKey, yLabel);
+  const seriesIcon = getChartConfigIcon(config, seriesKey);
+  const a11y = useChartA11y<BarChartDatum>({
+    id,
+    title,
+    chartType: 'bar',
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: seriesLabel }],
+  });
+  const activeDatum = tooltip == null ? null : data[tooltip.index];
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            config={config}
+            items={[{ key: seriesKey, label: seriesLabel, color: seriesColor, icon: seriesIcon }]}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridRows
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={yTickValues}
+              width={dimensions.innerWidth}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={
+                yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={yTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={xTickFormat}
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={visibleXTickValues}
+              top={dimensions.innerHeight}
+            />
+            <g {...a11y.getSeriesProps(0)}>
+              {data.map((datum, index) => {
+                const x = xScale(datum.x);
+                const y = yScale(datum.y);
+                const y0 = yScale(0);
+
+                if (x == null || y == null || y0 == null || !Number.isFinite(datum.y)) {
+                  return null;
+                }
+
+                if (Math.abs(y0 - y) <= 0) {
+                  return null;
+                }
+
+                const pointProps = a11y.getPointProps(0, index);
+                const { onFocus, ...barA11yProps } = pointProps;
+                const showDatumTooltip = () => {
+                  setTooltip({
+                    index,
+                    x: dimensions.margin.left + x + xScale.bandwidth() / 2,
+                    y: legendHeight + dimensions.margin.top + Math.min(y, y0),
+                  });
+                };
+
+                return (
+                  <BarRounded
+                    key={`${datum.x}-${index}`}
+                    x={x}
+                    y={Math.min(y, y0)}
+                    width={xScale.bandwidth()}
+                    height={Math.abs(y0 - y)}
+                    radius={4}
+                    top
+                    fill={seriesColor}
+                    data-bar-chart-bar=""
+                    {...barA11yProps}
+                    onBlur={() => setTooltip(null)}
+                    onFocus={() => {
+                      onFocus?.();
+                      showDatumTooltip();
+                    }}
+                    onPointerEnter={showDatumTooltip}
+                    onPointerLeave={() => setTooltip(null)}
+                    onPointerMove={showDatumTooltip}
+                  />
+                );
+              })}
+            </g>
+          </g>
+        </svg>
+        {showTooltip && activeDatum && (
+          <ChartTooltip
+            active
+            bounds={{
+              width: dimensions.width,
+              height,
+            }}
+            config={config}
+            items={[
+              {
+                key: seriesKey,
+                label: seriesLabel,
+                color: seriesColor,
+                icon: seriesIcon,
+                value: formatValue
+                  ? formatValue(activeDatum.y, activeDatum)
+                  : formatY(activeDatum.y),
+              },
+            ]}
+            label={activeDatum.x}
+            x={tooltip?.x}
+            y={tooltip?.y}
+          />
+        )}
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function BarChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: BarChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <BarChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          seriesKey={props.seriesKey ?? 'value'}
+          showLegend={props.showLegend ?? false}
+          showLiveRegion={props.showLiveRegion ?? true}
+          showTooltip={props.showTooltip ?? true}
+          title={props.title ?? 'Bar chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/bar-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/bar-chart/chart-ui.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getChartConfigColor,
+  getChartConfigIcon,
+  getChartConfigLabel,
+  type ChartConfig,
+  type ChartConfigItem,
+} from '@visx/chart';
+
+export type ChartLegendItem = {
+  key: string;
+  label?: ReactNode;
+  color?: string;
+  icon?: ChartConfigItem['icon'];
+};
+
+export type ChartLegendProps = {
+  'aria-label'?: string;
+  className?: string;
+  config?: ChartConfig;
+  items?: ChartLegendItem[];
+  series?: string[];
+  style?: CSSProperties;
+};
+
+export type ChartTooltipIndicator = 'dot' | 'line' | 'dashed';
+
+export type ChartTooltipItem = ChartLegendItem & {
+  value?: ReactNode;
+};
+
+export type ChartTooltipBounds = {
+  width: number;
+  height: number;
+  padding?: number;
+};
+
+export type ChartTooltipProps = {
+  active?: boolean;
+  bounds?: ChartTooltipBounds;
+  className?: string;
+  config?: ChartConfig;
+  formatValue?: (item: ChartTooltipItem) => ReactNode;
+  hideIndicator?: boolean;
+  hideLabel?: boolean;
+  indicator?: ChartTooltipIndicator;
+  items?: ChartTooltipItem[];
+  label?: ReactNode;
+  offset?: number;
+  style?: CSSProperties;
+  x?: number;
+  y?: number;
+};
+
+function getConfigSeries(config: ChartConfig | undefined) {
+  return Object.keys(config ?? {});
+}
+
+function getLegendItems({
+  config,
+  items,
+  series,
+}: Pick<ChartLegendProps, 'config' | 'items' | 'series'>) {
+  const baseItems: ChartLegendItem[] =
+    items ??
+    (series ?? getConfigSeries(config)).map((key) => ({
+      key,
+    }));
+
+  return baseItems.map((item) => ({
+    ...item,
+    color: item.color ?? getChartConfigColor(config, item.key),
+    icon: item.icon ?? getChartConfigIcon(config, item.key),
+    label: item.label ?? getChartConfigLabel(config, item.key),
+  }));
+}
+
+function ChartIndicator({
+  color,
+  indicator,
+}: {
+  color?: string;
+  indicator: ChartTooltipIndicator;
+}) {
+  const resolvedColor = color ?? 'currentColor';
+
+  if (indicator === 'line' || indicator === 'dashed') {
+    return (
+      <span
+        aria-hidden="true"
+        style={{
+          width: 14,
+          borderTop: `2px ${indicator === 'dashed' ? 'dashed' : 'solid'} ${resolvedColor}`,
+        }}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 8,
+        height: 8,
+        borderRadius: 999,
+        background: resolvedColor,
+      }}
+    />
+  );
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function ChartLegend({
+  'aria-label': ariaLabel = 'Chart legend',
+  className,
+  config,
+  items,
+  series,
+  style,
+}: ChartLegendProps) {
+  const legendItems = getLegendItems({ config, items, series });
+
+  if (legendItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={className}
+      role="list"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        flexWrap: 'wrap',
+        boxSizing: 'border-box',
+        gap: '10px 14px',
+        color: 'var(--muted-foreground, currentColor)',
+        fontSize: 12,
+        lineHeight: 1,
+        ...style,
+      }}
+    >
+      {legendItems.map(({ color, icon: Icon, key, label }) => (
+        <div
+          key={key}
+          role="listitem"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            minWidth: 0,
+          }}
+        >
+          {Icon ? (
+            <span aria-hidden="true" style={{ color }}>
+              <Icon className="visx-chart-legend-icon" />
+            </span>
+          ) : (
+            <ChartIndicator color={color} indicator="dot" />
+          )}
+          <span>{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ChartTooltip({
+  active,
+  bounds,
+  className,
+  config,
+  formatValue,
+  hideIndicator = false,
+  hideLabel = false,
+  indicator = 'dot',
+  items = [],
+  label,
+  offset = 10,
+  style,
+  x,
+  y,
+}: ChartTooltipProps) {
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const [tooltipSize, setTooltipSize] = useState({ width: 0, height: 0 });
+  const tooltipItems = getLegendItems({ config, items }).map((item) => ({
+    ...item,
+    value: items.find(({ key }) => key === item.key)?.value,
+  }));
+  const position = useMemo(() => {
+    const padding = bounds?.padding ?? 8;
+    const tooltipWidth = tooltipSize.width || 144;
+    const tooltipHeight = tooltipSize.height || 48;
+    const minX = padding + tooltipWidth / 2;
+    const maxX = bounds ? Math.max(minX, bounds.width - padding - tooltipWidth / 2) : minX;
+    const clampedX = bounds && x != null ? clamp(x, minX, maxX) : x;
+    const shouldPlaceBelow = bounds && y != null && y - tooltipHeight - offset < padding;
+    const top = shouldPlaceBelow && y != null ? y + offset : y;
+
+    return {
+      left: clampedX,
+      top,
+      transform: shouldPlaceBelow
+        ? 'translate(-50%, 0)'
+        : `translate(-50%, calc(-100% - ${offset}px))`,
+    };
+  }, [bounds, offset, tooltipSize.height, tooltipSize.width, x, y]);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const rect = tooltipRef.current?.getBoundingClientRect();
+
+    if (!rect) {
+      return;
+    }
+
+    setTooltipSize((currentSize) =>
+      currentSize.width === rect.width && currentSize.height === rect.height
+        ? currentSize
+        : { width: rect.width, height: rect.height },
+    );
+  }, [active, items, label, tooltipItems.length]);
+
+  if (!active || x == null || y == null || tooltipItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={tooltipRef}
+      className={className}
+      role="tooltip"
+      style={{
+        position: 'absolute',
+        left: position.left,
+        top: position.top,
+        zIndex: 10,
+        minWidth: 144,
+        maxWidth: bounds ? `calc(${bounds.width}px - ${(bounds.padding ?? 8) * 2}px)` : 240,
+        transform: position.transform,
+        pointerEvents: 'none',
+        border: '1px solid var(--border, rgb(229, 231, 235))',
+        borderRadius: 8,
+        background: 'var(--popover, var(--card, white))',
+        color: 'var(--popover-foreground, var(--foreground, black))',
+        boxShadow: '0 8px 24px rgb(0 0 0 / 12%)',
+        padding: 10,
+        fontSize: 12,
+        lineHeight: 1.2,
+        overflowWrap: 'break-word',
+        ...style,
+      }}
+    >
+      {!hideLabel && label != null && (
+        <div
+          style={{
+            marginBottom: 8,
+            fontWeight: 600,
+          }}
+        >
+          {label}
+        </div>
+      )}
+      <div style={{ display: 'grid', gap: 6 }}>
+        {tooltipItems.map((item) => {
+          const value = formatValue ? formatValue(item) : item.value;
+          const Icon = item.icon;
+
+          return (
+            <div
+              key={item.key}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              {!hideIndicator && (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: item.color,
+                  }}
+                >
+                  {Icon ? <Icon className="visx-chart-tooltip-icon" /> : null}
+                  {!Icon && <ChartIndicator color={item.color} indicator={indicator} />}
+                </span>
+              )}
+              <span
+                style={{
+                  color: 'var(--muted-foreground, currentColor)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {item.label}
+              </span>
+              <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>{value}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/visx-registry/registry/charts/grouped-bar-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/grouped-bar-chart/chart-ui.tsx
@@ -1,0 +1,9 @@
+export { ChartLegend, ChartTooltip } from '../bar-chart/chart-ui';
+export type {
+  ChartLegendItem,
+  ChartLegendProps,
+  ChartTooltipBounds,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipProps,
+} from '../bar-chart/chart-ui';

--- a/packages/visx-registry/registry/charts/grouped-bar-chart/grouped-bar-chart.tsx
+++ b/packages/visx-registry/registry/charts/grouped-bar-chart/grouped-bar-chart.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y, type ChartA11ySeriesConfig } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getPositiveDomain,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { BarRounded } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColorScale, useGridStyle } from '@visx/theme/react';
+import { ChartLegend } from './chart-ui';
+
+export type GroupedBarChartKey = 'desktop' | 'mobile' | 'tablet';
+
+export type GroupedBarChartDatum = {
+  x: string;
+} & Record<GroupedBarChartKey, number>;
+
+type GroupedBarChartSeriesDatum = {
+  x: string;
+  y: number;
+  series: GroupedBarChartKey;
+};
+
+type NonEmptyGroupedBarChartSeriesData = [
+  GroupedBarChartSeriesDatum[],
+  ...GroupedBarChartSeriesDatum[][],
+];
+
+type NonEmptyGroupedBarChartSeriesConfig = [
+  ChartA11ySeriesConfig<GroupedBarChartSeriesDatum>,
+  ...ChartA11ySeriesConfig<GroupedBarChartSeriesDatum>[],
+];
+
+export type GroupedBarChartMargin = MarginShape;
+
+export type GroupedBarChartProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'width'
+> & {
+  data?: GroupedBarChartDatum[];
+  height?: number;
+  keys?: GroupedBarChartKey[];
+  margin?: GroupedBarChartMargin;
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type GroupedBarChartSvgProps = Required<
+  Pick<
+    GroupedBarChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    GroupedBarChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultKeys: GroupedBarChartKey[] = ['desktop', 'mobile', 'tablet'];
+
+const defaultData: GroupedBarChartDatum[] = [
+  { x: 'Jan', desktop: 26, mobile: 18, tablet: 8 },
+  { x: 'Feb', desktop: 31, mobile: 23, tablet: 10 },
+  { x: 'Mar', desktop: 29, mobile: 26, tablet: 13 },
+  { x: 'Apr', desktop: 36, mobile: 31, tablet: 15 },
+  { x: 'May', desktop: 42, mobile: 34, tablet: 17 },
+  { x: 'Jun', desktop: 48, mobile: 38, tablet: 19 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function formatKey(key: string) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function getBarValue(datum: GroupedBarChartDatum, key: GroupedBarChartKey) {
+  const value = datum[key];
+
+  return Number.isFinite(value) ? value : 0;
+}
+
+function getYDomain(
+  data: readonly GroupedBarChartDatum[],
+  keys: readonly GroupedBarChartKey[],
+): [number, number] {
+  return getPositiveDomain(data.flatMap((datum) => keys.map((key) => getBarValue(datum, key))));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function GroupedBarChartSvg({
+  className,
+  data,
+  height,
+  id,
+  keys,
+  margin,
+  showLegend,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: GroupedBarChartSvgProps) {
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data, keys), [data, keys]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const seriesData = useMemo(
+    () =>
+      keys.map((key) =>
+        data.map((datum) => ({
+          x: datum.x,
+          y: getBarValue(datum, key),
+          series: key,
+        })),
+      ),
+    [data, keys],
+  );
+  const a11yData = useMemo(
+    () => (keys.length > 0 ? (seriesData as NonEmptyGroupedBarChartSeriesData) : []),
+    [keys.length, seriesData],
+  );
+  const a11ySeries = useMemo(
+    () =>
+      (keys.length > 0
+        ? keys.map((key) => ({ label: formatKey(key) }))
+        : [{ label: title }]) as NonEmptyGroupedBarChartSeriesConfig,
+    [keys, title],
+  );
+  const xScale = useScale({
+    type: 'band',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.24,
+  });
+  const groupScale = useScale({
+    type: 'band',
+    domain: keys,
+    range: [0, Math.max(0, xScale.bandwidth())],
+    padding: 0.12,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const colorScale = useColorScale(keys);
+  const legendItems = useMemo(
+    () =>
+      keys.map((key) => ({
+        key,
+        label: formatKey(key),
+        color: colorScale(key),
+      })),
+    [colorScale, keys],
+  );
+  const a11y = useChartA11y<GroupedBarChartSeriesDatum>({
+    id,
+    title,
+    chartType: 'bar',
+    data: a11yData,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0 && keys.length > 0,
+    series: a11ySeries,
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            items={legendItems}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridRows
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={yTickValues}
+              width={dimensions.innerWidth}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={
+                yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={yTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={xTickFormat}
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={visibleXTickValues}
+              top={dimensions.innerHeight}
+            />
+            {keys.map((key, seriesIndex) => (
+              <g key={key} {...a11y.getSeriesProps(seriesIndex)}>
+                {data.map((datum, index) => {
+                  const x = xScale(datum.x);
+                  const offset = groupScale(key);
+                  const y = yScale(getBarValue(datum, key));
+                  const y0 = yScale(0);
+
+                  if (x == null || offset == null || y == null || y0 == null) {
+                    return null;
+                  }
+
+                  const barHeight = Math.abs(y0 - y);
+
+                  return barHeight <= 0 ? null : (
+                    <BarRounded
+                      key={`${key}-${datum.x}-${index}`}
+                      x={x + offset}
+                      y={Math.min(y, y0)}
+                      width={groupScale.bandwidth()}
+                      height={barHeight}
+                      radius={4}
+                      top
+                      fill={colorScale(key)}
+                      data-grouped-bar-chart-bar=""
+                      {...a11y.getPointProps(seriesIndex, index)}
+                    />
+                  );
+                })}
+              </g>
+            ))}
+          </g>
+        </svg>
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function GroupedBarChart({
+  data = defaultData,
+  height = 320,
+  keys = defaultKeys,
+  width = 640,
+  ...props
+}: GroupedBarChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <GroupedBarChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          keys={keys}
+          margin={props.margin ?? defaultMargin}
+          showLegend={props.showLegend ?? true}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Grouped bar chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/heatmap-chart/heatmap-chart.tsx
+++ b/packages/visx-registry/registry/charts/heatmap-chart/heatmap-chart.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import {
+  getPositiveDomain,
+  getResponsiveWidth,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { HeatmapRect } from '@visx/heatmap';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { ThemeScope } from '@visx/theme';
+import { useColor } from '@visx/theme/react';
+
+export type HeatmapCellDatum = {
+  x: string;
+  y: string;
+  value: number;
+};
+
+type HeatmapColumnDatum = {
+  x: string;
+  bins: { y: string; value: number }[];
+};
+
+export type HeatmapChartMargin = MarginShape;
+
+export type HeatmapChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: HeatmapCellDatum[];
+  height?: number;
+  margin?: HeatmapChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  yLabel?: string;
+};
+
+type HeatmapChartSvgProps = Required<
+  Pick<
+    HeatmapChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    HeatmapChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: HeatmapCellDatum[] = [
+  { x: 'Mon', y: 'Search', value: 22 },
+  { x: 'Tue', y: 'Search', value: 28 },
+  { x: 'Wed', y: 'Search', value: 31 },
+  { x: 'Thu', y: 'Search', value: 36 },
+  { x: 'Fri', y: 'Search', value: 42 },
+  { x: 'Mon', y: 'Invite', value: 18 },
+  { x: 'Tue', y: 'Invite', value: 24 },
+  { x: 'Wed', y: 'Invite', value: 29 },
+  { x: 'Thu', y: 'Invite', value: 33 },
+  { x: 'Fri', y: 'Invite', value: 38 },
+  { x: 'Mon', y: 'Export', value: 10 },
+  { x: 'Tue', y: 'Export', value: 16 },
+  { x: 'Wed', y: 'Export', value: 21 },
+  { x: 'Thu', y: 'Export', value: 26 },
+  { x: 'Fri', y: 'Export', value: 31 },
+  { x: 'Mon', y: 'Share', value: 14 },
+  { x: 'Tue', y: 'Share', value: 19 },
+  { x: 'Wed', y: 'Share', value: 24 },
+  { x: 'Thu', y: 'Share', value: 30 },
+  { x: 'Fri', y: 'Share', value: 35 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 40,
+  left: 72,
+};
+
+function getOrderedValues(values: readonly string[]) {
+  return Array.from(new Set(values));
+}
+
+function getColumns(data: readonly HeatmapCellDatum[]) {
+  const xValues = getOrderedValues(data.map((datum) => datum.x));
+  const yValues = getOrderedValues(data.map((datum) => datum.y));
+
+  return xValues.map<HeatmapColumnDatum>((x) => ({
+    x,
+    bins: yValues.map((y) => ({
+      y,
+      value: data.find((datum) => datum.x === x && datum.y === y)?.value ?? 0,
+    })),
+  }));
+}
+
+function getValueDomain(data: readonly HeatmapCellDatum[]): [number, number] {
+  return getPositiveDomain(data.map((datum) => datum.value));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function HeatmapChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  yLabel,
+  ...svgProps
+}: HeatmapChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const columns = useMemo(() => getColumns(data), [data]);
+  const xValues = useMemo(() => columns.map((column) => column.x), [columns]);
+  const yValues = useMemo(() => columns[0]?.bins.map((bin) => bin.y) ?? [], [columns]);
+  const valueDomain = useMemo(() => getValueDomain(data), [data]);
+  const opacityScale = useScale({
+    type: 'linear',
+    domain: valueDomain,
+    range: [0.16, 0.9],
+  });
+  const cellColor = useColor(0);
+  const labelColor = useColor('textMuted');
+  const a11y = useChartA11y<HeatmapCellDatum>({
+    id,
+    title,
+    chartType: 'heatmap',
+    data,
+    x: (datum) => `${datum.x} ${datum.y}`,
+    y: (datum) => datum.value,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+  const binWidth = xValues.length > 0 ? dimensions.innerWidth / xValues.length : 0;
+  const binHeight = yValues.length > 0 ? dimensions.innerHeight / yValues.length : 0;
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+          <HeatmapRect
+            data={columns}
+            xScale={(index) => index * binWidth}
+            yScale={(index) => index * binHeight}
+            binWidth={binWidth}
+            binHeight={binHeight}
+            colorScale={() => cellColor}
+            opacityScale={(value) => opacityScale(value) ?? 0.16}
+            bins={(column) => column.bins}
+            count={(bin) => bin.value}
+            gap={4}
+          >
+            {(heatmap) =>
+              heatmap.flatMap((column) =>
+                column.map((cell) => {
+                  const pointIndex = data.findIndex(
+                    (datum) => datum.x === cell.datum.x && datum.y === cell.bin.y,
+                  );
+
+                  return (
+                    <rect
+                      key={`${cell.datum.x}-${cell.bin.y}`}
+                      x={cell.x}
+                      y={cell.y}
+                      width={Math.max(0, cell.width)}
+                      height={Math.max(0, cell.height)}
+                      rx={4}
+                      fill={cell.color}
+                      fillOpacity={cell.opacity}
+                      data-heatmap-chart-cell=""
+                      {...a11y.getPointProps(0, pointIndex)}
+                    />
+                  );
+                }),
+              )
+            }
+          </HeatmapRect>
+          {xValues.map((value, index) => (
+            <text
+              key={value}
+              x={index * binWidth + binWidth / 2}
+              y={dimensions.innerHeight + 20}
+              fill={labelColor}
+              fontSize={11}
+              textAnchor="middle"
+            >
+              {value}
+            </text>
+          ))}
+          {yValues.map((value, index) => (
+            <text
+              key={value}
+              x={-10}
+              y={index * binHeight + binHeight / 2}
+              dy="0.32em"
+              fill={labelColor}
+              fontSize={11}
+              textAnchor="end"
+            >
+              {value}
+            </text>
+          ))}
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function HeatmapChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: HeatmapChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <HeatmapChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Heatmap Chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Cell'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/heatmap-chart/heatmap-chart.tsx
+++ b/packages/visx-registry/registry/charts/heatmap-chart/heatmap-chart.tsx
@@ -23,7 +23,7 @@ export type HeatmapCellDatum = {
 
 type HeatmapColumnDatum = {
   x: string;
-  bins: { y: string; value: number }[];
+  bins: { pointIndex?: number; y: string; value: number }[];
 };
 
 export type HeatmapChartMargin = MarginShape;
@@ -87,13 +87,30 @@ function getOrderedValues(values: readonly string[]) {
 function getColumns(data: readonly HeatmapCellDatum[]) {
   const xValues = getOrderedValues(data.map((datum) => datum.x));
   const yValues = getOrderedValues(data.map((datum) => datum.y));
+  const cellsByX = new Map<string, Map<string, { pointIndex: number; value: number }>>();
+
+  data.forEach((datum, pointIndex) => {
+    const cellsByY =
+      cellsByX.get(datum.x) ?? new Map<string, { pointIndex: number; value: number }>();
+
+    cellsByY.set(datum.y, {
+      pointIndex,
+      value: Number.isFinite(datum.value) ? datum.value : 0,
+    });
+    cellsByX.set(datum.x, cellsByY);
+  });
 
   return xValues.map<HeatmapColumnDatum>((x) => ({
     x,
-    bins: yValues.map((y) => ({
-      y,
-      value: data.find((datum) => datum.x === x && datum.y === y)?.value ?? 0,
-    })),
+    bins: yValues.map((y) => {
+      const cell = cellsByX.get(x)?.get(y);
+
+      return {
+        pointIndex: cell?.pointIndex,
+        y,
+        value: cell?.value ?? 0,
+      };
+    }),
   }));
 }
 
@@ -182,13 +199,12 @@ function HeatmapChartSvg({
             {(heatmap) =>
               heatmap.flatMap((column) =>
                 column.map((cell) => {
-                  const pointIndex = data.findIndex(
-                    (datum) => datum.x === cell.datum.x && datum.y === cell.bin.y,
-                  );
+                  const pointProps =
+                    cell.bin.pointIndex == null ? {} : a11y.getPointProps(0, cell.bin.pointIndex);
 
                   return (
                     <rect
-                      key={`${cell.datum.x}-${cell.bin.y}`}
+                      key={JSON.stringify([cell.datum.x, cell.bin.y])}
                       x={cell.x}
                       y={cell.y}
                       width={Math.max(0, cell.width)}
@@ -197,7 +213,7 @@ function HeatmapChartSvg({
                       fill={cell.color}
                       fillOpacity={cell.opacity}
                       data-heatmap-chart-cell=""
-                      {...a11y.getPointProps(0, pointIndex)}
+                      {...pointProps}
                     />
                   );
                 }),

--- a/packages/visx-registry/registry/charts/histogram-chart/histogram-chart.tsx
+++ b/packages/visx-registry/registry/charts/histogram-chart/histogram-chart.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getPositiveDomain,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  isFiniteNumber,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { BarRounded } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useGridStyle } from '@visx/theme/react';
+
+export type HistogramBinDatum = {
+  x: string;
+  x0: number;
+  x1: number;
+  y: number;
+};
+
+export type HistogramChartMargin = MarginShape;
+
+export type HistogramChartProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'values' | 'width'
+> & {
+  binCount?: number;
+  height?: number;
+  margin?: HistogramChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  values?: number[];
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type HistogramChartSvgProps = Required<
+  Pick<
+    HistogramChartProps,
+    | 'binCount'
+    | 'height'
+    | 'margin'
+    | 'showLiveRegion'
+    | 'title'
+    | 'values'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    HistogramChartProps,
+    | 'binCount'
+    | 'height'
+    | 'margin'
+    | 'showLiveRegion'
+    | 'title'
+    | 'values'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultValues = [
+  18, 22, 24, 28, 31, 34, 36, 38, 41, 42, 46, 48, 49, 52, 55, 58, 61, 63, 68, 72, 76,
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 }).format(value);
+}
+
+function getBinLabel(x0: number, x1: number) {
+  return `${formatNumber(x0)}-${formatNumber(x1)}`;
+}
+
+function getBins(values: readonly number[], requestedBinCount: number): HistogramBinDatum[] {
+  const finiteValues = values.filter(isFiniteNumber);
+
+  if (finiteValues.length === 0) {
+    return [];
+  }
+
+  const binCount = Math.max(1, Math.floor(requestedBinCount));
+  const min = Math.min(...finiteValues);
+  const max = Math.max(...finiteValues);
+
+  if (min === max) {
+    return [{ x: formatNumber(min), x0: min, x1: max, y: finiteValues.length }];
+  }
+
+  const step = (max - min) / binCount;
+  const bins = Array.from({ length: binCount }, (_, index) => {
+    const x0 = min + step * index;
+    const x1 = index === binCount - 1 ? max : x0 + step;
+
+    return { x: getBinLabel(x0, x1), x0, x1, y: 0 };
+  });
+
+  finiteValues.forEach((value) => {
+    const index = Math.min(binCount - 1, Math.floor((value - min) / step));
+
+    bins[index].y += 1;
+  });
+
+  return bins;
+}
+
+function getYDomain(data: readonly HistogramBinDatum[]): [number, number] {
+  return getPositiveDomain(data.map((datum) => datum.y));
+}
+
+function HistogramChartSvg({
+  binCount,
+  className,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  values,
+  width,
+  xLabel,
+  xMinTickSpacing = 56,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: HistogramChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const bins = useMemo(() => getBins(values, binCount), [values, binCount]);
+  const xDomain = useMemo(() => bins.map((datum) => datum.x), [bins]);
+  const yDomain = useMemo(() => getYDomain(bins), [bins]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const xScale = useScale({
+    type: 'band',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.18,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const barColor = useColor(0);
+  const a11y = useChartA11y<HistogramBinDatum>({
+    id,
+    title,
+    chartType: 'histogram',
+    data: bins,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY: (value) => new Intl.NumberFormat('en-US').format(value),
+    keyboardNavEnabled: bins.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+          <GridRows
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={gridStyle.stroke}
+            strokeWidth={gridStyle.strokeWidth}
+            tickValues={yTickValues}
+            width={dimensions.innerWidth}
+          />
+          <AxisLeft
+            label={yLabel}
+            labelOffset={yAxisStyle.labelOffset}
+            labelProps={yAxisStyle.labelProps}
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={yAxisStyle.stroke}
+            strokeWidth={yAxisStyle.strokeWidth}
+            tickFormat={
+              yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+            }
+            tickLabelProps={yAxisStyle.tickLabelProps}
+            tickLength={yAxisStyle.tickLength}
+            tickStroke={yAxisStyle.tickStroke}
+            tickValues={yTickValues}
+          />
+          <AxisBottom
+            label={xLabel}
+            labelOffset={xAxisStyle.labelOffset}
+            labelProps={xAxisStyle.labelProps}
+            scale={xScale}
+            stroke={xAxisStyle.stroke}
+            strokeWidth={xAxisStyle.strokeWidth}
+            tickFormat={xTickFormat}
+            tickLabelProps={xAxisStyle.tickLabelProps}
+            tickLength={xAxisStyle.tickLength}
+            tickStroke={xAxisStyle.tickStroke}
+            tickValues={visibleXTickValues}
+            top={dimensions.innerHeight}
+          />
+          <g {...a11y.getSeriesProps(0)}>
+            {bins.map((datum, index) => {
+              const x = xScale(datum.x);
+              const y = yScale(datum.y);
+              const y0 = yScale(0);
+
+              if (x == null || y == null || y0 == null) {
+                return null;
+              }
+
+              return Math.abs(y0 - y) <= 0 ? null : (
+                <BarRounded
+                  key={`${datum.x}-${index}`}
+                  x={x}
+                  y={Math.min(y, y0)}
+                  width={xScale.bandwidth()}
+                  height={Math.abs(y0 - y)}
+                  radius={3}
+                  top
+                  fill={barColor}
+                  data-histogram-chart-bin=""
+                  {...a11y.getPointProps(0, index)}
+                />
+              );
+            })}
+          </g>
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function HistogramChart({
+  binCount = 6,
+  height = 320,
+  values = defaultValues,
+  width = 640,
+  ...props
+}: HistogramChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <HistogramChartSvg
+          {...props}
+          binCount={binCount}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Histogram Chart'}
+          values={values}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Range'}
+          yLabel={props.yLabel ?? 'Count'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/horizontal-stacked-bar-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/horizontal-stacked-bar-chart/chart-ui.tsx
@@ -1,0 +1,9 @@
+export { ChartLegend, ChartTooltip } from '../bar-chart/chart-ui';
+export type {
+  ChartLegendItem,
+  ChartLegendProps,
+  ChartTooltipBounds,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipProps,
+} from '../bar-chart/chart-ui';

--- a/packages/visx-registry/registry/charts/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.tsx
+++ b/packages/visx-registry/registry/charts/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.tsx
@@ -1,0 +1,423 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y, type ChartA11ySeriesConfig } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getPositiveDomain,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridColumns } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { BarRounded } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColorScale, useGridStyle } from '@visx/theme/react';
+import { ChartLegend } from './chart-ui';
+
+export type HorizontalStackedBarChartKey = 'desktop' | 'mobile' | 'tablet';
+
+export type HorizontalStackedBarChartDatum = {
+  x: string;
+} & Record<HorizontalStackedBarChartKey, number>;
+
+type HorizontalStackedBarChartSeriesDatum = {
+  x: string;
+  y: number;
+  series: HorizontalStackedBarChartKey;
+};
+
+type NonEmptyHorizontalStackedBarChartSeriesData = [
+  HorizontalStackedBarChartSeriesDatum[],
+  ...HorizontalStackedBarChartSeriesDatum[][],
+];
+
+type NonEmptyHorizontalStackedBarChartSeriesConfig = [
+  ChartA11ySeriesConfig<HorizontalStackedBarChartSeriesDatum>,
+  ...ChartA11ySeriesConfig<HorizontalStackedBarChartSeriesDatum>[],
+];
+
+export type HorizontalStackedBarChartMargin = MarginShape;
+
+export type HorizontalStackedBarChartProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'width'
+> & {
+  data?: HorizontalStackedBarChartDatum[];
+  height?: number;
+  keys?: HorizontalStackedBarChartKey[];
+  margin?: HorizontalStackedBarChartMargin;
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xNumTicks?: number;
+  xTickFormat?: AxisTickFormatter<number>;
+  xTickValues?: number[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yTickFormat?: AxisTickFormatter<string>;
+  yTickValues?: string[];
+};
+
+type HorizontalStackedBarChartSvgProps = Required<
+  Pick<
+    HorizontalStackedBarChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    HorizontalStackedBarChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultKeys: HorizontalStackedBarChartKey[] = ['desktop', 'mobile', 'tablet'];
+
+const defaultData: HorizontalStackedBarChartDatum[] = [
+  { x: 'Enterprise', desktop: 46, mobile: 34, tablet: 18 },
+  { x: 'Mid-market', desktop: 38, mobile: 42, tablet: 20 },
+  { x: 'Startup', desktop: 28, mobile: 48, tablet: 14 },
+  { x: 'Self serve', desktop: 22, mobile: 56, tablet: 12 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 92,
+};
+
+function formatKey(key: string) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function getStackValue(datum: HorizontalStackedBarChartDatum, key: HorizontalStackedBarChartKey) {
+  const value = datum[key];
+
+  return Number.isFinite(value) ? value : 0;
+}
+
+function getXDomain(
+  data: readonly HorizontalStackedBarChartDatum[],
+  keys: readonly HorizontalStackedBarChartKey[],
+): [number, number] {
+  return getPositiveDomain(
+    data.map((datum) => keys.reduce((sum, key) => sum + Math.max(0, getStackValue(datum, key)), 0)),
+  );
+}
+
+function getLastVisibleKey(
+  datum: HorizontalStackedBarChartDatum,
+  keys: readonly HorizontalStackedBarChartKey[],
+) {
+  for (let index = keys.length - 1; index >= 0; index -= 1) {
+    const key = keys[index];
+
+    if (key && getStackValue(datum, key) > 0) {
+      return key;
+    }
+  }
+
+  return null;
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function HorizontalStackedBarChartSvg({
+  className,
+  data,
+  height,
+  id,
+  keys,
+  margin,
+  showLegend,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xNumTicks,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 32,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: HorizontalStackedBarChartSvgProps) {
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const yDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const xDomain = useMemo(() => getXDomain(data, keys), [data, keys]);
+  const visibleYTickValues = useMemo(
+    () =>
+      yTickValues ??
+      getVisibleTickValues(yDomain, {
+        axisLength: dimensions.innerHeight,
+        minTickSpacing: yMinTickSpacing,
+      }),
+    [dimensions.innerHeight, yDomain, yMinTickSpacing, yTickValues],
+  );
+  const visibleXNumTicks =
+    xTickValues == null
+      ? xNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerWidth,
+          maxTicks: 5,
+          minTickSpacing: xMinTickSpacing,
+        })
+      : undefined;
+  const lastVisibleKeyByCategory = useMemo(
+    () => new Map(data.map((datum) => [datum.x, getLastVisibleKey(datum, keys)])),
+    [data, keys],
+  );
+  const seriesData = useMemo(
+    () =>
+      keys.map((key) =>
+        data.map((datum) => ({
+          x: datum.x,
+          y: getStackValue(datum, key),
+          series: key,
+        })),
+      ),
+    [data, keys],
+  );
+  const a11yData = useMemo(
+    () => (keys.length > 0 ? (seriesData as NonEmptyHorizontalStackedBarChartSeriesData) : []),
+    [keys.length, seriesData],
+  );
+  const a11ySeries = useMemo(
+    () =>
+      (keys.length > 0
+        ? keys.map((key) => ({ label: formatKey(key) }))
+        : [{ label: title }]) as NonEmptyHorizontalStackedBarChartSeriesConfig,
+    [keys, title],
+  );
+  const xScale = useScale({
+    type: 'linear',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    nice: true,
+  });
+  const yScale = useScale({
+    type: 'band',
+    domain: yDomain,
+    range: [0, dimensions.innerHeight],
+    padding: 0.32,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const colorScale = useColorScale(keys);
+  const legendItems = useMemo(
+    () =>
+      keys.map((key) => ({
+        key,
+        label: formatKey(key),
+        color: colorScale(key),
+      })),
+    [colorScale, keys],
+  );
+  const a11y = useChartA11y<HorizontalStackedBarChartSeriesDatum>({
+    id,
+    title,
+    chartType: 'bar',
+    data: a11yData,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel: yLabel,
+    yLabel: xLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0 && keys.length > 0,
+    series: a11ySeries,
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            items={legendItems}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridColumns
+              height={dimensions.innerHeight}
+              numTicks={visibleXNumTicks}
+              scale={xScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={xTickValues}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={yTickFormat}
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={visibleYTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              numTicks={visibleXNumTicks}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={
+                xTickFormat ? (value, index) => xTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={xTickValues}
+              top={dimensions.innerHeight}
+            />
+            {keys.map((key, seriesIndex) => (
+              <g key={key} {...a11y.getSeriesProps(seriesIndex)}>
+                {data.map((datum, index) => {
+                  const y = yScale(datum.x);
+                  const barHeight = yScale.bandwidth();
+                  const startValue = keys
+                    .slice(0, seriesIndex)
+                    .reduce((sum, nextKey) => sum + Math.max(0, getStackValue(datum, nextKey)), 0);
+                  const value = Math.max(0, getStackValue(datum, key));
+                  const x0 = xScale(startValue);
+                  const x1 = xScale(startValue + value);
+
+                  if (y == null || x0 == null || x1 == null || value <= 0) {
+                    return null;
+                  }
+
+                  const isLastVisible = lastVisibleKeyByCategory.get(datum.x) === key;
+
+                  return isLastVisible ? (
+                    <BarRounded
+                      key={`${key}-${datum.x}-${index}`}
+                      x={x0}
+                      y={y}
+                      width={Math.max(0, x1 - x0)}
+                      height={barHeight}
+                      radius={4}
+                      right
+                      fill={colorScale(key)}
+                      data-horizontal-stacked-bar-chart-bar=""
+                      {...a11y.getPointProps(seriesIndex, index)}
+                    />
+                  ) : (
+                    <rect
+                      key={`${key}-${datum.x}-${index}`}
+                      x={x0}
+                      y={y}
+                      width={Math.max(0, x1 - x0)}
+                      height={barHeight}
+                      fill={colorScale(key)}
+                      data-horizontal-stacked-bar-chart-bar=""
+                      {...a11y.getPointProps(seriesIndex, index)}
+                    />
+                  );
+                })}
+              </g>
+            ))}
+          </g>
+        </svg>
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function HorizontalStackedBarChart({
+  data = defaultData,
+  height = 320,
+  keys = defaultKeys,
+  width = 640,
+  ...props
+}: HorizontalStackedBarChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <HorizontalStackedBarChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          keys={keys}
+          margin={props.margin ?? defaultMargin}
+          showLegend={props.showLegend ?? true}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Horizontal stacked bar chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Value'}
+          yLabel={props.yLabel ?? 'Category'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/line-chart/line-chart.tsx
+++ b/packages/visx-registry/registry/charts/line-chart/line-chart.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  getZeroBaselineDomain,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { LinePath } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useGridStyle } from '@visx/theme/react';
+
+export type LineChartDatum = {
+  x: string;
+  y: number;
+};
+
+export type LineChartMargin = MarginShape;
+
+export type LineChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: LineChartDatum[];
+  height?: number;
+  margin?: LineChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type LineChartSvgProps = Required<
+  Pick<
+    LineChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    LineChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: LineChartDatum[] = [
+  { x: 'Jan', y: 32 },
+  { x: 'Feb', y: 48 },
+  { x: 'Mar', y: 41 },
+  { x: 'Apr', y: 64 },
+  { x: 'May', y: 58 },
+  { x: 'Jun', y: 72 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function getYDomain(data: readonly LineChartDatum[]): [number, number] {
+  return getZeroBaselineDomain(data.map((datum) => datum.y));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function LineChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: LineChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data), [data]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const xScale = useScale({
+    type: 'point',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.35,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const lineColor = useColor(0);
+  const pointColor = useColor('background');
+  const a11y = useChartA11y<LineChartDatum>({
+    id,
+    title,
+    chartType: 'line',
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+          <GridRows
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={gridStyle.stroke}
+            strokeWidth={gridStyle.strokeWidth}
+            tickValues={yTickValues}
+            width={dimensions.innerWidth}
+          />
+          <AxisLeft
+            label={yLabel}
+            labelOffset={yAxisStyle.labelOffset}
+            labelProps={yAxisStyle.labelProps}
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={yAxisStyle.stroke}
+            strokeWidth={yAxisStyle.strokeWidth}
+            tickFormat={
+              yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+            }
+            tickLabelProps={yAxisStyle.tickLabelProps}
+            tickLength={yAxisStyle.tickLength}
+            tickStroke={yAxisStyle.tickStroke}
+            tickValues={yTickValues}
+          />
+          <AxisBottom
+            label={xLabel}
+            labelOffset={xAxisStyle.labelOffset}
+            labelProps={xAxisStyle.labelProps}
+            scale={xScale}
+            stroke={xAxisStyle.stroke}
+            strokeWidth={xAxisStyle.strokeWidth}
+            tickFormat={xTickFormat}
+            tickLabelProps={xAxisStyle.tickLabelProps}
+            tickLength={xAxisStyle.tickLength}
+            tickStroke={xAxisStyle.tickStroke}
+            tickValues={visibleXTickValues}
+            top={dimensions.innerHeight}
+          />
+          {data.length > 1 && (
+            <LinePath
+              data={data}
+              defined={(datum) => Number.isFinite(datum.y) && xScale(datum.x) != null}
+              fill="none"
+              stroke={lineColor}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+              x={(datum) => xScale(datum.x) ?? 0}
+              y={(datum) => yScale(datum.y) ?? dimensions.innerHeight}
+            />
+          )}
+          <g {...a11y.getSeriesProps(0)}>
+            {data.map((datum, index) => {
+              const cx = xScale(datum.x);
+              const cy = yScale(datum.y);
+
+              if (cx == null || cy == null || !Number.isFinite(datum.y)) {
+                return null;
+              }
+
+              return (
+                <circle
+                  key={`${datum.x}-${index}`}
+                  cx={cx}
+                  cy={cy}
+                  r={4}
+                  fill={pointColor}
+                  stroke={lineColor}
+                  strokeWidth={2}
+                  data-line-chart-point=""
+                  {...a11y.getPointProps(0, index)}
+                />
+              );
+            })}
+          </g>
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function LineChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: LineChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <LineChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Line chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/multi-series-line-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/multi-series-line-chart/chart-ui.tsx
@@ -1,0 +1,9 @@
+export { ChartLegend, ChartTooltip } from '../bar-chart/chart-ui';
+export type {
+  ChartLegendItem,
+  ChartLegendProps,
+  ChartTooltipBounds,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipProps,
+} from '../bar-chart/chart-ui';

--- a/packages/visx-registry/registry/charts/multi-series-line-chart/multi-series-line-chart.tsx
+++ b/packages/visx-registry/registry/charts/multi-series-line-chart/multi-series-line-chart.tsx
@@ -1,0 +1,397 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y, type ChartA11ySeriesConfig } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  getZeroBaselineDomain,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { LinePath } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useColorScale, useGridStyle } from '@visx/theme/react';
+import { ChartLegend } from './chart-ui';
+
+export type MultiSeriesLineChartDatum = {
+  x: string;
+  y: number;
+};
+
+export type MultiSeriesLineChartSeries = {
+  label: string;
+  data: MultiSeriesLineChartDatum[];
+};
+
+type NonEmptyMultiSeriesLineChartData = [
+  MultiSeriesLineChartDatum[],
+  ...MultiSeriesLineChartDatum[][],
+];
+
+type NonEmptyMultiSeriesLineChartSeriesConfig = [
+  ChartA11ySeriesConfig<MultiSeriesLineChartDatum>,
+  ...ChartA11ySeriesConfig<MultiSeriesLineChartDatum>[],
+];
+
+export type MultiSeriesLineChartMargin = MarginShape;
+
+export type MultiSeriesLineChartProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'width'
+> & {
+  height?: number;
+  margin?: MultiSeriesLineChartMargin;
+  series?: MultiSeriesLineChartSeries[];
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type MultiSeriesLineChartSvgProps = Required<
+  Pick<
+    MultiSeriesLineChartProps,
+    | 'height'
+    | 'margin'
+    | 'series'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    MultiSeriesLineChartProps,
+    | 'height'
+    | 'margin'
+    | 'series'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultSeries: MultiSeriesLineChartSeries[] = [
+  {
+    label: 'Desktop',
+    data: [
+      { x: 'Jan', y: 32 },
+      { x: 'Feb', y: 48 },
+      { x: 'Mar', y: 41 },
+      { x: 'Apr', y: 64 },
+      { x: 'May', y: 58 },
+      { x: 'Jun', y: 72 },
+    ],
+  },
+  {
+    label: 'Mobile',
+    data: [
+      { x: 'Jan', y: 22 },
+      { x: 'Feb', y: 28 },
+      { x: 'Mar', y: 36 },
+      { x: 'Apr', y: 46 },
+      { x: 'May', y: 52 },
+      { x: 'Jun', y: 61 },
+    ],
+  },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function getYDomain(series: readonly MultiSeriesLineChartSeries[]): [number, number] {
+  return getZeroBaselineDomain(series.flatMap(({ data }) => data.map((datum) => datum.y)));
+}
+
+function getXDomain(series: readonly MultiSeriesLineChartSeries[]) {
+  const seen = new Set<string>();
+
+  series.forEach(({ data }) => {
+    data.forEach((datum) => {
+      seen.add(datum.x);
+    });
+  });
+
+  return Array.from(seen);
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function MultiSeriesLineChartSvg({
+  className,
+  height,
+  id,
+  margin,
+  series,
+  showLegend,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: MultiSeriesLineChartSvgProps) {
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const xDomain = useMemo(() => getXDomain(series), [series]);
+  const yDomain = useMemo(() => getYDomain(series), [series]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const a11yData = useMemo(
+    () =>
+      series.length > 0 ? (series.map(({ data }) => data) as NonEmptyMultiSeriesLineChartData) : [],
+    [series],
+  );
+  const a11ySeries = useMemo(
+    () =>
+      (series.length > 0
+        ? series.map(({ label }) => ({ label }))
+        : [{ label: title }]) as NonEmptyMultiSeriesLineChartSeriesConfig,
+    [series, title],
+  );
+  const xScale = useScale({
+    type: 'point',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.35,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const pointColor = useColor('background');
+  const colorScale = useColorScale(series.map(({ label }) => label));
+  const legendItems = useMemo(
+    () =>
+      series.map(({ label }) => ({
+        key: label,
+        label,
+        color: colorScale(label),
+      })),
+    [colorScale, series],
+  );
+  const a11y = useChartA11y<MultiSeriesLineChartDatum>({
+    id,
+    title,
+    chartType: 'line',
+    data: a11yData,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: series.some(({ data }) => data.length > 0),
+    series: a11ySeries,
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            items={legendItems}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridRows
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={yTickValues}
+              width={dimensions.innerWidth}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={
+                yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={yTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={xTickFormat}
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={visibleXTickValues}
+              top={dimensions.innerHeight}
+            />
+            {series.map(({ data, label }, seriesIndex) => {
+              const lineColor = colorScale(label);
+
+              return (
+                <g key={label} {...a11y.getSeriesProps(seriesIndex)}>
+                  {data.length > 1 && (
+                    <LinePath
+                      data={data}
+                      defined={(datum) => Number.isFinite(datum.y) && xScale(datum.x) != null}
+                      fill="none"
+                      stroke={lineColor}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2.5}
+                      x={(datum) => xScale(datum.x) ?? 0}
+                      y={(datum) => yScale(datum.y) ?? dimensions.innerHeight}
+                    />
+                  )}
+                  {data.map((datum, index) => {
+                    const cx = xScale(datum.x);
+                    const cy = yScale(datum.y);
+
+                    if (cx == null || cy == null || !Number.isFinite(datum.y)) {
+                      return null;
+                    }
+
+                    return (
+                      <circle
+                        key={`${datum.x}-${index}`}
+                        cx={cx}
+                        cy={cy}
+                        r={4}
+                        fill={pointColor}
+                        stroke={lineColor}
+                        strokeWidth={2}
+                        data-multi-series-line-chart-point=""
+                        {...a11y.getPointProps(seriesIndex, index)}
+                      />
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function MultiSeriesLineChart({
+  height = 320,
+  series = defaultSeries,
+  width = 640,
+  ...props
+}: MultiSeriesLineChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <MultiSeriesLineChartSvg
+          {...props}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          series={series}
+          showLegend={props.showLegend ?? true}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Multi-series line chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/pie-chart/pie-chart.tsx
+++ b/packages/visx-registry/registry/charts/pie-chart/pie-chart.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import { getResponsiveWidth, type MarginShape, useChartDimensions } from '@visx/chart';
+import { ParentSize } from '@visx/responsive';
+import { Pie } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useColorScale } from '@visx/theme/react';
+
+export type PieChartDatum = {
+  label: string;
+  value: number;
+};
+
+export type PieChartMargin = MarginShape;
+
+export type PieChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: PieChartDatum[];
+  height?: number;
+  margin?: PieChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  yLabel?: string;
+};
+
+type PieChartSvgProps = Required<
+  Pick<
+    PieChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    PieChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: PieChartDatum[] = [
+  { label: 'Organic', value: 42 },
+  { label: 'Paid', value: 28 },
+  { label: 'Referral', value: 18 },
+  { label: 'Direct', value: 12 },
+];
+
+const defaultMargin = {
+  top: 18,
+  right: 18,
+  bottom: 18,
+  left: 18,
+};
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function PieChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  yLabel,
+  ...svgProps
+}: PieChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const filteredData = useMemo(
+    () => data.filter((datum) => Number.isFinite(datum.value) && datum.value >= 0),
+    [data],
+  );
+  const radius = Math.max(0, Math.min(dimensions.innerWidth, dimensions.innerHeight) / 2);
+  const centerX = dimensions.margin.left + dimensions.innerWidth / 2;
+  const centerY = dimensions.margin.top + dimensions.innerHeight / 2;
+  const colorScale = useColorScale(data.map((datum) => datum.label));
+  const a11y = useChartA11y<PieChartDatum>({
+    id,
+    title,
+    chartType: 'pie',
+    data: filteredData,
+    x: (datum) => datum.label,
+    y: (datum) => datum.value,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: filteredData.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${centerX} ${centerY})`} {...a11y.getSeriesProps(0)}>
+          {radius > 0 && (
+            <Pie
+              data={filteredData}
+              pieValue={(datum) => datum.value}
+              pieSort={null}
+              outerRadius={radius}
+              innerRadius={0}
+              padAngle={0.01}
+            >
+              {({ arcs, path }) =>
+                arcs.map((arc, index) => (
+                  <path
+                    key={`${arc.data.label}-${index}`}
+                    d={path(arc) ?? undefined}
+                    fill={colorScale(arc.data.label)}
+                    stroke="var(--background, #fff)"
+                    strokeWidth={2}
+                    data-pie-chart-segment=""
+                    {...a11y.getPointProps(0, index)}
+                  />
+                ))
+              }
+            </Pie>
+          )}
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function PieChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: PieChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <PieChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Pie chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Segment'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/radar-chart/radar-chart.tsx
+++ b/packages/visx-registry/registry/charts/radar-chart/radar-chart.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import {
+  getPositiveDomain,
+  getResponsiveWidth,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { ThemeScope } from '@visx/theme';
+import { useColor } from '@visx/theme/react';
+
+export type RadarChartDatum = {
+  x: string;
+  y: number;
+};
+
+export type RadarChartMargin = MarginShape;
+
+export type RadarChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: RadarChartDatum[];
+  height?: number;
+  levels?: number;
+  margin?: RadarChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  yLabel?: string;
+};
+
+type RadarChartSvgProps = Required<
+  Pick<
+    RadarChartProps,
+    | 'data'
+    | 'height'
+    | 'levels'
+    | 'margin'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    RadarChartProps,
+    | 'data'
+    | 'height'
+    | 'levels'
+    | 'margin'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultData: RadarChartDatum[] = [
+  { x: 'Reliability', y: 92 },
+  { x: 'Adoption', y: 76 },
+  { x: 'Velocity', y: 84 },
+  { x: 'Quality', y: 88 },
+  { x: 'Coverage', y: 69 },
+  { x: 'Efficiency', y: 81 },
+];
+
+const defaultMargin = {
+  top: 28,
+  right: 44,
+  bottom: 28,
+  left: 44,
+};
+
+function getValueDomain(data: readonly RadarChartDatum[]): [number, number] {
+  return getPositiveDomain(data.map((datum) => datum.y));
+}
+
+function getAngle(index: number, length: number) {
+  return (index / Math.max(1, length)) * Math.PI * 2;
+}
+
+function getPoint(angle: number, radius: number) {
+  return {
+    x: Math.sin(angle) * radius,
+    y: -Math.cos(angle) * radius,
+  };
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function RadarChartSvg({
+  className,
+  data,
+  height,
+  id,
+  levels,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  yLabel,
+  ...svgProps
+}: RadarChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const radius = Math.max(0, Math.min(dimensions.innerWidth, dimensions.innerHeight) / 2);
+  const centerX = dimensions.margin.left + dimensions.innerWidth / 2;
+  const centerY = dimensions.margin.top + dimensions.innerHeight / 2;
+  const valueDomain = useMemo(() => getValueDomain(data), [data]);
+  const radiusScale = useScale({
+    type: 'linear',
+    domain: valueDomain,
+    range: [0, radius],
+    nice: true,
+  });
+  const polygonPoints = data
+    .map((datum, index) => {
+      const angle = getAngle(index, data.length);
+      const point = getPoint(angle, radiusScale(Math.max(0, datum.y)) ?? 0);
+
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+  const gridColor = useColor('border');
+  const labelColor = useColor('textMuted');
+  const fillColor = useColor(0);
+  const pointColor = useColor('background');
+  const a11y = useChartA11y<RadarChartDatum>({
+    id,
+    title,
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${centerX} ${centerY})`}>
+          {Array.from({ length: levels }, (_, index) => {
+            const levelRadius = (radius * (index + 1)) / levels;
+            const points = data
+              .map((_datum, pointIndex) => {
+                const point = getPoint(getAngle(pointIndex, data.length), levelRadius);
+
+                return `${point.x},${point.y}`;
+              })
+              .join(' ');
+
+            return (
+              <polygon
+                key={`level-${index}`}
+                points={points}
+                fill="none"
+                stroke={gridColor}
+                strokeWidth={1}
+              />
+            );
+          })}
+          {data.map((datum, index) => {
+            const axisPoint = getPoint(getAngle(index, data.length), radius);
+            const labelPoint = getPoint(getAngle(index, data.length), radius + 16);
+
+            return (
+              <g key={datum.x}>
+                <line x1={0} x2={axisPoint.x} y1={0} y2={axisPoint.y} stroke={gridColor} />
+                <text
+                  x={labelPoint.x}
+                  y={labelPoint.y}
+                  dy="0.32em"
+                  fill={labelColor}
+                  fontSize={11}
+                  textAnchor={
+                    Math.abs(labelPoint.x) < 2 ? 'middle' : labelPoint.x > 0 ? 'start' : 'end'
+                  }
+                >
+                  {datum.x}
+                </text>
+              </g>
+            );
+          })}
+          <g {...a11y.getSeriesProps(0)}>
+            {data.length > 0 && (
+              <polygon
+                points={polygonPoints}
+                fill={fillColor}
+                fillOpacity={0.2}
+                stroke={fillColor}
+                strokeWidth={2}
+                data-radar-chart-area=""
+              />
+            )}
+            {data.map((datum, index) => {
+              const angle = getAngle(index, data.length);
+              const point = getPoint(angle, radiusScale(Math.max(0, datum.y)) ?? 0);
+
+              return (
+                <circle
+                  key={`${datum.x}-${index}`}
+                  cx={point.x}
+                  cy={point.y}
+                  r={4}
+                  fill={pointColor}
+                  stroke={fillColor}
+                  strokeWidth={2}
+                  data-radar-chart-point=""
+                  {...a11y.getPointProps(0, index)}
+                />
+              );
+            })}
+          </g>
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function RadarChart({
+  data = defaultData,
+  height = 360,
+  levels = 4,
+  width = 640,
+  ...props
+}: RadarChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <RadarChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          levels={levels}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Radar chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Metric'}
+          yLabel={props.yLabel ?? 'Score'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/radial-bar-chart/radial-bar-chart.tsx
+++ b/packages/visx-registry/registry/charts/radial-bar-chart/radial-bar-chart.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import {
+  getPositiveDomain,
+  getResponsiveWidth,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { Arc } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useColor, useColorScale } from '@visx/theme/react';
+
+export type RadialBarChartDatum = {
+  x: string;
+  y: number;
+};
+
+export type RadialBarChartMargin = MarginShape;
+
+export type RadialBarChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: RadialBarChartDatum[];
+  height?: number;
+  margin?: RadialBarChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  yLabel?: string;
+};
+
+type RadialBarChartSvgProps = Required<
+  Pick<
+    RadialBarChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    RadialBarChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: RadialBarChartDatum[] = [
+  { x: 'North', y: 72 },
+  { x: 'South', y: 58 },
+  { x: 'East', y: 84 },
+  { x: 'West', y: 64 },
+  { x: 'Central', y: 76 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 24,
+  left: 24,
+};
+
+function getValueDomain(data: readonly RadialBarChartDatum[]): [number, number] {
+  return getPositiveDomain(data.map((datum) => datum.y));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function RadialBarChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  yLabel,
+  ...svgProps
+}: RadialBarChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const radius = Math.max(0, Math.min(dimensions.innerWidth, dimensions.innerHeight) / 2);
+  const centerX = dimensions.margin.left + dimensions.innerWidth / 2;
+  const centerY = dimensions.margin.top + dimensions.innerHeight / 2;
+  const valueDomain = useMemo(() => getValueDomain(data), [data]);
+  const radiusScale = useScale({
+    type: 'linear',
+    domain: valueDomain,
+    range: [radius * 0.34, radius],
+    nice: true,
+  });
+  const colorScale = useColorScale(data.map((datum) => datum.x));
+  const labelColor = useColor('textMuted');
+  const a11y = useChartA11y<RadialBarChartDatum>({
+    id,
+    title,
+    chartType: 'bar',
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+  const angleStep = (Math.PI * 2) / Math.max(1, data.length);
+  const padAngle = Math.min(0.04, angleStep * 0.16);
+  const innerRadius = radius * 0.28;
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${centerX} ${centerY})`} {...a11y.getSeriesProps(0)}>
+          {data.map((datum, index) => {
+            const startAngle = index * angleStep + padAngle;
+            const endAngle = (index + 1) * angleStep - padAngle;
+            const outerRadius = radiusScale(Math.max(0, datum.y)) ?? innerRadius;
+            const labelAngle = startAngle + (endAngle - startAngle) / 2;
+            const labelRadius = radius + 14;
+            const labelX = Math.sin(labelAngle) * labelRadius;
+            const labelY = -Math.cos(labelAngle) * labelRadius;
+
+            return (
+              <g key={`${datum.x}-${index}`}>
+                <Arc
+                  startAngle={startAngle}
+                  endAngle={endAngle}
+                  innerRadius={innerRadius}
+                  outerRadius={outerRadius}
+                  cornerRadius={4}
+                  fill={colorScale(datum.x)}
+                  data-radial-bar-chart-bar=""
+                  {...a11y.getPointProps(0, index)}
+                />
+                <text
+                  x={labelX}
+                  y={labelY}
+                  dy="0.32em"
+                  fill={labelColor}
+                  fontSize={11}
+                  textAnchor={Math.abs(labelX) < 2 ? 'middle' : labelX > 0 ? 'start' : 'end'}
+                >
+                  {datum.x}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function RadialBarChart({
+  data = defaultData,
+  height = 360,
+  width = 640,
+  ...props
+}: RadialBarChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <RadialBarChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Radial bar chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/scatter-chart/scatter-chart.tsx
+++ b/packages/visx-registry/registry/charts/scatter-chart/scatter-chart.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getPaddedDomain,
+  getResponsiveWidth,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { Circle } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useGridStyle } from '@visx/theme/react';
+
+export type ScatterChartDatum = {
+  x: number;
+  y: number;
+  label?: string;
+};
+
+export type ScatterChartMargin = MarginShape;
+
+export type ScatterChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: ScatterChartDatum[];
+  height?: number;
+  margin?: ScatterChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xNumTicks?: number;
+  xTickFormat?: AxisTickFormatter<number>;
+  xTickValues?: number[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type ScatterChartSvgProps = Required<
+  Pick<
+    ScatterChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    ScatterChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: ScatterChartDatum[] = [
+  { x: 14, y: 38, label: 'Segment A' },
+  { x: 24, y: 46, label: 'Segment B' },
+  { x: 34, y: 42, label: 'Segment C' },
+  { x: 46, y: 58, label: 'Segment D' },
+  { x: 58, y: 63, label: 'Segment E' },
+  { x: 72, y: 76, label: 'Segment F' },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function ScatterChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xNumTicks,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: ScatterChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const xDomain = useMemo(() => getPaddedDomain(data.map((datum) => datum.x)), [data]);
+  const yDomain = useMemo(() => getPaddedDomain(data.map((datum) => datum.y)), [data]);
+  const visibleXNumTicks =
+    xTickValues == null
+      ? xNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerWidth,
+          maxTicks: 5,
+          minTickSpacing: xMinTickSpacing,
+        })
+      : undefined;
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const formatXTick = xTickFormat ?? ((value: number) => formatNumber(value));
+  const formatYTick = yTickFormat ?? ((value: number) => formatNumber(value));
+  const xScale = useScale({
+    type: 'linear',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    nice: true,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const pointColor = useColor(0);
+  const a11y = useChartA11y<ScatterChartDatum>({
+    id,
+    title,
+    chartType: 'scatter',
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY: formatNumber,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+          <GridRows
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={gridStyle.stroke}
+            strokeWidth={gridStyle.strokeWidth}
+            tickValues={yTickValues}
+            width={dimensions.innerWidth}
+          />
+          <AxisLeft
+            label={yLabel}
+            labelOffset={yAxisStyle.labelOffset}
+            labelProps={yAxisStyle.labelProps}
+            numTicks={visibleYNumTicks}
+            scale={yScale}
+            stroke={yAxisStyle.stroke}
+            strokeWidth={yAxisStyle.strokeWidth}
+            tickFormat={(value, index) => formatYTick(Number(value), index)}
+            tickLabelProps={yAxisStyle.tickLabelProps}
+            tickLength={yAxisStyle.tickLength}
+            tickStroke={yAxisStyle.tickStroke}
+            tickValues={yTickValues}
+          />
+          <AxisBottom
+            label={xLabel}
+            labelOffset={xAxisStyle.labelOffset}
+            labelProps={xAxisStyle.labelProps}
+            numTicks={visibleXNumTicks}
+            scale={xScale}
+            stroke={xAxisStyle.stroke}
+            strokeWidth={xAxisStyle.strokeWidth}
+            tickFormat={(value, index) => formatXTick(Number(value), index)}
+            tickLabelProps={xAxisStyle.tickLabelProps}
+            tickLength={xAxisStyle.tickLength}
+            tickStroke={xAxisStyle.tickStroke}
+            tickValues={xTickValues}
+            top={dimensions.innerHeight}
+          />
+          <g {...a11y.getSeriesProps(0)}>
+            {data.map((datum, index) => {
+              const cx = xScale(datum.x);
+              const cy = yScale(datum.y);
+
+              if (
+                cx == null ||
+                cy == null ||
+                !Number.isFinite(datum.x) ||
+                !Number.isFinite(datum.y)
+              ) {
+                return null;
+              }
+
+              return (
+                <Circle
+                  key={`${datum.label ?? 'point'}-${index}`}
+                  cx={cx}
+                  cy={cy}
+                  r={5}
+                  fill={pointColor}
+                  fillOpacity={0.84}
+                  stroke={pointColor}
+                  strokeWidth={1.5}
+                  data-scatter-chart-point=""
+                  {...a11y.getPointProps(0, index)}
+                />
+              );
+            })}
+          </g>
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function ScatterChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: ScatterChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <ScatterChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Scatter chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'X value'}
+          yLabel={props.yLabel ?? 'Y value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/stacked-area-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/stacked-area-chart/chart-ui.tsx
@@ -1,0 +1,9 @@
+export { ChartLegend, ChartTooltip } from '../bar-chart/chart-ui';
+export type {
+  ChartLegendItem,
+  ChartLegendProps,
+  ChartTooltipBounds,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipProps,
+} from '../bar-chart/chart-ui';

--- a/packages/visx-registry/registry/charts/stacked-area-chart/stacked-area-chart.tsx
+++ b/packages/visx-registry/registry/charts/stacked-area-chart/stacked-area-chart.tsx
@@ -1,0 +1,423 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y, type ChartA11ySeriesConfig } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getPositiveDomain,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { AreaStack } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useColorScale, useGridStyle } from '@visx/theme/react';
+import { ChartLegend } from './chart-ui';
+
+export type StackedAreaChartKey = 'desktop' | 'mobile' | 'tablet';
+
+export type StackedAreaChartDatum = {
+  x: string;
+} & Record<StackedAreaChartKey, number>;
+
+type StackedAreaChartSeriesDatum = {
+  x: string;
+  y: number;
+  series: StackedAreaChartKey;
+};
+
+type NonEmptyStackedAreaChartSeriesData = [
+  StackedAreaChartSeriesDatum[],
+  ...StackedAreaChartSeriesDatum[][],
+];
+
+type NonEmptyStackedAreaChartSeriesConfig = [
+  ChartA11ySeriesConfig<StackedAreaChartSeriesDatum>,
+  ...ChartA11ySeriesConfig<StackedAreaChartSeriesDatum>[],
+];
+
+export type StackedAreaChartMargin = MarginShape;
+
+export type StackedAreaChartProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'width'
+> & {
+  data?: StackedAreaChartDatum[];
+  height?: number;
+  keys?: StackedAreaChartKey[];
+  margin?: StackedAreaChartMargin;
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type StackedAreaChartSvgProps = Required<
+  Pick<
+    StackedAreaChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    StackedAreaChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultKeys: StackedAreaChartKey[] = ['desktop', 'mobile', 'tablet'];
+
+const defaultData: StackedAreaChartDatum[] = [
+  { x: 'Jan', desktop: 26, mobile: 18, tablet: 8 },
+  { x: 'Feb', desktop: 31, mobile: 23, tablet: 10 },
+  { x: 'Mar', desktop: 29, mobile: 26, tablet: 13 },
+  { x: 'Apr', desktop: 36, mobile: 31, tablet: 15 },
+  { x: 'May', desktop: 42, mobile: 34, tablet: 17 },
+  { x: 'Jun', desktop: 48, mobile: 38, tablet: 19 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function formatKey(key: string) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function getAreaValue(datum: StackedAreaChartDatum, key: StackedAreaChartKey) {
+  const value = datum[key];
+
+  return Number.isFinite(value) ? value : 0;
+}
+
+function getYDomain(
+  data: readonly StackedAreaChartDatum[],
+  keys: readonly StackedAreaChartKey[],
+): [number, number] {
+  return getPositiveDomain(
+    data.map((datum) => keys.reduce((sum, key) => sum + Math.max(0, getAreaValue(datum, key)), 0)),
+  );
+}
+
+function getStackTop(
+  datum: StackedAreaChartDatum,
+  keys: readonly StackedAreaChartKey[],
+  seriesIndex: number,
+) {
+  return keys
+    .slice(0, seriesIndex + 1)
+    .reduce((sum, key) => sum + Math.max(0, getAreaValue(datum, key)), 0);
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function StackedAreaChartSvg({
+  className,
+  data,
+  height,
+  id,
+  keys,
+  margin,
+  showLegend,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: StackedAreaChartSvgProps) {
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data, keys), [data, keys]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const seriesData = useMemo(
+    () =>
+      keys.map((key) =>
+        data.map((datum) => ({
+          x: datum.x,
+          y: getAreaValue(datum, key),
+          series: key,
+        })),
+      ),
+    [data, keys],
+  );
+  const a11yData = useMemo(
+    () => (keys.length > 0 ? (seriesData as NonEmptyStackedAreaChartSeriesData) : []),
+    [keys.length, seriesData],
+  );
+  const a11ySeries = useMemo(
+    () =>
+      (keys.length > 0
+        ? keys.map((key) => ({ label: formatKey(key) }))
+        : [{ label: title }]) as NonEmptyStackedAreaChartSeriesConfig,
+    [keys, title],
+  );
+  const xScale = useScale({
+    type: 'point',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.35,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const pointColor = useColor('background');
+  const colorScale = useColorScale(keys);
+  const legendItems = useMemo(
+    () =>
+      keys.map((key) => ({
+        key,
+        label: formatKey(key),
+        color: colorScale(key),
+      })),
+    [colorScale, keys],
+  );
+  const a11y = useChartA11y<StackedAreaChartSeriesDatum>({
+    id,
+    title,
+    chartType: 'area',
+    data: a11yData,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0 && keys.length > 0,
+    series: a11ySeries,
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            items={legendItems}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridRows
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={yTickValues}
+              width={dimensions.innerWidth}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={
+                yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={yTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={xTickFormat}
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={visibleXTickValues}
+              top={dimensions.innerHeight}
+            />
+            <AreaStack
+              data={data}
+              keys={keys}
+              x={(datum) => xScale(datum.data.x) ?? 0}
+              y0={(d) => yScale(d[0]) ?? dimensions.innerHeight}
+              y1={(d) => yScale(d[1]) ?? dimensions.innerHeight}
+              color={(key) => colorScale(key as StackedAreaChartKey)}
+              value={(datum, key) => Math.max(0, getAreaValue(datum, key as StackedAreaChartKey))}
+            >
+              {({ stacks, path }) =>
+                stacks.map((series, seriesIndex) => (
+                  <path
+                    key={series.key}
+                    d={path(series) ?? undefined}
+                    fill={colorScale(series.key as StackedAreaChartKey)}
+                    fillOpacity={0.68}
+                    data-stacked-area-chart-area=""
+                    {...a11y.getSeriesProps(seriesIndex)}
+                  />
+                ))
+              }
+            </AreaStack>
+            {keys.map((key, seriesIndex) => {
+              const lineColor = colorScale(key);
+
+              return (
+                <g key={key}>
+                  {data.map((datum, index) => {
+                    const cx = xScale(datum.x);
+                    const cy = yScale(getStackTop(datum, keys, seriesIndex));
+
+                    if (cx == null || cy == null) {
+                      return null;
+                    }
+
+                    return (
+                      <circle
+                        key={`${key}-${datum.x}-${index}`}
+                        cx={cx}
+                        cy={cy}
+                        r={3.5}
+                        fill={pointColor}
+                        stroke={lineColor}
+                        strokeWidth={2}
+                        data-stacked-area-chart-point=""
+                        {...a11y.getPointProps(seriesIndex, index)}
+                      />
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function StackedAreaChart({
+  data = defaultData,
+  height = 320,
+  keys = defaultKeys,
+  width = 640,
+  ...props
+}: StackedAreaChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <StackedAreaChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          keys={keys}
+          margin={props.margin ?? defaultMargin}
+          showLegend={props.showLegend ?? true}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Stacked area chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/stacked-bar-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/stacked-bar-chart/chart-ui.tsx
@@ -1,0 +1,9 @@
+export { ChartLegend, ChartTooltip } from '../bar-chart/chart-ui';
+export type {
+  ChartLegendItem,
+  ChartLegendProps,
+  ChartTooltipBounds,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipProps,
+} from '../bar-chart/chart-ui';

--- a/packages/visx-registry/registry/charts/stacked-bar-chart/stacked-bar-chart.tsx
+++ b/packages/visx-registry/registry/charts/stacked-bar-chart/stacked-bar-chart.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y, type ChartA11ySeriesConfig } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getPositiveDomain,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { BarStack } from '@visx/shape';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColorScale, useGridStyle } from '@visx/theme/react';
+import { ChartLegend } from './chart-ui';
+
+export type StackedBarChartKey = 'desktop' | 'mobile' | 'tablet';
+
+export type StackedBarChartDatum = {
+  x: string;
+} & Record<StackedBarChartKey, number>;
+
+type StackedBarChartSeriesDatum = {
+  x: string;
+  y: number;
+  series: StackedBarChartKey;
+};
+
+type NonEmptyStackedBarChartSeriesData = [
+  StackedBarChartSeriesDatum[],
+  ...StackedBarChartSeriesDatum[][],
+];
+
+type NonEmptyStackedBarChartSeriesConfig = [
+  ChartA11ySeriesConfig<StackedBarChartSeriesDatum>,
+  ...ChartA11ySeriesConfig<StackedBarChartSeriesDatum>[],
+];
+
+export type StackedBarChartMargin = MarginShape;
+
+export type StackedBarChartProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'width'
+> & {
+  data?: StackedBarChartDatum[];
+  height?: number;
+  keys?: StackedBarChartKey[];
+  margin?: StackedBarChartMargin;
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type StackedBarChartSvgProps = Required<
+  Pick<
+    StackedBarChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    StackedBarChartProps,
+    | 'data'
+    | 'height'
+    | 'keys'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultKeys: StackedBarChartKey[] = ['desktop', 'mobile', 'tablet'];
+
+const defaultData: StackedBarChartDatum[] = [
+  { x: 'Jan', desktop: 26, mobile: 18, tablet: 8 },
+  { x: 'Feb', desktop: 31, mobile: 23, tablet: 10 },
+  { x: 'Mar', desktop: 29, mobile: 26, tablet: 13 },
+  { x: 'Apr', desktop: 36, mobile: 31, tablet: 15 },
+  { x: 'May', desktop: 42, mobile: 34, tablet: 17 },
+  { x: 'Jun', desktop: 48, mobile: 38, tablet: 19 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function formatKey(key: string) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function getStackValue(datum: StackedBarChartDatum, key: StackedBarChartKey) {
+  const value = datum[key];
+
+  return Number.isFinite(value) ? value : 0;
+}
+
+function getYDomain(
+  data: readonly StackedBarChartDatum[],
+  keys: readonly StackedBarChartKey[],
+): [number, number] {
+  return getPositiveDomain(
+    data.map((datum) => keys.reduce((sum, key) => sum + Math.max(0, getStackValue(datum, key)), 0)),
+  );
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function getTopRoundedBarPath({
+  height,
+  radius,
+  width,
+  x,
+  y,
+}: {
+  height: number;
+  radius: number;
+  width: number;
+  x: number;
+  y: number;
+}) {
+  const r = Math.min(radius, width / 2, height);
+  const right = x + width;
+  const bottom = y + height;
+
+  return [
+    `M ${x} ${bottom}`,
+    `L ${x} ${y + r}`,
+    `Q ${x} ${y} ${x + r} ${y}`,
+    `L ${right - r} ${y}`,
+    `Q ${right} ${y} ${right} ${y + r}`,
+    `L ${right} ${bottom}`,
+    'Z',
+  ].join(' ');
+}
+
+function StackedBarChartSvg({
+  className,
+  data,
+  height,
+  id,
+  keys,
+  margin,
+  showLegend,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: StackedBarChartSvgProps) {
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data, keys), [data, keys]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const seriesData = useMemo(
+    () =>
+      keys.map((key) =>
+        data.map((datum) => ({
+          x: datum.x,
+          y: getStackValue(datum, key),
+          series: key,
+        })),
+      ),
+    [data, keys],
+  );
+  const a11yData = useMemo(
+    () => (keys.length > 0 ? (seriesData as NonEmptyStackedBarChartSeriesData) : []),
+    [keys.length, seriesData],
+  );
+  const a11ySeries = useMemo(
+    () =>
+      (keys.length > 0
+        ? keys.map((key) => ({ label: formatKey(key) }))
+        : [{ label: title }]) as NonEmptyStackedBarChartSeriesConfig,
+    [keys, title],
+  );
+  const xScale = useScale({
+    type: 'band',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.28,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const colorScale = useColorScale(keys);
+  const legendItems = useMemo(
+    () =>
+      keys.map((key) => ({
+        key,
+        label: formatKey(key),
+        color: colorScale(key),
+      })),
+    [colorScale, keys],
+  );
+  const a11y = useChartA11y<StackedBarChartSeriesDatum>({
+    id,
+    title,
+    chartType: 'bar',
+    data: a11yData,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0 && keys.length > 0,
+    series: a11ySeries,
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            items={legendItems}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridRows
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={yTickValues}
+              width={dimensions.innerWidth}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={
+                yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={yTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={xTickFormat}
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={visibleXTickValues}
+              top={dimensions.innerHeight}
+            />
+            <BarStack
+              data={data}
+              keys={keys}
+              x={(datum) => datum.x}
+              xScale={xScale}
+              yScale={yScale}
+              color={(key) => colorScale(key as StackedBarChartKey)}
+              value={(datum, key) => getStackValue(datum, key as StackedBarChartKey)}
+            >
+              {(barStacks) => {
+                const topBarSeriesByIndex = new Map<number, number>();
+                const topBarYByIndex = new Map<number, number>();
+
+                barStacks.forEach((barStack, seriesIndex) => {
+                  barStack.bars.forEach((bar) => {
+                    if (bar.height <= 0) {
+                      return;
+                    }
+
+                    const currentY = topBarYByIndex.get(bar.index);
+
+                    if (currentY == null || bar.y < currentY) {
+                      topBarYByIndex.set(bar.index, bar.y);
+                      topBarSeriesByIndex.set(bar.index, seriesIndex);
+                    }
+                  });
+                });
+
+                return barStacks.map((barStack, seriesIndex) => (
+                  <g key={barStack.key} {...a11y.getSeriesProps(seriesIndex)}>
+                    {barStack.bars.map((bar) => {
+                      if (bar.height <= 0) {
+                        return null;
+                      }
+
+                      const isTopBar = topBarSeriesByIndex.get(bar.index) === seriesIndex;
+                      const pointProps = a11y.getPointProps(seriesIndex, bar.index);
+
+                      return isTopBar ? (
+                        <path
+                          key={`${barStack.key}-${bar.index}`}
+                          d={getTopRoundedBarPath({
+                            x: bar.x,
+                            y: bar.y,
+                            width: bar.width,
+                            height: bar.height,
+                            radius: 4,
+                          })}
+                          fill={bar.color}
+                          data-stacked-bar-chart-bar=""
+                          {...pointProps}
+                        />
+                      ) : (
+                        <rect
+                          key={`${barStack.key}-${bar.index}`}
+                          x={bar.x}
+                          y={bar.y}
+                          width={bar.width}
+                          height={bar.height}
+                          fill={bar.color}
+                          data-stacked-bar-chart-bar=""
+                          {...pointProps}
+                        />
+                      );
+                    })}
+                  </g>
+                ));
+              }}
+            </BarStack>
+          </g>
+        </svg>
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function StackedBarChart({
+  data = defaultData,
+  height = 320,
+  keys = defaultKeys,
+  width = 640,
+  ...props
+}: StackedBarChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <StackedBarChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          keys={keys}
+          margin={props.margin ?? defaultMargin}
+          showLegend={props.showLegend ?? true}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Stacked bar chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/threshold-chart/chart-ui.tsx
+++ b/packages/visx-registry/registry/charts/threshold-chart/chart-ui.tsx
@@ -1,0 +1,9 @@
+export { ChartLegend, ChartTooltip } from '../bar-chart/chart-ui';
+export type {
+  ChartLegendItem,
+  ChartLegendProps,
+  ChartTooltipBounds,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipProps,
+} from '../bar-chart/chart-ui';

--- a/packages/visx-registry/registry/charts/threshold-chart/threshold-chart.tsx
+++ b/packages/visx-registry/registry/charts/threshold-chart/threshold-chart.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y, type ChartA11ySeriesConfig } from '@visx/a11y/react';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import {
+  getAxisTickCount,
+  getResponsiveWidth,
+  getVisibleTickValues,
+  getZeroBaselineDomain,
+  type AxisTickFormatter,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { LinePath } from '@visx/shape';
+import { Threshold } from '@visx/threshold';
+import { ThemeScope } from '@visx/theme';
+import { useAxisStyle, useColor, useGridStyle } from '@visx/theme/react';
+import { ChartLegend } from './chart-ui';
+
+export type ThresholdChartDatum = {
+  x: string;
+  actual: number;
+  target: number;
+};
+
+type ThresholdChartSeriesDatum = {
+  x: string;
+  y: number;
+  series: 'actual' | 'target';
+};
+
+type NonEmptyThresholdChartSeriesData = [
+  ThresholdChartSeriesDatum[],
+  ...ThresholdChartSeriesDatum[][],
+];
+
+type NonEmptyThresholdChartSeriesConfig = [
+  ChartA11ySeriesConfig<ThresholdChartSeriesDatum>,
+  ...ChartA11ySeriesConfig<ThresholdChartSeriesDatum>[],
+];
+
+export type ThresholdChartMargin = MarginShape;
+
+export type ThresholdChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: ThresholdChartDatum[];
+  height?: number;
+  margin?: ThresholdChartMargin;
+  showLegend?: boolean;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  xMinTickSpacing?: number;
+  xTickFormat?: AxisTickFormatter<string>;
+  xTickValues?: string[];
+  yLabel?: string;
+  yMinTickSpacing?: number;
+  yNumTicks?: number;
+  yTickFormat?: AxisTickFormatter<number>;
+  yTickValues?: number[];
+};
+
+type ThresholdChartSvgProps = Required<
+  Pick<
+    ThresholdChartProps,
+    | 'data'
+    | 'height'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >
+> &
+  Omit<
+    ThresholdChartProps,
+    | 'data'
+    | 'height'
+    | 'margin'
+    | 'showLegend'
+    | 'showLiveRegion'
+    | 'title'
+    | 'width'
+    | 'xLabel'
+    | 'yLabel'
+  >;
+
+const defaultData: ThresholdChartDatum[] = [
+  { x: 'Jan', actual: 42, target: 46 },
+  { x: 'Feb', actual: 49, target: 48 },
+  { x: 'Mar', actual: 53, target: 52 },
+  { x: 'Apr', actual: 51, target: 56 },
+  { x: 'May', actual: 62, target: 60 },
+  { x: 'Jun', actual: 68, target: 64 },
+  { x: 'Jul', actual: 66, target: 68 },
+  { x: 'Aug', actual: 76, target: 72 },
+];
+
+const defaultMargin = {
+  top: 24,
+  right: 24,
+  bottom: 52,
+  left: 48,
+};
+
+function getYDomain(data: readonly ThresholdChartDatum[]): [number, number] {
+  return getZeroBaselineDomain(data.flatMap((datum) => [datum.actual, datum.target]));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function ThresholdChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLegend,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  xMinTickSpacing = 48,
+  xTickFormat,
+  xTickValues,
+  yLabel,
+  yMinTickSpacing = 48,
+  yNumTicks,
+  yTickFormat,
+  yTickValues,
+  ...svgProps
+}: ThresholdChartSvgProps) {
+  const legendHeight = showLegend ? 28 : 0;
+  const dimensions = useChartDimensions({
+    width,
+    height: Math.max(0, height - legendHeight),
+    margin,
+  });
+  const xDomain = useMemo(() => data.map((datum) => datum.x), [data]);
+  const yDomain = useMemo(() => getYDomain(data), [data]);
+  const visibleXTickValues = useMemo(
+    () =>
+      xTickValues ??
+      getVisibleTickValues(xDomain, {
+        axisLength: dimensions.innerWidth,
+        minTickSpacing: xMinTickSpacing,
+      }),
+    [dimensions.innerWidth, xDomain, xMinTickSpacing, xTickValues],
+  );
+  const visibleYNumTicks =
+    yTickValues == null
+      ? yNumTicks ??
+        getAxisTickCount({
+          axisLength: dimensions.innerHeight,
+          maxTicks: 5,
+          minTickSpacing: yMinTickSpacing,
+        })
+      : undefined;
+  const seriesData = useMemo(
+    () =>
+      [
+        data.map((datum) => ({ x: datum.x, y: datum.actual, series: 'actual' as const })),
+        data.map((datum) => ({ x: datum.x, y: datum.target, series: 'target' as const })),
+      ] as NonEmptyThresholdChartSeriesData,
+    [data],
+  );
+  const a11ySeries = useMemo(
+    () => [{ label: 'Actual' }, { label: 'Target' }] as NonEmptyThresholdChartSeriesConfig,
+    [],
+  );
+  const xScale = useScale({
+    type: 'point',
+    domain: xDomain,
+    range: [0, dimensions.innerWidth],
+    padding: 0.35,
+  });
+  const yScale = useScale({
+    type: 'linear',
+    domain: yDomain,
+    range: [dimensions.innerHeight, 0],
+    nice: true,
+  });
+  const xAxisStyle = useAxisStyle('bottom');
+  const yAxisStyle = useAxisStyle('left');
+  const gridStyle = useGridStyle();
+  const positiveColor = useColor(0);
+  const negativeColor = useColor(4);
+  const targetColor = useColor(2);
+  const pointColor = useColor('background');
+  const legendItems = useMemo(
+    () => [
+      { key: 'actual', label: 'Actual', color: positiveColor },
+      { key: 'target', label: 'Target', color: targetColor },
+    ],
+    [positiveColor, targetColor],
+  );
+  const a11y = useChartA11y<ThresholdChartSeriesDatum>({
+    id,
+    title,
+    chartType: 'area',
+    data: seriesData,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: a11ySeries,
+  });
+  const thresholdId = `${a11y.id}-threshold`;
+
+  return (
+    <ThemeScope as={false}>
+      <div style={{ position: 'relative', width: '100%', height }}>
+        {showLegend && (
+          <ChartLegend
+            items={legendItems}
+            style={{
+              height: legendHeight,
+              justifyContent: 'flex-start',
+            }}
+          />
+        )}
+        <svg
+          {...svgProps}
+          {...a11y.svgProps}
+          id={a11y.id}
+          className={className}
+          width={dimensions.width}
+          height={dimensions.height}
+          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: dimensions.height,
+            overflow: 'visible',
+            ...style,
+          }}
+        >
+          <desc id={a11y.descriptionId}>{a11y.description}</desc>
+          <g transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}>
+            <GridRows
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={gridStyle.stroke}
+              strokeWidth={gridStyle.strokeWidth}
+              tickValues={yTickValues}
+              width={dimensions.innerWidth}
+            />
+            <AxisLeft
+              label={yLabel}
+              labelOffset={yAxisStyle.labelOffset}
+              labelProps={yAxisStyle.labelProps}
+              numTicks={visibleYNumTicks}
+              scale={yScale}
+              stroke={yAxisStyle.stroke}
+              strokeWidth={yAxisStyle.strokeWidth}
+              tickFormat={
+                yTickFormat ? (value, index) => yTickFormat(Number(value), index) : undefined
+              }
+              tickLabelProps={yAxisStyle.tickLabelProps}
+              tickLength={yAxisStyle.tickLength}
+              tickStroke={yAxisStyle.tickStroke}
+              tickValues={yTickValues}
+            />
+            <AxisBottom
+              label={xLabel}
+              labelOffset={xAxisStyle.labelOffset}
+              labelProps={xAxisStyle.labelProps}
+              scale={xScale}
+              stroke={xAxisStyle.stroke}
+              strokeWidth={xAxisStyle.strokeWidth}
+              tickFormat={xTickFormat}
+              tickLabelProps={xAxisStyle.tickLabelProps}
+              tickLength={xAxisStyle.tickLength}
+              tickStroke={xAxisStyle.tickStroke}
+              tickValues={visibleXTickValues}
+              top={dimensions.innerHeight}
+            />
+            {data.length > 1 && (
+              <>
+                <Threshold
+                  id={thresholdId}
+                  data={data}
+                  x={(datum) => xScale(datum.x) ?? 0}
+                  y0={(datum) => yScale(datum.target) ?? dimensions.innerHeight}
+                  y1={(datum) => yScale(datum.actual) ?? dimensions.innerHeight}
+                  clipAboveTo={0}
+                  clipBelowTo={dimensions.innerHeight}
+                  aboveAreaProps={{
+                    fill: positiveColor,
+                    fillOpacity: 0.22,
+                  }}
+                  belowAreaProps={{
+                    fill: negativeColor,
+                    fillOpacity: 0.18,
+                  }}
+                />
+                <LinePath
+                  data={data}
+                  fill="none"
+                  stroke={positiveColor}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2.5}
+                  x={(datum) => xScale(datum.x) ?? 0}
+                  y={(datum) => yScale(datum.actual) ?? dimensions.innerHeight}
+                />
+                <LinePath
+                  data={data}
+                  fill="none"
+                  stroke={targetColor}
+                  strokeDasharray="4 4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  x={(datum) => xScale(datum.x) ?? 0}
+                  y={(datum) => yScale(datum.target) ?? dimensions.innerHeight}
+                />
+              </>
+            )}
+            {seriesData.map((series, seriesIndex) => {
+              const stroke = seriesIndex === 0 ? positiveColor : targetColor;
+
+              return (
+                <g
+                  key={seriesIndex === 0 ? 'actual' : 'target'}
+                  {...a11y.getSeriesProps(seriesIndex)}
+                >
+                  {series.map((datum, index) => {
+                    const cx = xScale(datum.x);
+                    const cy = yScale(datum.y);
+
+                    if (cx == null || cy == null || !Number.isFinite(datum.y)) {
+                      return null;
+                    }
+
+                    return (
+                      <circle
+                        key={`${datum.series}-${datum.x}-${index}`}
+                        cx={cx}
+                        cy={cy}
+                        r={3.5}
+                        fill={pointColor}
+                        stroke={stroke}
+                        strokeWidth={2}
+                        data-threshold-chart-point=""
+                        {...a11y.getPointProps(seriesIndex, index)}
+                      />
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function ThresholdChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: ThresholdChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <ThresholdChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLegend={props.showLegend ?? true}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Threshold chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/registry/charts/treemap-chart/treemap-chart.tsx
+++ b/packages/visx-registry/registry/charts/treemap-chart/treemap-chart.tsx
@@ -22,7 +22,9 @@ export type TreemapDatum = {
 };
 
 type TreemapNode = {
+  group?: string;
   name: string;
+  pointIndex?: number;
   value?: number;
   children?: TreemapNode[];
 };
@@ -68,13 +70,13 @@ const defaultMargin = {
 };
 
 function getHierarchyData(data: readonly TreemapDatum[]): TreemapNode {
-  const groups = new Map<string, TreemapDatum[]>();
+  const groups = new Map<string, { datum: TreemapDatum; pointIndex: number }[]>();
 
-  data.forEach((datum) => {
+  data.forEach((datum, pointIndex) => {
     const group = datum.group ?? 'Data';
     const current = groups.get(group) ?? [];
 
-    current.push(datum);
+    current.push({ datum, pointIndex });
     groups.set(group, current);
   });
 
@@ -82,8 +84,10 @@ function getHierarchyData(data: readonly TreemapDatum[]): TreemapNode {
     name: 'root',
     children: Array.from(groups.entries()).map(([name, children]) => ({
       name,
-      children: children.map((datum) => ({
+      children: children.map(({ datum, pointIndex }) => ({
+        group: name,
         name: datum.x,
+        pointIndex,
         value: Number.isFinite(datum.y) ? Math.max(0, datum.y) : 0,
       })),
     })),
@@ -132,7 +136,6 @@ function TreemapChartSvg({
   const a11y = useChartA11y<TreemapDatum>({
     id,
     title,
-    chartType: 'heatmap',
     data,
     x: (datum) => datum.x,
     y: (datum) => datum.y,
@@ -140,6 +143,9 @@ function TreemapChartSvg({
     yLabel,
     formatY,
     keyboardNavEnabled: data.length > 0,
+    locale: {
+      chartRoleDescription: 'treemap chart',
+    },
     series: [{ label: title }],
   });
 
@@ -177,12 +183,16 @@ function TreemapChartSvg({
             >
               {(treemap) =>
                 treemap.leaves().map((node) => {
-                  const datumIndex = data.findIndex((datum) => datum.x === node.data.name);
+                  const datumIndex = node.data.pointIndex;
+                  const pointProps = datumIndex == null ? {} : a11y.getPointProps(0, datumIndex);
                   const nodeWidth = Math.max(0, node.x1 - node.x0);
                   const nodeHeight = Math.max(0, node.y1 - node.y0);
 
                   return (
-                    <g key={node.data.name} transform={`translate(${node.x0} ${node.y0})`}>
+                    <g
+                      key={`${node.data.group ?? 'Data'}-${node.data.name}-${datumIndex ?? 0}`}
+                      transform={`translate(${node.x0} ${node.y0})`}
+                    >
                       <rect
                         width={nodeWidth}
                         height={nodeHeight}
@@ -192,7 +202,7 @@ function TreemapChartSvg({
                         stroke={borderColor}
                         strokeWidth={2}
                         data-treemap-chart-cell=""
-                        {...a11y.getPointProps(0, datumIndex)}
+                        {...pointProps}
                       />
                       {nodeWidth > 72 && nodeHeight > 30 && (
                         <text

--- a/packages/visx-registry/registry/charts/treemap-chart/treemap-chart.tsx
+++ b/packages/visx-registry/registry/charts/treemap-chart/treemap-chart.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useMemo } from 'react';
+import { useChartA11y } from '@visx/a11y/react';
+import {
+  getPositiveDomain,
+  getResponsiveWidth,
+  type MarginShape,
+  useChartDimensions,
+} from '@visx/chart';
+import { hierarchy, Treemap as VisxTreemap, treemapSquarify } from '@visx/hierarchy';
+import { ParentSize } from '@visx/responsive';
+import { useScale } from '@visx/scale/react';
+import { ThemeScope } from '@visx/theme';
+import { useColor } from '@visx/theme/react';
+
+export type TreemapDatum = {
+  x: string;
+  y: number;
+  group?: string;
+};
+
+type TreemapNode = {
+  name: string;
+  value?: number;
+  children?: TreemapNode[];
+};
+
+export type TreemapChartMargin = MarginShape;
+
+export type TreemapChartProps = Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> & {
+  data?: TreemapDatum[];
+  height?: number;
+  margin?: TreemapChartMargin;
+  showLiveRegion?: boolean;
+  title?: string;
+  width?: number;
+  xLabel?: string;
+  yLabel?: string;
+};
+
+type TreemapChartSvgProps = Required<
+  Pick<
+    TreemapChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >
+> &
+  Omit<
+    TreemapChartProps,
+    'data' | 'height' | 'margin' | 'showLiveRegion' | 'title' | 'width' | 'xLabel' | 'yLabel'
+  >;
+
+const defaultData: TreemapDatum[] = [
+  { x: 'Enterprise', y: 42, group: 'Accounts' },
+  { x: 'Mid-market', y: 31, group: 'Accounts' },
+  { x: 'Startup', y: 18, group: 'Accounts' },
+  { x: 'Expansion', y: 26, group: 'Pipeline' },
+  { x: 'Renewal', y: 22, group: 'Pipeline' },
+  { x: 'Self serve', y: 14, group: 'Pipeline' },
+];
+
+const defaultMargin = {
+  top: 18,
+  right: 18,
+  bottom: 18,
+  left: 18,
+};
+
+function getHierarchyData(data: readonly TreemapDatum[]): TreemapNode {
+  const groups = new Map<string, TreemapDatum[]>();
+
+  data.forEach((datum) => {
+    const group = datum.group ?? 'Data';
+    const current = groups.get(group) ?? [];
+
+    current.push(datum);
+    groups.set(group, current);
+  });
+
+  return {
+    name: 'root',
+    children: Array.from(groups.entries()).map(([name, children]) => ({
+      name,
+      children: children.map((datum) => ({
+        name: datum.x,
+        value: Number.isFinite(datum.y) ? Math.max(0, datum.y) : 0,
+      })),
+    })),
+  };
+}
+
+function getValueDomain(data: readonly TreemapDatum[]): [number, number] {
+  return getPositiveDomain(data.map((datum) => datum.y));
+}
+
+function formatY(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function TreemapChartSvg({
+  className,
+  data,
+  height,
+  id,
+  margin,
+  showLiveRegion,
+  style,
+  title,
+  width,
+  xLabel,
+  yLabel,
+  ...svgProps
+}: TreemapChartSvgProps) {
+  const dimensions = useChartDimensions({ width, height, margin });
+  const root = useMemo(
+    () =>
+      hierarchy(getHierarchyData(data))
+        .sum((datum) => datum.value ?? 0)
+        .sort((a, b) => (b.value ?? 0) - (a.value ?? 0)),
+    [data],
+  );
+  const valueDomain = useMemo(() => getValueDomain(data), [data]);
+  const opacityScale = useScale({
+    type: 'linear',
+    domain: valueDomain,
+    range: [0.2, 0.88],
+  });
+  const cellColor = useColor(0);
+  const borderColor = useColor('background');
+  const labelColor = useColor('textPrimary');
+  const a11y = useChartA11y<TreemapDatum>({
+    id,
+    title,
+    chartType: 'heatmap',
+    data,
+    x: (datum) => datum.x,
+    y: (datum) => datum.y,
+    xLabel,
+    yLabel,
+    formatY,
+    keyboardNavEnabled: data.length > 0,
+    series: [{ label: title }],
+  });
+
+  return (
+    <ThemeScope as={false}>
+      <svg
+        {...svgProps}
+        {...a11y.svgProps}
+        id={a11y.id}
+        className={className}
+        width={dimensions.width}
+        height={dimensions.height}
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: dimensions.height,
+          overflow: 'visible',
+          ...style,
+        }}
+      >
+        <desc id={a11y.descriptionId}>{a11y.description}</desc>
+        <g
+          transform={`translate(${dimensions.margin.left} ${dimensions.margin.top})`}
+          {...a11y.getSeriesProps(0)}
+        >
+          {data.length > 0 && (
+            <VisxTreemap
+              root={root}
+              size={[dimensions.innerWidth, dimensions.innerHeight]}
+              tile={treemapSquarify}
+              round
+              paddingInner={3}
+              paddingOuter={3}
+            >
+              {(treemap) =>
+                treemap.leaves().map((node) => {
+                  const datumIndex = data.findIndex((datum) => datum.x === node.data.name);
+                  const nodeWidth = Math.max(0, node.x1 - node.x0);
+                  const nodeHeight = Math.max(0, node.y1 - node.y0);
+
+                  return (
+                    <g key={node.data.name} transform={`translate(${node.x0} ${node.y0})`}>
+                      <rect
+                        width={nodeWidth}
+                        height={nodeHeight}
+                        rx={4}
+                        fill={cellColor}
+                        fillOpacity={opacityScale(node.value ?? 0) ?? 0.2}
+                        stroke={borderColor}
+                        strokeWidth={2}
+                        data-treemap-chart-cell=""
+                        {...a11y.getPointProps(0, datumIndex)}
+                      />
+                      {nodeWidth > 72 && nodeHeight > 30 && (
+                        <text
+                          x={8}
+                          y={18}
+                          fill={labelColor}
+                          fillOpacity={0.82}
+                          fontSize={11}
+                          fontWeight={600}
+                        >
+                          {node.data.name}
+                        </text>
+                      )}
+                    </g>
+                  );
+                })
+              }
+            </VisxTreemap>
+          )}
+        </g>
+      </svg>
+      <a11y.DataTable />
+      {showLiveRegion && <a11y.Announcer />}
+    </ThemeScope>
+  );
+}
+
+export function TreemapChart({
+  data = defaultData,
+  height = 320,
+  width = 640,
+  ...props
+}: TreemapChartProps) {
+  return (
+    <ParentSize
+      debounceTime={10}
+      ignoreDimensions={['height', 'top', 'left']}
+      initialSize={{ width, height }}
+      style={{ width: '100%', height }}
+    >
+      {({ width: measuredWidth }) => (
+        <TreemapChartSvg
+          {...props}
+          data={data}
+          height={height}
+          id={props.id}
+          margin={props.margin ?? defaultMargin}
+          showLiveRegion={props.showLiveRegion ?? true}
+          title={props.title ?? 'Treemap Chart'}
+          width={getResponsiveWidth(measuredWidth, width)}
+          xLabel={props.xLabel ?? 'Category'}
+          yLabel={props.yLabel ?? 'Value'}
+        />
+      )}
+    </ParentSize>
+  );
+}

--- a/packages/visx-registry/scripts/smokeInstallRegistryItem.ts
+++ b/packages/visx-registry/scripts/smokeInstallRegistryItem.ts
@@ -1,0 +1,340 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+type FixtureKind = 'next' | 'vite';
+
+type RegistryItem = {
+  dependencies?: string[];
+  files?: { target?: string }[];
+  name: string;
+};
+
+type RegistryIndex = {
+  items?: RegistryItem[];
+};
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(DIRNAME, '..');
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, '../..');
+const SOURCE_REGISTRY_PATH = path.join(PACKAGE_ROOT, 'registry.json');
+const REPO_NODE_MODULES = path.join(REPO_ROOT, 'node_modules');
+const SHADCN_BIN = path.join(REPO_NODE_MODULES, '.bin/shadcn');
+const TSC_BIN = path.join(REPO_NODE_MODULES, 'typescript/bin/tsc');
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+}
+
+function getRegistryItems() {
+  const registry = readJson(SOURCE_REGISTRY_PATH) as RegistryIndex;
+
+  return registry.items ?? [];
+}
+
+function getRegistryItem(itemName: string) {
+  const item = getRegistryItems().find(({ name }) => name === itemName);
+
+  assert(item != null, `Missing source registry item: ${itemName}`);
+
+  return item;
+}
+
+function getComponentExportName(itemName: string) {
+  return itemName
+    .split('-')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join('');
+}
+
+function getImportPath(target: string) {
+  return target.replace(/^components\//, '@/components/').replace(/\.tsx$/, '');
+}
+
+function createPackageManagerShim(binDir: string) {
+  const npmPath = path.join(binDir, 'npm');
+
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    npmPath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function getPackageName(specifier) {
+  if (specifier.startsWith('-') || specifier.startsWith('.') || specifier.includes('://')) {
+    return null;
+  }
+  if (specifier.startsWith('@')) {
+    const slashIndex = specifier.indexOf('/');
+    if (slashIndex === -1) {
+      return null;
+    }
+    const secondSegment = specifier.slice(slashIndex + 1);
+    const versionIndex = secondSegment.indexOf('@');
+    return versionIndex === -1
+      ? specifier
+      : specifier.slice(0, slashIndex + 1 + versionIndex);
+  }
+  const versionIndex = specifier.indexOf('@');
+  return versionIndex === -1 ? specifier : specifier.slice(0, versionIndex);
+}
+
+const args = process.argv.slice(2);
+const commandIndex = args.findIndex((arg) => ['install', 'i', 'add'].includes(arg));
+const installArgs = commandIndex === -1 ? [] : args.slice(commandIndex + 1);
+const dependencies = installArgs.map(getPackageName).filter(Boolean);
+
+if (dependencies.length > 0) {
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  packageJson.dependencies = packageJson.dependencies || {};
+  dependencies.forEach((dependency) => {
+    packageJson.dependencies[dependency] = packageJson.dependencies[dependency] || 'latest';
+  });
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\\n');
+}
+`,
+  );
+  fs.chmodSync(npmPath, 0o755);
+}
+
+function createFixture(root: string, kind: FixtureKind, item: RegistryItem) {
+  const isNext = kind === 'next';
+  const cssPath = isNext ? 'src/app/globals.css' : 'src/index.css';
+  const target = item.files?.[0]?.target;
+
+  assert(target != null, `${item.name} registry item must declare a target file.`);
+
+  const componentName = getComponentExportName(item.name);
+  const importPath = getImportPath(target);
+  const chartId = `${kind}-${item.name}`;
+
+  fs.mkdirSync(path.join(root, path.dirname(cssPath)), { recursive: true });
+  fs.writeFileSync(path.join(root, cssPath), '');
+  writeJson(path.join(root, 'package.json'), {
+    name: `visx-registry-${kind}-smoke`,
+    private: true,
+    dependencies: isNext
+      ? { next: '15.0.0', react: '^19.0.0', 'react-dom': '^19.0.0' }
+      : {
+          '@vitejs/plugin-react': '^5.0.0',
+          vite: '^7.0.0',
+          react: '^19.0.0',
+          'react-dom': '^19.0.0',
+        },
+    devDependencies: {},
+  });
+  writeJson(path.join(root, 'tsconfig.json'), {
+    compilerOptions: {
+      allowSyntheticDefaultImports: true,
+      baseUrl: '.',
+      esModuleInterop: true,
+      jsx: 'react-jsx',
+      lib: ['dom', 'dom.iterable', 'es2022'],
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      noEmit: true,
+      paths: {
+        '@/*': ['./src/*'],
+      },
+      skipLibCheck: true,
+      strict: true,
+      target: 'ES2022',
+    },
+    include: ['src/**/*.ts', 'src/**/*.tsx'],
+  });
+  writeJson(path.join(root, 'components.json'), {
+    $schema: 'https://ui.shadcn.com/schema.json',
+    style: 'new-york',
+    rsc: isNext,
+    tsx: true,
+    tailwind: {
+      config: '',
+      css: cssPath,
+      baseColor: 'neutral',
+      cssVariables: true,
+    },
+    aliases: {
+      components: '@/components',
+      utils: '@/lib/utils',
+      ui: '@/components/ui',
+      lib: '@/lib',
+      hooks: '@/hooks',
+    },
+  });
+
+  if (isNext) {
+    fs.writeFileSync(
+      path.join(root, 'src/app/page.tsx'),
+      `import { ${componentName} } from '${importPath}';\n\nexport default function Page() {\n  return <${componentName} id="${chartId}" />;\n}\n`,
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(root, 'src/App.tsx'),
+      `import { ${componentName} } from '${importPath}';\n\nexport function App() {\n  return <${componentName} id="${chartId}" />;\n}\n`,
+    );
+  }
+}
+
+function linkRepoNodeModules(root: string) {
+  assert(
+    fs.existsSync(REPO_NODE_MODULES),
+    'Install repository dependencies before running registry install smoke tests.',
+  );
+  assert(fs.existsSync(SHADCN_BIN), 'Install shadcn before running registry install smoke tests.');
+  assert(fs.existsSync(TSC_BIN), 'Install TypeScript before running registry install smoke tests.');
+
+  fs.symlinkSync(REPO_NODE_MODULES, path.join(root, 'node_modules'), 'dir');
+}
+
+function assertFixtureDependencies(root: string, kind: FixtureKind, item: RegistryItem) {
+  const packageJson = readJson(path.join(root, 'package.json')) as {
+    dependencies?: Record<string, string>;
+  };
+
+  (item.dependencies ?? []).forEach((dependency) => {
+    assert(
+      packageJson.dependencies?.[dependency] != null,
+      `${kind} fixture did not install ${dependency} for ${item.name}.`,
+    );
+  });
+}
+
+function typecheckFixture(root: string, kind: FixtureKind) {
+  try {
+    execFileSync('node', [TSC_BIN, '--project', path.join(root, 'tsconfig.json')], {
+      cwd: root,
+      stdio: 'pipe',
+    });
+  } catch (error) {
+    const { stderr, stdout } = error as { stderr?: unknown; stdout?: unknown };
+    const output = [stdout, stderr]
+      .filter((chunk): chunk is NonNullable<typeof chunk> => chunk != null)
+      .map(String)
+      .join('\n');
+
+    throw new Error(`${kind} fixture failed to typecheck installed registry item.\n${output}`);
+  }
+}
+
+function buildRegistryArtifacts(outputDir: string) {
+  assert(fs.existsSync(SHADCN_BIN), 'Install shadcn before running registry install smoke tests.');
+
+  try {
+    execFileSync(
+      SHADCN_BIN,
+      ['build', 'registry.json', '--cwd', REPO_ROOT, '--output', outputDir],
+      {
+        cwd: REPO_ROOT,
+        stdio: 'pipe',
+      },
+    );
+  } catch (error) {
+    const { stderr, stdout } = error as { stderr?: unknown; stdout?: unknown };
+    const output = [stdout, stderr]
+      .filter((chunk): chunk is NonNullable<typeof chunk> => chunk != null)
+      .map(String)
+      .join('\n');
+
+    throw new Error(`Failed to build temporary registry artifacts.\n${output}`);
+  }
+}
+
+function smokeInstallBuiltRegistryItem(itemName: string, registryOutputDir: string) {
+  const itemPath = path.join(registryOutputDir, `${itemName}.json`);
+  const item = getRegistryItem(itemName);
+  const componentName = getComponentExportName(itemName);
+
+  assert(fs.existsSync(itemPath), `Temporary registry build did not create ${itemName}.json.`);
+
+  (['next', 'vite'] as const).forEach((kind) => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `visx-registry-${kind}-`));
+    const binDir = path.join(tempRoot, 'bin');
+
+    try {
+      createFixture(tempRoot, kind, item);
+      linkRepoNodeModules(tempRoot);
+      createPackageManagerShim(binDir);
+
+      execFileSync(
+        SHADCN_BIN,
+        ['add', itemPath, '--cwd', tempRoot, '--yes', '--silent', '--overwrite'],
+        {
+          cwd: REPO_ROOT,
+          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}` },
+          stdio: 'pipe',
+        },
+      );
+
+      const target = item.files?.[0]?.target;
+
+      assert(target != null, `${itemName} registry item must declare a target file.`);
+
+      const installedPath = path.join(
+        tempRoot,
+        'src',
+        target.replace(/^components\//, 'components/'),
+      );
+      const installed = fs.readFileSync(installedPath, 'utf8');
+
+      assertFixtureDependencies(tempRoot, kind, item);
+      assert(
+        installed.includes(`export function ${componentName}`),
+        `${kind} fixture did not install ${componentName}.`,
+      );
+      assert(
+        installed.includes('@visx/a11y/react'),
+        `${kind} fixture installed stale chart content.`,
+      );
+      typecheckFixture(tempRoot, kind);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+}
+
+export function smokeInstallRegistryItem(itemName: string) {
+  const registryOutputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'visx-registry-build-'));
+
+  try {
+    buildRegistryArtifacts(registryOutputDir);
+    smokeInstallBuiltRegistryItem(itemName, registryOutputDir);
+  } finally {
+    fs.rmSync(registryOutputDir, { recursive: true, force: true });
+  }
+}
+
+export function smokeInstallRegistryItems(itemNames = getRegistryItems().map(({ name }) => name)) {
+  const registryOutputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'visx-registry-build-'));
+
+  try {
+    buildRegistryArtifacts(registryOutputDir);
+    itemNames.forEach((itemName) => smokeInstallBuiltRegistryItem(itemName, registryOutputDir));
+  } finally {
+    fs.rmSync(registryOutputDir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const itemNames = process.argv.slice(2);
+
+    smokeInstallRegistryItems(itemNames.length > 0 ? itemNames : undefined);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/packages/visx-registry/src/index.ts
+++ b/packages/visx-registry/src/index.ts
@@ -1,0 +1,2 @@
+// Registry items are built from source files by the shadcn CLI; this private package has no runtime API.
+export {};

--- a/packages/visx-registry/test/registry.test.tsx
+++ b/packages/visx-registry/test/registry.test.tsx
@@ -563,6 +563,48 @@ describe('@visx/registry scaffold', () => {
     expect(single.container.innerHTML).not.toContain('Infinity');
   });
 
+  it('renders heatmap gaps without assigning synthetic cells point semantics', () => {
+    const { container } = render(
+      <HeatmapChart
+        id="heatmap-gaps"
+        title="Heatmap gaps"
+        data={[
+          { x: 'Mon', y: 'Search', value: 22 },
+          { x: 'Tue', y: 'Search', value: 28 },
+          { x: 'Mon', y: 'Invite', value: 18 },
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('[data-heatmap-chart-cell]')).toHaveLength(4);
+    expect(
+      container.querySelectorAll('[data-heatmap-chart-cell][role="graphics-symbol"]'),
+    ).toHaveLength(3);
+    expect(container.querySelectorAll('[data-heatmap-chart-cell][aria-label=""]')).toHaveLength(0);
+  });
+
+  it('uses treemap semantics and stable point props for duplicate leaf names', () => {
+    const { container } = render(
+      <TreemapChart
+        id="treemap-duplicates"
+        title="Treemap duplicates"
+        data={[
+          { x: 'Revenue', y: 42, group: 'Accounts' },
+          { x: 'Revenue', y: 24, group: 'Pipeline' },
+        ]}
+      />,
+    );
+    const svg = container.querySelector('svg');
+    const cells = Array.from(container.querySelectorAll('[data-treemap-chart-cell]'));
+    const labels = cells.map((cell) => cell.getAttribute('aria-label'));
+
+    expect(svg?.getAttribute('aria-roledescription')).toBe('treemap chart');
+    expect(container.querySelector('desc')?.textContent).toContain('treemap chart');
+    expect(cells).toHaveLength(2);
+    expect(labels).toContain('Treemap duplicates, Revenue, 42');
+    expect(labels).toContain('Treemap duplicates, Revenue, 24');
+  });
+
   it.each(emptyStateChartComponents)(
     'renders an empty $name without invalid SVG output',
     ({ Component, markerSelector, name, props }) => {

--- a/packages/visx-registry/test/registry.test.tsx
+++ b/packages/visx-registry/test/registry.test.tsx
@@ -1,0 +1,603 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { fireEvent, render } from '@testing-library/react';
+import type { ComponentType } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { smokeInstallRegistryItem } from '../scripts/smokeInstallRegistryItem';
+import { AreaChart } from '../registry/charts/area-chart/area-chart';
+import { BarChart } from '../registry/charts/bar-chart/bar-chart';
+import { GroupedBarChart } from '../registry/charts/grouped-bar-chart/grouped-bar-chart';
+import { HeatmapChart } from '../registry/charts/heatmap-chart/heatmap-chart';
+import { HistogramChart } from '../registry/charts/histogram-chart/histogram-chart';
+import { HorizontalStackedBarChart } from '../registry/charts/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart';
+import { LineChart } from '../registry/charts/line-chart/line-chart';
+import { MultiSeriesLineChart } from '../registry/charts/multi-series-line-chart/multi-series-line-chart';
+import { PieChart } from '../registry/charts/pie-chart/pie-chart';
+import { RadarChart } from '../registry/charts/radar-chart/radar-chart';
+import { RadialBarChart } from '../registry/charts/radial-bar-chart/radial-bar-chart';
+import { ScatterChart } from '../registry/charts/scatter-chart/scatter-chart';
+import { StackedAreaChart } from '../registry/charts/stacked-area-chart/stacked-area-chart';
+import { StackedBarChart } from '../registry/charts/stacked-bar-chart/stacked-bar-chart';
+import { ThresholdChart } from '../registry/charts/threshold-chart/threshold-chart';
+import { TreemapChart } from '../registry/charts/treemap-chart/treemap-chart';
+
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, '../..');
+const ROOT_REGISTRY_PATH = path.join(REPO_ROOT, 'registry.json');
+const SOURCE_REGISTRY_PATH = path.join(PACKAGE_ROOT, 'registry.json');
+
+class MockResizeObserver implements ResizeObserver {
+  private readonly observed = new Set<Element>();
+
+  disconnect() {
+    this.observed.clear();
+  }
+
+  observe(target: Element) {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.observed.delete(target);
+  }
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  configurable: true,
+  value: MockResizeObserver,
+  writable: true,
+});
+
+function readJson(filePath: string) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+}
+
+const CORE_CHART_ITEMS = [
+  'line-chart',
+  'bar-chart',
+  'area-chart',
+  'scatter-chart',
+  'stacked-bar-chart',
+  'multi-series-line-chart',
+  'pie-chart',
+  'histogram-chart',
+] as const;
+
+const EXTENDED_CHART_ITEMS = [
+  'grouped-bar-chart',
+  'horizontal-stacked-bar-chart',
+  'stacked-area-chart',
+  'threshold-chart',
+  'heatmap-chart',
+  'radar-chart',
+  'radial-bar-chart',
+  'treemap-chart',
+] as const;
+
+const REGISTRY_ITEMS = [...CORE_CHART_ITEMS, ...EXTENDED_CHART_ITEMS] as const;
+
+type RegistryItemName = (typeof REGISTRY_ITEMS)[number];
+
+const CHART_UI_ITEMS = [
+  'bar-chart',
+  'stacked-bar-chart',
+  'multi-series-line-chart',
+  'grouped-bar-chart',
+  'horizontal-stacked-bar-chart',
+  'stacked-area-chart',
+  'threshold-chart',
+] as const;
+
+const CARTESIAN_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/axis',
+  '@visx/chart',
+  '@visx/grid',
+  '@visx/responsive',
+  '@visx/scale',
+  '@visx/shape',
+  '@visx/theme',
+];
+
+const PIE_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/chart',
+  '@visx/responsive',
+  '@visx/shape',
+  '@visx/theme',
+];
+
+const THRESHOLD_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/axis',
+  '@visx/chart',
+  '@visx/grid',
+  '@visx/responsive',
+  '@visx/scale',
+  '@visx/shape',
+  '@visx/threshold',
+  '@visx/theme',
+];
+
+const HEATMAP_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/chart',
+  '@visx/heatmap',
+  '@visx/responsive',
+  '@visx/scale',
+  '@visx/theme',
+];
+
+const RADAR_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/chart',
+  '@visx/responsive',
+  '@visx/scale',
+  '@visx/theme',
+];
+
+const RADIAL_BAR_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/chart',
+  '@visx/responsive',
+  '@visx/scale',
+  '@visx/shape',
+  '@visx/theme',
+];
+
+const TREEMAP_DEPENDENCIES = [
+  '@visx/a11y',
+  '@visx/chart',
+  '@visx/hierarchy',
+  '@visx/responsive',
+  '@visx/scale',
+  '@visx/theme',
+];
+
+const REGISTRY_DEPENDENCIES = {
+  'line-chart': CARTESIAN_DEPENDENCIES,
+  'bar-chart': CARTESIAN_DEPENDENCIES,
+  'area-chart': CARTESIAN_DEPENDENCIES,
+  'scatter-chart': CARTESIAN_DEPENDENCIES,
+  'stacked-bar-chart': CARTESIAN_DEPENDENCIES,
+  'multi-series-line-chart': CARTESIAN_DEPENDENCIES,
+  'pie-chart': PIE_DEPENDENCIES,
+  'histogram-chart': CARTESIAN_DEPENDENCIES,
+  'grouped-bar-chart': CARTESIAN_DEPENDENCIES,
+  'horizontal-stacked-bar-chart': CARTESIAN_DEPENDENCIES,
+  'stacked-area-chart': CARTESIAN_DEPENDENCIES,
+  'threshold-chart': THRESHOLD_DEPENDENCIES,
+  'heatmap-chart': HEATMAP_DEPENDENCIES,
+  'radar-chart': RADAR_DEPENDENCIES,
+  'radial-bar-chart': RADIAL_BAR_DEPENDENCIES,
+  'treemap-chart': TREEMAP_DEPENDENCIES,
+} satisfies Record<RegistryItemName, readonly string[]>;
+
+const chartComponents: {
+  Component: ComponentType<{ id?: string; showLiveRegion?: boolean; title: string }>;
+  markerSelector: string;
+  name: RegistryItemName;
+}[] = [
+  { name: 'line-chart', Component: LineChart, markerSelector: '[data-line-chart-point]' },
+  { name: 'bar-chart', Component: BarChart, markerSelector: '[data-bar-chart-bar]' },
+  { name: 'area-chart', Component: AreaChart, markerSelector: '[data-area-chart-point]' },
+  { name: 'scatter-chart', Component: ScatterChart, markerSelector: '[data-scatter-chart-point]' },
+  {
+    name: 'stacked-bar-chart',
+    Component: StackedBarChart,
+    markerSelector: '[data-stacked-bar-chart-bar]',
+  },
+  {
+    name: 'multi-series-line-chart',
+    Component: MultiSeriesLineChart,
+    markerSelector: '[data-multi-series-line-chart-point]',
+  },
+  { name: 'pie-chart', Component: PieChart, markerSelector: '[data-pie-chart-segment]' },
+  {
+    name: 'histogram-chart',
+    Component: HistogramChart,
+    markerSelector: '[data-histogram-chart-bin]',
+  },
+  {
+    name: 'grouped-bar-chart',
+    Component: GroupedBarChart,
+    markerSelector: '[data-grouped-bar-chart-bar]',
+  },
+  {
+    name: 'horizontal-stacked-bar-chart',
+    Component: HorizontalStackedBarChart,
+    markerSelector: '[data-horizontal-stacked-bar-chart-bar]',
+  },
+  {
+    name: 'stacked-area-chart',
+    Component: StackedAreaChart,
+    markerSelector: '[data-stacked-area-chart-point]',
+  },
+  {
+    name: 'threshold-chart',
+    Component: ThresholdChart,
+    markerSelector: '[data-threshold-chart-point]',
+  },
+  {
+    name: 'heatmap-chart',
+    Component: HeatmapChart,
+    markerSelector: '[data-heatmap-chart-cell]',
+  },
+  { name: 'radar-chart', Component: RadarChart, markerSelector: '[data-radar-chart-point]' },
+  {
+    name: 'radial-bar-chart',
+    Component: RadialBarChart,
+    markerSelector: '[data-radial-bar-chart-bar]',
+  },
+  {
+    name: 'treemap-chart',
+    Component: TreemapChart,
+    markerSelector: '[data-treemap-chart-cell]',
+  },
+];
+
+const emptyStateChartComponents: {
+  Component: ComponentType<Record<string, unknown>>;
+  markerSelector: string;
+  name: RegistryItemName;
+  props: Record<string, unknown>;
+}[] = chartComponents.map(({ Component, markerSelector, name }) => ({
+  Component: Component as ComponentType<Record<string, unknown>>,
+  markerSelector,
+  name,
+  props:
+    name === 'histogram-chart'
+      ? { values: [] }
+      : name === 'multi-series-line-chart'
+      ? { series: [] }
+      : { data: [] },
+}));
+
+const legendChartComponents: {
+  Component: ComponentType<{
+    id?: string;
+    showLegend?: boolean;
+    showLiveRegion?: boolean;
+    title: string;
+  }>;
+  labels: string[];
+  name: (typeof CHART_UI_ITEMS)[number];
+}[] = [
+  {
+    name: 'stacked-bar-chart',
+    Component: StackedBarChart,
+    labels: ['Desktop', 'Mobile', 'Tablet'],
+  },
+  {
+    name: 'multi-series-line-chart',
+    Component: MultiSeriesLineChart,
+    labels: ['Desktop', 'Mobile'],
+  },
+  {
+    name: 'grouped-bar-chart',
+    Component: GroupedBarChart,
+    labels: ['Desktop', 'Mobile', 'Tablet'],
+  },
+  {
+    name: 'horizontal-stacked-bar-chart',
+    Component: HorizontalStackedBarChart,
+    labels: ['Desktop', 'Mobile', 'Tablet'],
+  },
+  {
+    name: 'stacked-area-chart',
+    Component: StackedAreaChart,
+    labels: ['Desktop', 'Mobile', 'Tablet'],
+  },
+  { name: 'threshold-chart', Component: ThresholdChart, labels: ['Actual', 'Target'] },
+];
+
+describe('@visx/registry scaffold', () => {
+  it('exposes a root GitHub registry entrypoint for shadcn installs', () => {
+    const rootRegistry = readJson(ROOT_REGISTRY_PATH) as {
+      homepage?: string;
+      include?: string[];
+      name?: string;
+    };
+
+    expect(rootRegistry.name).toBe('visx');
+    expect(rootRegistry.homepage).toBe('https://github.com/airbnb/visx');
+    expect(rootRegistry.include).toEqual(['packages/visx-registry/registry.json']);
+  });
+
+  it('ships the core and extended chart sets in registry order', () => {
+    const registry = readJson(SOURCE_REGISTRY_PATH) as {
+      items: { meta?: Record<string, unknown>; name: string }[];
+    };
+
+    expect(registry.items.map((item) => item.name)).toEqual(REGISTRY_ITEMS);
+    registry.items.forEach((item, index) => {
+      expect(item.meta).toMatchObject({
+        a11y: true,
+        client: true,
+        ssr: true,
+        tier: index < CORE_CHART_ITEMS.length ? 'core' : 'extended',
+      });
+    });
+  });
+
+  it('declares GitHub registry source files and install metadata', () => {
+    const registry = readJson(SOURCE_REGISTRY_PATH) as {
+      items: {
+        dependencies?: string[];
+        files?: { content?: string; path: string; target?: string; type: string }[];
+        name: string;
+        type?: string;
+      }[];
+    };
+    const itemsByName = new Map(registry.items.map((item) => [item.name, item]));
+
+    REGISTRY_ITEMS.forEach((name) => {
+      const item = itemsByName.get(name);
+      const file = item?.files?.find(({ target }) => target === `components/charts/${name}.tsx`);
+
+      expect(item?.type).toBe('registry:block');
+      expect(item?.dependencies).toEqual(REGISTRY_DEPENDENCIES[name]);
+      expect(file).toMatchObject({
+        path: `registry/charts/${name}/${name}.tsx`,
+        target: `components/charts/${name}.tsx`,
+        type: 'registry:component',
+      });
+      expect(file?.content).toBeUndefined();
+
+      const source = fs.readFileSync(path.join(PACKAGE_ROOT, file?.path ?? ''), 'utf8');
+
+      expect(source.startsWith("'use client';\n\n")).toBe(true);
+      expect(source).toContain('export function');
+      expect(source).toContain('@visx/a11y/react');
+    });
+
+    CHART_UI_ITEMS.forEach((name) => {
+      expect(itemsByName.get(name)?.files).toContainEqual({
+        path: 'registry/charts/bar-chart/chart-ui.tsx',
+        target: 'components/charts/chart-ui.tsx',
+        type: 'registry:component',
+      });
+    });
+  });
+
+  it('renders the line chart with themed marks and a11y semantics', () => {
+    const { container } = render(<LineChart id="sales-chart" title="Sales" />);
+    const svg = container.querySelector('svg');
+    const line = container.querySelector('path');
+    const points = container.querySelectorAll('[data-line-chart-point]');
+    const table = container.querySelector('table');
+    const liveRegions = container.querySelectorAll('[aria-live]');
+
+    expect(svg?.getAttribute('role')).toBe('graphics-document');
+    expect(svg?.getAttribute('aria-label')).toBe('Sales');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 640 320');
+    expect(svg?.getAttribute('width')).toBe('640');
+    expect(line?.getAttribute('stroke')).toContain('var(--chart-1');
+    expect(points).toHaveLength(6);
+    expect(points[0].getAttribute('aria-label')).toContain('Sales, Jan, 32');
+    expect(table?.id).toBe('sales-chart-table');
+    expect(liveRegions).toHaveLength(1);
+  });
+
+  it('can disable its live region when a dashboard owns the page-level announcer', () => {
+    const { container } = render(
+      <>
+        <LineChart id="primary-chart" title="Primary" />
+        <LineChart id="secondary-chart" title="Secondary" showLiveRegion={false} />
+      </>,
+    );
+
+    expect(container.querySelectorAll('[aria-live]')).toHaveLength(1);
+  });
+
+  it('renders bar chart config, legend, and tooltip affordances', () => {
+    const { container } = render(
+      <BarChart
+        config={{
+          bookings: {
+            label: 'Bookings',
+            color: 'var(--chart-2)',
+          },
+        }}
+        formatValue={(value) => `${value} bookings`}
+        id="booking-chart"
+        seriesKey="bookings"
+        showLegend
+        title="Bookings by channel"
+      />,
+    );
+    const bar = container.querySelector('[data-bar-chart-bar]');
+    const legend = container.querySelector('[aria-label="Chart legend"]');
+
+    expect(bar?.getAttribute('fill')).toBe('var(--chart-2)');
+    expect(legend?.textContent).toContain('Bookings');
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+
+    fireEvent.pointerEnter(bar as Element);
+
+    const tooltip = container.querySelector('[role="tooltip"]');
+
+    expect(tooltip?.textContent).toContain('Jan');
+    expect(tooltip?.textContent).toContain('Bookings');
+    expect(tooltip?.textContent).toContain('32 bookings');
+    expect(tooltip?.getAttribute('style')).toContain('max-width: calc(624px)');
+
+    fireEvent.pointerLeave(bar as Element);
+
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it('generates unique a11y ids for multiple chart instances without explicit ids', () => {
+    const { container } = render(
+      <>
+        <LineChart title="Sales" showLiveRegion={false} />
+        <LineChart title="Sales" showLiveRegion={false} />
+      </>,
+    );
+    const svgs = Array.from(container.querySelectorAll('svg[role="graphics-document"]'));
+    const svgIds = svgs.map((svg) => svg.id);
+    const descriptionIds = svgs.map((svg) => svg.getAttribute('aria-describedby'));
+    const tableIds = Array.from(container.querySelectorAll('table'), (table) => table.id);
+
+    expect(svgs.length).toBe(2);
+    expect(svgIds.length).toBe(2);
+    expect(descriptionIds.length).toBe(2);
+    expect(tableIds.length).toBe(2);
+    expect(new Set(svgIds).size).toBe(2);
+    expect(new Set(descriptionIds).size).toBe(2);
+    expect(new Set(tableIds).size).toBe(2);
+    expect(descriptionIds).toEqual(svgIds.map((svgId) => `${svgId}-description`));
+    descriptionIds.forEach((descriptionId) => {
+      expect(container.querySelector(`desc[id="${descriptionId}"]`)).not.toBeNull();
+    });
+  });
+
+  it.each(chartComponents)(
+    'renders $name with live a11y wiring',
+    ({ Component, markerSelector, name }) => {
+      const { container } = render(<Component id={`${name}-chart`} title={name} />);
+      const svg = container.querySelector('svg');
+      const table = container.querySelector('table');
+      const liveRegions = container.querySelectorAll('[aria-live]');
+
+      expect(svg?.getAttribute('role')).toBe('graphics-document');
+      expect(svg?.getAttribute('aria-label')).toBe(name);
+      expect(table?.id).toBe(`${name}-chart-table`);
+      expect(container.querySelector(markerSelector)).not.toBeNull();
+      expect(liveRegions).toHaveLength(1);
+      expect(container.innerHTML).not.toContain('NaN');
+      expect(container.innerHTML).not.toContain('Infinity');
+    },
+  );
+
+  it('rounds only the top visible stacked bar segment for each category', () => {
+    const { container } = render(
+      <StackedBarChart
+        data={[
+          { x: 'Jan', desktop: 10, mobile: 20, tablet: 30 },
+          { x: 'Feb', desktop: 12, mobile: 0, tablet: 24 },
+        ]}
+        id="stacked-rounding"
+        title="Stacked rounding"
+      />,
+    );
+
+    expect(container.querySelectorAll('[data-stacked-bar-chart-bar]')).toHaveLength(5);
+    expect(container.querySelectorAll('path[data-stacked-bar-chart-bar]')).toHaveLength(2);
+    expect(container.querySelectorAll('rect[data-stacked-bar-chart-bar]')).toHaveLength(3);
+    container.querySelectorAll('rect[data-stacked-bar-chart-bar]').forEach((rect) => {
+      expect(rect.getAttribute('rx')).toBeNull();
+    });
+  });
+
+  it('rounds only the top corners for bar and histogram chart marks', () => {
+    const bar = render(<BarChart id="bar-rounding" title="Bar rounding" />);
+    const histogram = render(<HistogramChart id="histogram-rounding" title="Histogram rounding" />);
+    const countArcs = (element: Element) => element.getAttribute('d')?.match(/a/g)?.length ?? 0;
+
+    expect(bar.container.querySelectorAll('path[data-bar-chart-bar]')).toHaveLength(6);
+    expect(bar.container.querySelectorAll('rect[data-bar-chart-bar]')).toHaveLength(0);
+    bar.container.querySelectorAll('path[data-bar-chart-bar]').forEach((element) => {
+      expect(countArcs(element)).toBe(2);
+    });
+    expect(histogram.container.querySelectorAll('path[data-histogram-chart-bin]')).toHaveLength(6);
+    expect(histogram.container.querySelectorAll('rect[data-histogram-chart-bin]')).toHaveLength(0);
+    histogram.container.querySelectorAll('path[data-histogram-chart-bin]').forEach((element) => {
+      expect(countArcs(element)).toBe(2);
+    });
+  });
+
+  it('supports explicit histogram tick values and tick formatting', () => {
+    const { container } = render(
+      <HistogramChart
+        binCount={4}
+        id="histogram-ticks"
+        title="Histogram ticks"
+        values={[0, 10, 20, 30, 40]}
+        xTickFormat={(value) => `bin:${value}`}
+        xTickValues={['0-10', '30-40']}
+      />,
+    );
+    const svgLabels = Array.from(
+      container.querySelectorAll('svg text'),
+      (text) => text.textContent,
+    );
+
+    expect(svgLabels).toContain('bin:0-10');
+    expect(svgLabels).toContain('bin:30-40');
+    expect(svgLabels).not.toContain('bin:10-20');
+    expect(svgLabels).not.toContain('bin:20-30');
+  });
+
+  it.each(legendChartComponents)(
+    'renders a legend for $name by default',
+    ({ Component, labels, name }) => {
+      const { container } = render(
+        <Component id={`${name}-legend`} title={name} showLiveRegion={false} />,
+      );
+      const legend = container.querySelector('[aria-label="Chart legend"]');
+
+      expect(legend).not.toBeNull();
+      labels.forEach((label) => {
+        expect(legend?.textContent).toContain(label);
+      });
+    },
+  );
+
+  it('renders empty and single-datum states without invalid SVG output', () => {
+    const empty = render(<LineChart id="empty-chart" title="Empty" data={[]} />);
+
+    expect(empty.container.querySelector('desc')?.textContent).toContain('has no data');
+    expect(empty.container.querySelector('path')).toBeNull();
+    expect(empty.container.querySelectorAll('[data-line-chart-point]')).toHaveLength(0);
+
+    const single = render(
+      <LineChart id="single-chart" title="Single" data={[{ x: 'Only', y: 10 }]} />,
+    );
+
+    expect(single.container.querySelector('path')).toBeNull();
+    expect(single.container.querySelectorAll('[data-line-chart-point]')).toHaveLength(1);
+    expect(single.container.innerHTML).not.toContain('NaN');
+    expect(single.container.innerHTML).not.toContain('Infinity');
+  });
+
+  it.each(emptyStateChartComponents)(
+    'renders an empty $name without invalid SVG output',
+    ({ Component, markerSelector, name, props }) => {
+      const { container } = render(
+        <Component
+          id={`empty-${name}`}
+          title={`Empty ${name}`}
+          showLiveRegion={false}
+          {...props}
+        />,
+      );
+
+      expect(container.querySelector('svg[role="graphics-document"]')).not.toBeNull();
+      expect(container.querySelector('desc')?.textContent).toMatch(
+        /has no data|has no numeric values/,
+      );
+      expect(container.querySelectorAll(markerSelector)).toHaveLength(0);
+      expect(container.innerHTML).not.toContain('NaN');
+      expect(container.innerHTML).not.toContain('Infinity');
+    },
+  );
+
+  it.each(chartComponents)(
+    'supports server rendering $name with hidden tabular fallback content',
+    ({ Component, name }) => {
+      const html = renderToString(<Component id={`ssr-${name}`} title={`SSR ${name}`} />);
+
+      expect(html).toContain('role="graphics-document"');
+      expect(html).toContain(`ssr-${name}-description`);
+      expect(html).toContain('<table');
+      expect(html).toContain(`SSR ${name}`);
+    },
+  );
+
+  it('installs line-chart into fresh Next and Vite fixtures with the real shadcn CLI', () => {
+    expect(() => smokeInstallRegistryItem('line-chart')).not.toThrow();
+  }, 20_000);
+});

--- a/packages/visx-registry/tsconfig.json
+++ b/packages/visx-registry/tsconfig.json
@@ -1,0 +1,55 @@
+{
+  "compilerOptions": {
+    "declarationDir": "lib",
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "exclude": [
+    "lib",
+    "public",
+    "registry",
+    "scripts",
+    "test"
+  ],
+  "extends": "../../tsconfig.options.json",
+  "include": [
+    "src/**/*",
+    "types/**/*",
+    "../../types/**/*"
+  ],
+  "references": [
+    {
+      "path": "../visx-a11y"
+    },
+    {
+      "path": "../visx-axis"
+    },
+    {
+      "path": "../visx-chart"
+    },
+    {
+      "path": "../visx-grid"
+    },
+    {
+      "path": "../visx-heatmap"
+    },
+    {
+      "path": "../visx-hierarchy"
+    },
+    {
+      "path": "../visx-responsive"
+    },
+    {
+      "path": "../visx-scale"
+    },
+    {
+      "path": "../visx-shape"
+    },
+    {
+      "path": "../visx-theme"
+    },
+    {
+      "path": "../visx-threshold"
+    }
+  ]
+}

--- a/packages/visx-registry/vitest.config.ts
+++ b/packages/visx-registry/vitest.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    name: '@visx/registry',
+    globals: true,
+    environment: 'jsdom',
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'json-summary', 'html', 'json', 'text'],
+      include: ['packages/visx-registry/scripts/**/*.{ts,tsx}'],
+      exclude: ['**/node_modules/**', '**/esm/**', '**/lib/**', '**/test/**', '**/dist/**'],
+      reportsDirectory: './coverage',
+    },
+  },
+  resolve: {
+    alias: {
+      '@visx/a11y': path.resolve(__dirname, '../visx-a11y/src'),
+      '@visx/a11y/react': path.resolve(__dirname, '../visx-a11y/src/react'),
+      '@visx/axis': path.resolve(__dirname, '../visx-axis/src'),
+      '@visx/axis/react': path.resolve(__dirname, '../visx-axis/src/react'),
+      '@visx/chart': path.resolve(__dirname, '../visx-chart/src'),
+      '@visx/clip-path': path.resolve(__dirname, '../visx-clip-path/src'),
+      '@visx/grid': path.resolve(__dirname, '../visx-grid/src'),
+      '@visx/heatmap': path.resolve(__dirname, '../visx-heatmap/src'),
+      '@visx/hierarchy': path.resolve(__dirname, '../visx-hierarchy/src'),
+      '@visx/kernel': path.resolve(__dirname, '../visx-kernel/src'),
+      '@visx/responsive': path.resolve(__dirname, '../visx-responsive/src'),
+      '@visx/scale': path.resolve(__dirname, '../visx-scale/src'),
+      '@visx/scale/react': path.resolve(__dirname, '../visx-scale/src/react'),
+      '@visx/shape': path.resolve(__dirname, '../visx-shape/src'),
+      '@visx/threshold': path.resolve(__dirname, '../visx-threshold/src'),
+      '@visx/theme': path.resolve(__dirname, '../visx-theme/src'),
+      '@visx/theme/react': path.resolve(__dirname, '../visx-theme/src/react'),
+      '@visx/vendor/d3-array': path.resolve(__dirname, '../visx-vendor/esm/d3-array.js'),
+      '@visx/vendor/d3-path': path.resolve(__dirname, '../visx-vendor/esm/d3-path.js'),
+      '@visx/vendor/d3-scale': path.resolve(__dirname, '../visx-vendor/esm/d3-scale.js'),
+      '@visx/vendor/d3-shape': path.resolve(__dirname, '../visx-vendor/esm/d3-shape.js'),
+    },
+  },
+});

--- a/packages/visx-theme/src/react/useAxisStyle.ts
+++ b/packages/visx-theme/src/react/useAxisStyle.ts
@@ -15,7 +15,7 @@ export type AxisTextStyleProps = {
 };
 
 export type AxisStyleProps = {
-  labelOffset: number;
+  labelOffset?: number;
   stroke: string;
   strokeWidth: number;
   tickLength: number;

--- a/packages/visx-theme/src/react/useAxisStyle.ts
+++ b/packages/visx-theme/src/react/useAxisStyle.ts
@@ -15,6 +15,7 @@ export type AxisTextStyleProps = {
 };
 
 export type AxisStyleProps = {
+  labelOffset: number;
   stroke: string;
   strokeWidth: number;
   tickLength: number;
@@ -69,10 +70,18 @@ const labelPositionByOrientation: Record<
   },
 };
 
+const labelOffsetByOrientation: Record<AxisOrientation, number> = {
+  bottom: 22,
+  top: 22,
+  left: 20,
+  right: 20,
+};
+
 export default function useAxisStyle(orientation: AxisOrientation): AxisStyleProps {
   const theme = useTheme();
 
   return {
+    labelOffset: labelOffsetByOrientation[orientation],
     stroke: theme.colors.axisStroke,
     strokeWidth: theme.axis.strokeWidth,
     tickLength: theme.axis.tickLength,

--- a/packages/visx-theme/test/hooks.test.tsx
+++ b/packages/visx-theme/test/hooks.test.tsx
@@ -242,6 +242,7 @@ describe('@visx/theme/react hooks', () => {
     render(<AxisStyleProbe orientation="left" onStyle={onStyle} />);
 
     expect(onStyle).toHaveBeenCalledWith({
+      labelOffset: 20,
       stroke: theme.colors.axisStroke,
       strokeWidth: lightTheme.axis.strokeWidth,
       tickLength: lightTheme.axis.tickLength,

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "visx",
+  "homepage": "https://github.com/airbnb/visx",
+  "include": ["packages/visx-registry/registry.json"]
+}

--- a/scripts/generateDocs.ts
+++ b/scripts/generateDocs.ts
@@ -656,6 +656,7 @@ function generateDocsForPackages(): PackageDocs {
     ignore: [
       '**/node_modules/**',
       'packages/visx-demo/**',
+      'packages/visx-registry/**',
       'packages/visx-vendor/**',
       'packages/visx-visx/**',
     ],

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,6 +6,7 @@
     "packages/*/test/**/*",
     "packages/*/types/**/*",
     "packages/*/scripts/**/*",
+    "packages/*/registry/**/*",
     "vitest.workspace.ts",
     "packages/*/vitest.config.ts"
   ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       'packages/visx-heatmap/vitest.config.ts',
       'packages/visx-hierarchy/vitest.config.ts',
       'packages/visx-kernel/vitest.config.ts',
+      'packages/visx-registry/vitest.config.ts',
       'packages/visx-react-spring/vitest.config.ts',
       'packages/visx-sankey/vitest.config.ts',
       'packages/visx-shape/vitest.config.ts',

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.28.0":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
+  languageName: node
+  linkType: hard
+
 "@babel/eslint-parser@npm:^7.25.9":
   version: 7.28.5
   resolution: "@babel/eslint-parser@npm:7.28.5"
@@ -531,6 +554,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
+  dependencies:
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/parser@npm:7.28.5"
@@ -542,7 +575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.29.3, @babel/parser@npm:^7.29.7":
+"@babel/parser@npm:^7.28.0, @babel/parser@npm:^7.29.3, @babel/parser@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/parser@npm:7.29.7"
   dependencies:
@@ -666,6 +699,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-jsx@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/plugin-syntax-jsx@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/1736000de183538ba8eef34520105508860e48b0c763254ba9158af5e814ed8bbceeedbb4281fbda33de787ae5b3870e92f60c6ae7131e7d322e451d57387896
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-typescript@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-syntax-typescript@npm:7.27.1"
@@ -674,6 +718,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/11589b4c89c66ef02d57bf56c6246267851ec0c361f58929327dc3e070b0dab644be625bbe7fb4c4df30c3634bfdfe31244e1f517be397d2def1487dbbe3c37d
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/plugin-syntax-typescript@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/c49883b0327e8683b770dc823205af5c697da216e590dcf5bf53f3f031e7e381de450b164f8f99853f0837a3de5cb793298e2be6697a0f6e452bb9dd34b5165e
   languageName: node
   linkType: hard
 
@@ -1304,6 +1359,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-typescript@npm:^7.28.0, @babel/plugin-transform-typescript@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-typescript@npm:7.29.7"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.29.7"
+    "@babel/helper-create-class-features-plugin": "npm:^7.29.7"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.29.7"
+    "@babel/plugin-syntax-typescript": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/8bf6a89c6827af6f11d4b189f1f97a64b8d754cc4caa5cbae16a6a8b113294d7f310dd40efd82e87ebcff2a1c683584b872d6d8960abe88d48f441d42f94c4d1
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-typescript@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/plugin-transform-typescript@npm:7.28.5"
@@ -1491,6 +1561,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-typescript@npm:^7.27.1":
+  version: 7.29.7
+  resolution: "@babel/preset-typescript@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    "@babel/plugin-syntax-jsx": "npm:^7.29.7"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.29.7"
+    "@babel/plugin-transform-typescript": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/40746a23a7ab46c0beb1c02d69883d9ffbe3043685cb3ae5363644391376b9261189fdad317191349e322c2c9bc550b031daa42470a1f8987362e4c56e492194
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.12.5":
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
@@ -1627,6 +1712,36 @@ __metadata:
   version: 3.0.4
   resolution: "@csstools/css-tokenizer@npm:3.0.4"
   checksum: 10c0/3b589f8e9942075a642213b389bab75a2d50d05d203727fcdac6827648a5572674caff07907eff3f9a2389d86a4ee47308fafe4f8588f4a77b7167c588d2559f
+  languageName: node
+  linkType: hard
+
+"@dotenvx/dotenvx@npm:^1.48.4":
+  version: 1.71.3
+  resolution: "@dotenvx/dotenvx@npm:1.71.3"
+  dependencies:
+    commander: "npm:^11.1.0"
+    dotenv: "npm:^17.2.1"
+    eciesjs: "npm:^0.4.10"
+    enquirer: "npm:^2.4.1"
+    execa: "npm:^5.1.1"
+    fdir: "npm:^6.2.0"
+    ignore: "npm:^5.3.0"
+    object-treeify: "npm:1.1.33"
+    picomatch: "npm:^4.0.4"
+    which: "npm:^4.0.0"
+    yocto-spinner: "npm:^1.1.0"
+  bin:
+    dotenvx: src/cli/dotenvx.js
+  checksum: 10c0/bd2f757af7548e0d4d2dbfeb710bc738de6caaac5efa95d39768aaa1b333b485316324f55c1ab4b7f953fce7150c9d2825a785be01fd376f1122ecee77f16c36
+  languageName: node
+  linkType: hard
+
+"@ecies/ciphers@npm:^0.2.5":
+  version: 0.2.6
+  resolution: "@ecies/ciphers@npm:0.2.6"
+  peerDependencies:
+    "@noble/ciphers": ^1.0.0
+  checksum: 10c0/31cbfbaedae690e12344e49eb1b7fd0697f36cf4d03100df52b925e1f19d02a6f445834938ecdd1cd74154496a74fa9147cdda6209255512220e45eb9c693ca0
   languageName: node
   linkType: hard
 
@@ -1942,6 +2057,15 @@ __metadata:
   version: 1.0.3
   resolution: "@gar/promise-retry@npm:1.0.3"
   checksum: 10c0/885b02c8b0d75b2d215da25f3b639158c4fbe8fefe0d79163304534b9a6d0710db4b7699f7cd3cc1a730792bff04cbe19f4850a62d3e105a663eaeec88f38332
+  languageName: node
+  linkType: hard
+
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.14
+  resolution: "@hono/node-server@npm:1.19.14"
+  peerDependencies:
+    hono: ^4
+  checksum: 10c0/41a099bb3705d96aac44b7a8db8805f2a22ce8a0f767a27b6d10b74a9964925df01c5f35d3631e882f8bcdeee3518884c30f40588ac8c960d88bf71048ba0df3
   languageName: node
   linkType: hard
 
@@ -2555,6 +2679,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@modelcontextprotocol/sdk@npm:^1.26.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:0.2.4":
   version: 0.2.4
   resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
@@ -2654,6 +2811,29 @@ __metadata:
   dependencies:
     eslint-scope: "npm:5.1.1"
   checksum: 10c0/75dda3e623b8ad7369ca22552d6beee337a814b2d0e8a32d23edd13fcb65c8082b32c5d86e436f3860dd7ade30d91d5db55d4ef9a08fb5a976c718ecc0d88a74
+  languageName: node
+  linkType: hard
+
+"@noble/ciphers@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@noble/ciphers@npm:1.3.0"
+  checksum: 10c0/3ba6da645ce45e2f35e3b2e5c87ceba86b21dfa62b9466ede9edfb397f8116dae284f06652c0cd81d99445a2262b606632e868103d54ecc99fd946ae1af8cd37
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:^1.9.7":
+  version: 1.9.7
+  resolution: "@noble/curves@npm:1.9.7"
+  dependencies:
+    "@noble/hashes": "npm:1.8.0"
+  checksum: 10c0/150014751ebe8ca06a8654ca2525108452ea9ee0be23430332769f06808cddabfe84f248b6dbf836916bc869c27c2092957eec62c7506d68a1ed0a624017c2a3
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
   languageName: node
   linkType: hard
 
@@ -3515,6 +3695,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
 "@sigstore/bundle@npm:^4.0.0":
   version: 4.0.0
   resolution: "@sigstore/bundle@npm:4.0.0"
@@ -3577,6 +3764,13 @@ __metadata:
   version: 0.34.41
   resolution: "@sinclair/typebox@npm:0.34.41"
   checksum: 10c0/0fb61fc2f90c25e30b19b0096eb8ab3ccef401d3e2acfce42168ff0ee877ba5981c8243fa6b1035ac756cde95316724e978b2837dd642d7e4e095de03a999c90
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/merge-streams@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
+  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
   languageName: node
   linkType: hard
 
@@ -3654,6 +3848,17 @@ __metadata:
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
   checksum: 10c0/ff57edaeab31322c80c3f01d55404b4cebb907b9ec7672b96a1a14d053f172046b01c5f27b45677927ebee8ed91bce695a7d09edec9a48875cfacabe39d0426a
+  languageName: node
+  linkType: hard
+
+"@ts-morph/common@npm:~0.27.0":
+  version: 0.27.0
+  resolution: "@ts-morph/common@npm:0.27.0"
+  dependencies:
+    fast-glob: "npm:^3.3.3"
+    minimatch: "npm:^10.0.1"
+    path-browserify: "npm:^1.0.1"
+  checksum: 10c0/3daa267bd78114ff504eb064c5215da6e46589e775b781ec0da4998d999b0d7130eff287e70d6e13e0a0a897ea16e9387f4cd885b4b9d6d628f318cecb81d473
   languageName: node
   linkType: hard
 
@@ -4085,6 +4290,13 @@ __metadata:
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
   checksum: 10c0/24dcdf25a168f453bb70298145eb043cfdbb82472db0bc0b56d6d51cd2e484b9ed8271d4ac93000a80da568f2402e9339723db262d0869e2bf13bc58e081768d
+  languageName: node
+  linkType: hard
+
+"@types/validate-npm-package-name@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@types/validate-npm-package-name@npm:4.0.2"
+  checksum: 10c0/5a109fe12570b7125740fdac8678970e3caf7de0cbd6e15cf93dad67a427a3a83e0759b5d4b64fd75bce6cdf43b0569275456a35183059046cba6c25d096b916
   languageName: node
   linkType: hard
 
@@ -4729,6 +4941,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@visx/registry@workspace:packages/visx-registry":
+  version: 0.0.0-use.local
+  resolution: "@visx/registry@workspace:packages/visx-registry"
+  dependencies:
+    "@types/node": "npm:^22.10.2"
+    "@types/react": "npm:^19.0.0"
+    "@visx/a11y": "workspace:*"
+    "@visx/axis": "workspace:*"
+    "@visx/chart": "workspace:*"
+    "@visx/grid": "workspace:*"
+    "@visx/heatmap": "workspace:*"
+    "@visx/hierarchy": "workspace:*"
+    "@visx/responsive": "workspace:*"
+    "@visx/scale": "workspace:*"
+    "@visx/shape": "workspace:*"
+    "@visx/theme": "workspace:*"
+    "@visx/threshold": "workspace:*"
+    react: "npm:^18.0.0 || ^19.0.0"
+    shadcn: "npm:4.11.0"
+    tsx: "npm:^4.19.0"
+    typescript: "npm:^5.7.0"
+    vitest: "npm:4.1.8"
+  languageName: unknown
+  linkType: soft
+
 "@visx/responsive@workspace:*, @visx/responsive@workspace:packages/visx-responsive":
   version: 0.0.0-use.local
   resolution: "@visx/responsive@workspace:packages/visx-responsive"
@@ -5306,6 +5543,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -5373,6 +5620,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10c0/168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -5394,6 +5655,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:^8.0.0, ajv@npm:^8.17.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "ansi-colors@npm:4.1.3, ansi-colors@npm:^4.1.1":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
@@ -5408,7 +5681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^6.0.1":
+"ansi-regex@npm:^6.0.1, ansi-regex@npm:^6.2.2":
   version: 6.2.2
   resolution: "ansi-regex@npm:6.2.2"
   checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
@@ -5641,6 +5914,15 @@ __metadata:
   version: 0.0.8
   resolution: "ast-types-flow@npm:0.0.8"
   checksum: 10c0/f2a0ba8055353b743c41431974521e5e852a9824870cd6fce2db0e538ac7bf4da406bbd018d109af29ff3f8f0993f6a730c9eddbd0abd031fbcb29ca75c1014e
+  languageName: node
+  linkType: hard
+
+"ast-types@npm:^0.16.1":
+  version: 0.16.1
+  resolution: "ast-types@npm:0.16.1"
+  dependencies:
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/abcc49e42eb921a7ebc013d5bec1154651fb6dbc3f497541d488859e681256901b2990b954d530ba0da4d0851271d484f7057d5eff5e07cb73e8b10909f711bf
   languageName: node
   linkType: hard
 
@@ -5890,6 +6172,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.1":
+  version: 2.3.0
+  resolution: "body-parser@npm:2.3.0"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^2.0.0"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.1"
+    iconv-lite: "npm:^0.7.2"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.15.2"
+    raw-body: "npm:^3.0.2"
+    type-is: "npm:^2.1.0"
+  checksum: 10c0/2a8fbbdc471b588338555a3e1a597d1eb0ad0c21cf20fdc3bac5d3f8d9c3a4b19b4163575ab852a43a5dfc0df7770ced5284f979e561f1a24c2f851ce89e695a
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:5.0.6, brace-expansion@npm:^5.0.5":
   version: 5.0.6
   resolution: "brace-expansion@npm:5.0.6"
@@ -5942,7 +6241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.28.1":
+"browserslist@npm:^4.26.2, browserslist@npm:^4.28.1":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
   dependencies:
@@ -5981,10 +6280,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-name@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "bundle-name@npm:4.1.0"
+  dependencies:
+    run-applescript: "npm:^7.0.0"
+  checksum: 10c0/8e575981e79c2bcf14d8b1c027a3775c095d362d1382312f444a7c861b0e21513c0bd8db5bd2b16e50ba0709fa622d4eab6b53192d222120305e68359daece29
+  languageName: node
+  linkType: hard
+
 "byte-size@npm:8.1.1":
   version: 8.1.1
   resolution: "byte-size@npm:8.1.1"
   checksum: 10c0/83170a16820fde48ebaef93bf6b2e86c5f72041f76e44eba1f3c738cceb699aeadf11088198944d5d7c6f970b465ab1e3dddc2e60bfb49a74374f3447a8db5b9
+  languageName: node
+  linkType: hard
+
+"bytes@npm:^3.1.2, bytes@npm:~3.1.2":
+  version: 3.1.2
+  resolution: "bytes@npm:3.1.2"
+  checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
   languageName: node
   linkType: hard
 
@@ -6125,6 +6440,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^5.3.0":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
+  languageName: node
+  linkType: hard
+
 "character-entities-html4@npm:^2.0.0":
   version: 2.1.0
   resolution: "character-entities-html4@npm:2.1.0"
@@ -6232,6 +6554,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-cursor@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cli-cursor@npm:5.0.0"
+  dependencies:
+    restore-cursor: "npm:^5.0.0"
+  checksum: 10c0/7ec62f69b79f6734ab209a3e4dbdc8af7422d44d360a7cb1efa8a0887bbe466a6e625650c466fe4359aee44dbe2dc0b6994b583d40a05d0808a5cb193641d220
+  languageName: node
+  linkType: hard
+
 "cli-spinners@npm:2.6.1":
   version: 2.6.1
   resolution: "cli-spinners@npm:2.6.1"
@@ -6239,7 +6570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0":
+"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.9.2":
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
@@ -6303,6 +6634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"code-block-writer@npm:^13.0.3":
+  version: 13.0.3
+  resolution: "code-block-writer@npm:13.0.3"
+  checksum: 10c0/87db97b37583f71cfd7eced8bf3f0a0a0ca53af912751a734372b36c08cd27f3e8a4878ec05591c0cd9ae11bea8add1423e132d660edd86aab952656dd41fd66
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:2.0.1, color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
@@ -6358,6 +6696,20 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
+  languageName: node
+  linkType: hard
+
+"commander@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "commander@npm:11.1.0"
+  checksum: 10c0/13cc6ac875e48780250f723fb81c1c1178d35c5decb1abb1b628b3177af08a8554e76b2c0f29de72d69eef7c864d12613272a71fabef8047922bc622ab75a179
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.0":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
   languageName: node
   linkType: hard
 
@@ -6429,6 +6781,27 @@ __metadata:
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 10c0/7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
+  languageName: node
+  linkType: hard
+
+"content-disposition@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "content-disposition@npm:1.1.0"
+  checksum: 10c0/94e0aef65873e69330f5f187fbc44ebce593bdcb8013dd8a68b7d0f159ca089bd30db3f8095d829f81c341695b60a6085ee6e15e6d775c4a325b586cc8d91974
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "content-type@npm:1.0.5"
+  checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "content-type@npm:2.0.0"
+  checksum: 10c0/491539fff707d7594b0ca4fabcc084bef2a31ffa754ff0a4f80c4377e3963cff0394317f9271c24087596c97fa675bc123d61fa34ffe65b4904e7d3d3098de72
   languageName: node
   linkType: hard
 
@@ -6532,6 +6905,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 10c0/54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
+  languageName: node
+  linkType: hard
+
 "core-js-compat@npm:^3.48.0":
   version: 3.49.0
   resolution: "core-js-compat@npm:3.49.0"
@@ -6545,6 +6932,16 @@ __metadata:
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.6
+  resolution: "cors@npm:2.8.6"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/ab2bc57b8af8ef8476682a59647f7c55c1a7d406b559ac06119aa1c5f70b96d35036864d197b24cf86e228e4547231088f1f94ca05061dbb14d89cc0bc9d4cab
   languageName: node
   linkType: hard
 
@@ -6565,7 +6962,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
+"cosmiconfig@npm:^9.0.0":
+  version: 9.0.2
+  resolution: "cosmiconfig@npm:9.0.2"
+  dependencies:
+    env-paths: "npm:^2.2.1"
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/132d32863c0b3d9ace7010a10011e09089532b36e3b11e02004d671dcbd8b8f2f16293b82d510d9c15890f30358baf8722127c7b1c011449c90b6a178f9c6594
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -6860,6 +7274,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-uri-to-buffer@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "data-uri-to-buffer@npm:4.0.1"
+  checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
+  languageName: node
+  linkType: hard
+
 "data-urls@npm:^6.0.0":
   version: 6.0.0
   resolution: "data-urls@npm:6.0.0"
@@ -6910,7 +7331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -6976,10 +7397,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dedent@npm:^1.6.0":
+  version: 1.7.2
+  resolution: "dedent@npm:1.7.2"
+  peerDependencies:
+    babel-plugin-macros: ^3.1.0
+  peerDependenciesMeta:
+    babel-plugin-macros:
+      optional: true
+  checksum: 10c0/acaff07cac355b93f17b1b17ebbb84d3cc55af6ab4b7814c3f505e061903e168bc6bf9ddce331552d64dee1525f0b4c549c9ade46aebfac6f69caaed74e90751
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
+  languageName: node
+  linkType: hard
+
+"deepmerge@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
+"default-browser-id@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "default-browser-id@npm:5.0.1"
+  checksum: 10c0/5288b3094c740ef3a86df9b999b04ff5ba4dee6b64e7b355c0fff5217752c8c86908d67f32f6cba9bb4f9b7b61a1b640c0a4f9e34c57e0ff3493559a625245ee
+  languageName: node
+  linkType: hard
+
+"default-browser@npm:^5.4.0":
+  version: 5.5.0
+  resolution: "default-browser@npm:5.5.0"
+  dependencies:
+    bundle-name: "npm:^4.1.0"
+    default-browser-id: "npm:^5.0.0"
+  checksum: 10c0/576593b617b17a7223014b4571bfe1c06a2581a4eb8b130985d90d253afa3f40999caec70eb0e5776e80d4af6a41cce91018cd3f86e57ad578bf59e46fb19abe
   languageName: node
   linkType: hard
 
@@ -7010,6 +7467,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-lazy-prop@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "define-lazy-prop@npm:3.0.0"
+  checksum: 10c0/5ab0b2bf3fa58b3a443140bbd4cd3db1f91b985cc8a246d330b9ac3fc0b6a325a6d82bddc0b055123d745b3f9931afeea74a5ec545439a1630b9c8512b0eeb49
+  languageName: node
+  linkType: hard
+
 "define-properties@npm:^1.1.3, define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
@@ -7034,6 +7498,13 @@ __metadata:
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
   checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
+  languageName: node
+  linkType: hard
+
+"depd@npm:^2.0.0, depd@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "depd@npm:2.0.0"
+  checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
   languageName: node
   linkType: hard
 
@@ -7064,6 +7535,13 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
+  languageName: node
+  linkType: hard
+
+"diff@npm:^8.0.2":
+  version: 8.0.4
+  resolution: "diff@npm:8.0.4"
+  checksum: 10c0/7ee5d03926db4039be7252ac3b0abaae1bd122a2ca971e5ca7270e444e36ff83dd906fad1a719740ca347e97ed5dc8f458a76a8391dbcd7aff363bdafb348a00
   languageName: node
   linkType: hard
 
@@ -7131,6 +7609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^17.2.1":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10c0/164f8e77a646c8446867d5b588d26ea6005c8ea7c5eb41cf926f6113d23f2191355f6e0cfd95ea9bab98394a5b0a3f1e51a8399711b666fe55cc7b0bd745f942
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:1.0.1, dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -7146,6 +7631,25 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
+"eciesjs@npm:^0.4.10":
+  version: 0.4.18
+  resolution: "eciesjs@npm:0.4.18"
+  dependencies:
+    "@ecies/ciphers": "npm:^0.2.5"
+    "@noble/ciphers": "npm:^1.3.0"
+    "@noble/curves": "npm:^1.9.7"
+    "@noble/hashes": "npm:^1.8.0"
+  checksum: 10c0/ecccb17b2fd33c143cf9b78014cca4cb00db1615ef8bd20fb6c835b62ef744ff772dd1545aff2cc215a2924bd9cadb2abd8c06a408e85c78b91efcb1712bc1eb
+  languageName: node
+  linkType: hard
+
+"ee-first@npm:1.1.1":
+  version: 1.1.1
+  resolution: "ee-first@npm:1.1.1"
+  checksum: 10c0/b5bb125ee93161bc16bfe6e56c6b04de5ad2aa44234d8f644813cc95d861a6910903132b05093706de2b706599367c4130eb6d170f6b46895686b95f87d017b7
   languageName: node
   linkType: hard
 
@@ -7179,6 +7683,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^10.3.0":
+  version: 10.6.0
+  resolution: "emoji-regex@npm:10.6.0"
+  checksum: 10c0/1e4aa097bb007301c3b4b1913879ae27327fdc48e93eeefefe3b87e495eb33c5af155300be951b4349ff6ac084f4403dc9eff970acba7c1c572d89396a9a32d7
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^9.2.2":
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
@@ -7190,6 +7701,13 @@ __metadata:
   version: 3.0.0
   resolution: "emojis-list@npm:3.0.0"
   checksum: 10c0/7dc4394b7b910444910ad64b812392159a21e1a7ecc637c775a440227dcb4f80eff7fe61f4453a7d7603fa23d23d30cc93fe9e4b5ed985b88d6441cd4a35117b
+  languageName: node
+  linkType: hard
+
+"encodeurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
   languageName: node
   linkType: hard
 
@@ -7217,6 +7735,16 @@ __metadata:
   dependencies:
     ansi-colors: "npm:^4.1.1"
   checksum: 10c0/8e070e052c2c64326a2803db9084d21c8aaa8c688327f133bf65c4a712586beb126fd98c8a01cfb0433e82a4bd3b6262705c55a63e0f7fb91d06b9cedbde9a11
+  languageName: node
+  linkType: hard
+
+"enquirer@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "enquirer@npm:2.4.1"
+  dependencies:
+    ansi-colors: "npm:^4.1.1"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/43850479d7a51d36a9c924b518dcdc6373b5a8ae3401097d336b7b7e258324749d0ad37a1fcaa5706f04799baa05585cd7af19ebdf7667673e7694435fcea918
   languageName: node
   linkType: hard
 
@@ -7541,6 +8069,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-html@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "escape-html@npm:1.0.3"
+  checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:1.0.5, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
@@ -7862,6 +8397,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esprima@npm:~4.0.0":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
+  languageName: node
+  linkType: hard
+
 "esquery@npm:^1.4.0, esquery@npm:^1.4.2":
   version: 1.6.0
   resolution: "esquery@npm:1.6.0"
@@ -7917,10 +8462,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"etag@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "etag@npm:1.8.1"
+  checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
+  languageName: node
+  linkType: hard
+
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "eventsource-parser@npm:3.1.0"
+  checksum: 10c0/5ab4c6c9a2a042be0b387b6d03810eb580bac4ce90e299ede56458125a97ffe3af8145b2740089fc898a96cfa5aae792ee79f2a06257fba2776b0e7bce037071
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10c0/c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
   languageName: node
   linkType: hard
 
@@ -7941,6 +8509,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "execa@npm:5.1.1"
+  dependencies:
+    cross-spawn: "npm:^7.0.3"
+    get-stream: "npm:^6.0.0"
+    human-signals: "npm:^2.1.0"
+    is-stream: "npm:^2.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^4.0.1"
+    onetime: "npm:^5.1.2"
+    signal-exit: "npm:^3.0.3"
+    strip-final-newline: "npm:^2.0.0"
+  checksum: 10c0/c8e615235e8de4c5addf2fa4c3da3e3aa59ce975a3e83533b4f6a71750fb816a2e79610dc5f1799b6e28976c9ae86747a36a606655bf8cb414a74d8d507b304f
+  languageName: node
+  linkType: hard
+
+"execa@npm:^9.6.0":
+  version: 9.6.1
+  resolution: "execa@npm:9.6.1"
+  dependencies:
+    "@sindresorhus/merge-streams": "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    figures: "npm:^6.1.0"
+    get-stream: "npm:^9.0.0"
+    human-signals: "npm:^8.0.1"
+    is-plain-obj: "npm:^4.1.0"
+    is-stream: "npm:^4.0.1"
+    npm-run-path: "npm:^6.0.0"
+    pretty-ms: "npm:^9.2.0"
+    signal-exit: "npm:^4.1.0"
+    strip-final-newline: "npm:^4.0.0"
+    yoctocolors: "npm:^2.1.1"
+  checksum: 10c0/636b36585306a3c8bc3a9d7b25d2d915fb06d8c9b9b02a804280d62562de3b34535affc1b7702b039320e0953daa6545a073f3c4b63fe974c1fe11336c56b467
+  languageName: node
+  linkType: hard
+
 "expect-type@npm:^1.3.0":
   version: 1.3.0
   resolution: "expect-type@npm:1.3.0"
@@ -7952,6 +8557,53 @@ __metadata:
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
+"express-rate-limit@npm:^8.2.1":
+  version: 8.5.2
+  resolution: "express-rate-limit@npm:8.5.2"
+  dependencies:
+    ip-address: "npm:^10.2.0"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/c98c49b93e94627940cf5e7c2578718b94d77163357161c3343d148e46257136c988933a96d6e1e728a010683133a58f68cad46928b063cf8d99521c8772578d
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "express@npm:5.2.1"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.1"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10c0/45e8c841ad188a41402ddcd1294901e861ee0819f632fb494f2ed344ef9c43315d294d443fb48d594e6586a3b779785120f43321417adaef8567316a55072949
   languageName: node
   linkType: hard
 
@@ -7990,7 +8642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -8017,6 +8669,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-uri@npm:^3.0.1":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.19.1
   resolution: "fastq@npm:1.19.1"
@@ -8026,7 +8685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.3, fdir@npm:^6.5.0":
+"fdir@npm:^6.2.0, fdir@npm:^6.4.3, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
   peerDependencies:
@@ -8035,6 +8694,16 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
+"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
+  version: 3.2.0
+  resolution: "fetch-blob@npm:3.2.0"
+  dependencies:
+    node-domexception: "npm:^1.0.0"
+    web-streams-polyfill: "npm:^3.0.3"
+  checksum: 10c0/60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
   languageName: node
   linkType: hard
 
@@ -8051,6 +8720,15 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
+  languageName: node
+  linkType: hard
+
+"figures@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "figures@npm:6.1.0"
+  dependencies:
+    is-unicode-supported: "npm:^2.0.0"
+  checksum: 10c0/9159df4264d62ef447a3931537de92f5012210cf5135c35c010df50a2169377581378149abfe1eb238bd6acbba1c0d547b1f18e0af6eee49e30363cedaffcfe4
   languageName: node
   linkType: hard
 
@@ -8076,6 +8754,20 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10c0/6bd664e21b7b2e79efcaace7d1a427169f61cce048fae68eb56290e6934e676b78e55d89f5998c5508871345bc59a61f47002dc505dc7288be68cceac1b701e2
   languageName: node
   linkType: hard
 
@@ -8206,6 +8898,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"formdata-polyfill@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "formdata-polyfill@npm:4.0.10"
+  dependencies:
+    fetch-blob: "npm:^3.1.2"
+  checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
+  languageName: node
+  linkType: hard
+
+"forwarded@npm:0.2.0":
+  version: 0.2.0
+  resolution: "forwarded@npm:0.2.0"
+  checksum: 10c0/9b67c3fac86acdbc9ae47ba1ddd5f2f81526fa4c8226863ede5600a3f7c7416ef451f6f1e240a3cc32d0fd79fcfe6beb08fd0da454f360032bde70bf80afbb33
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10c0/0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
+  languageName: node
+  linkType: hard
+
 "fs-constants@npm:1.0.0, fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -8221,6 +8936,17 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/f5d629e1bb646d5dedb4d8b24c5aad3deb8cc1d5438979d6f237146cd10e113b49a949ae1b54212c2fbc98e2d0995f38009a9a1d0520f0287943335e65fe919b
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.3.1":
+  version: 11.3.5
+  resolution: "fs-extra@npm:11.3.5"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
   languageName: node
   linkType: hard
 
@@ -8294,6 +9020,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuzzysort@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "fuzzysort@npm:3.1.0"
+  checksum: 10c0/da9bb32de16f2a5c2c000b99031d9f4f8a01380c12d5d3b67296443a1152c55987ce3c4ddbfe97481b0e9b6f2fb77d61dceba29a93ad36ee23ef5bab6a31afb8
+  languageName: node
+  linkType: hard
+
 "generator-function@npm:^2.0.0":
   version: 2.0.1
   resolution: "generator-function@npm:2.0.1"
@@ -8312,6 +9045,13 @@ __metadata:
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
+  languageName: node
+  linkType: hard
+
+"get-east-asian-width@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "get-east-asian-width@npm:1.6.0"
+  checksum: 10c0/7e72e9550fd49ca5b246f9af6bb2afc129c96412845ff6556b3274fd44817a381702ca17028efe9866b261a3d44254cbf21e6c90cf05b4b61675630af776d431
   languageName: node
   linkType: hard
 
@@ -8354,6 +9094,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-own-enumerable-keys@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "get-own-enumerable-keys@npm:1.0.0"
+  checksum: 10c0/3e14fbcf7cbb27a09f4335b3fe28ec4ac73254cd5007c141ff8e248c854fb1f4b44271fcc707c9aec1de7ae889eb28ffbd5b8a82f6abd9adb91df926fb7cec44
+  languageName: node
+  linkType: hard
+
 "get-pkg-repo@npm:^4.2.1":
   version: 4.2.1
   resolution: "get-pkg-repo@npm:4.2.1"
@@ -8389,6 +9136,16 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
   languageName: node
   linkType: hard
 
@@ -8797,6 +9554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hono@npm:^4.11.4":
+  version: 4.12.25
+  resolution: "hono@npm:4.12.25"
+  checksum: 10c0/9216d647fe2f39b17855b0e74913688b837e3fa9519d367c7beeec399265b36608a820928cc33ab926eee58fe2daf7e33296235b52e56dbfac0fbcd51a5e818e
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -8868,6 +9632,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
+  dependencies:
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -8895,6 +9672,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "human-signals@npm:8.0.1"
+  checksum: 10c0/195ac607108c56253757717242e17cd2e21b29f06c5d2dad362e86c672bf2d096e8a3bbb2601841c376c2301c4ae7cff129e87f740aa4ebff1390c163114c7c4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -8910,6 +9694,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/2382400469071c55b6746c531eed5fa4d033e5db6690b7331fb2a5f59a30d7a9782932e92253db26df33c1cf46fa200a3fbe524a2a7c62037c762283f188ec2f
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.2, iconv-lite@npm:~0.7.0":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
   languageName: node
   linkType: hard
 
@@ -8936,7 +9729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0, ignore@npm:^5.3.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -8989,7 +9782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -9077,10 +9870,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
+"ip-address@npm:^10.0.1, ip-address@npm:^10.2.0":
   version: 10.2.0
   resolution: "ip-address@npm:10.2.0"
   checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  languageName: node
+  linkType: hard
+
+"ipaddr.js@npm:1.9.1":
+  version: 1.9.1
+  resolution: "ipaddr.js@npm:1.9.1"
+  checksum: 10c0/0486e775047971d3fdb5fb4f063829bac45af299ae0b82dcf3afa2145338e08290563a2a70f34b732d795ecc8311902e541a8530eeb30d75860a78ff4e94ce2a
   languageName: node
   linkType: hard
 
@@ -9243,6 +10043,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-docker@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-docker@npm:3.0.0"
+  bin:
+    is-docker: cli.js
+  checksum: 10c0/d2c4f8e6d3e34df75a5defd44991b6068afad4835bb783b902fa12d13ebdb8f41b2a199dcb0b5ed2cb78bfee9e4c0bbdb69c2d9646f4106464674d3e697a5856
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -9295,10 +10104,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-in-ssh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-in-ssh@npm:1.0.0"
+  checksum: 10c0/fbb4c25d85c543df09997fbe7aeca410ae0c839c5825bba2d4c672df765e9ce0e7558e781b371c0a21d6ef9bbac39b31875617a68eaaea5504438d07db9a2ffa
+  languageName: node
+  linkType: hard
+
+"is-inside-container@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-inside-container@npm:1.0.0"
+  dependencies:
+    is-docker: "npm:^3.0.0"
+  bin:
+    is-inside-container: cli.js
+  checksum: 10c0/a8efb0e84f6197e6ff5c64c52890fa9acb49b7b74fed4da7c95383965da6f0fa592b4dbd5e38a79f87fc108196937acdbcd758fcefc9b140e479b39ce1fcd1cd
+  languageName: node
+  linkType: hard
+
 "is-interactive@npm:1.0.0, is-interactive@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-interactive@npm:1.0.0"
   checksum: 10c0/dd47904dbf286cd20aa58c5192161be1a67138485b9836d5a70433b21a45442e9611b8498b8ab1f839fc962c7620667a50535fdfb4a6bc7989b8858645c06b4d
+  languageName: node
+  linkType: hard
+
+"is-interactive@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-interactive@npm:2.0.0"
+  checksum: 10c0/801c8f6064f85199dc6bf99b5dd98db3282e930c3bc197b32f2c5b89313bb578a07d1b8a01365c4348c2927229234f3681eb861b9c2c92bee72ff397390fa600
   languageName: node
   linkType: hard
 
@@ -9340,6 +10174,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-obj@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-obj@npm:3.0.0"
+  checksum: 10c0/48d678fa15c56fd38353634ae2106a538827af9050211b18df13540dba0b38aa25c5cb498648a01311bf493a99ac3ce416576649b8cace10bcce7344611fa56a
+  languageName: node
+  linkType: hard
+
 "is-path-inside@npm:^3.0.3":
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
@@ -9354,7 +10195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^4.0.0":
+"is-plain-obj@npm:^4.0.0, is-plain-obj@npm:^4.1.0":
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
@@ -9375,6 +10216,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10c0/ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
@@ -9384,6 +10232,13 @@ __metadata:
     has-tostringtag: "npm:^1.0.2"
     hasown: "npm:^2.0.2"
   checksum: 10c0/1d3715d2b7889932349241680032e85d0b492cfcb045acb75ffc2c3085e8d561184f1f7e84b6f8321935b4aea39bc9c6ba74ed595b57ce4881a51dfdbc214e04
+  languageName: node
+  linkType: hard
+
+"is-regexp@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "is-regexp@npm:3.1.0"
+  checksum: 10c0/99dbaea41bddee2205db468c0946f5fee25cc4ae486333cb4d2b8095ab4b0a500e74ba61afd9e6e4f63ececcd55b4df5ae2a555b1c3e26308e516ff53c9533cd
   languageName: node
   linkType: hard
 
@@ -9416,6 +10271,13 @@ __metadata:
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
   languageName: node
   linkType: hard
 
@@ -9465,6 +10327,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-unicode-supported@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "is-unicode-supported@npm:1.3.0"
+  checksum: 10c0/b8674ea95d869f6faabddc6a484767207058b91aea0250803cbf1221345cb0c56f466d4ecea375dc77f6633d248d33c47bd296fb8f4cdba0b4edba8917e83d8a
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "is-unicode-supported@npm:2.1.0"
+  checksum: 10c0/a0f53e9a7c1fdbcf2d2ef6e40d4736fdffff1c9f8944c75e15425118ff3610172c87bf7bc6c34d3903b04be59790bb2212ddbe21ee65b5a97030fc50370545a5
+  languageName: node
+  linkType: hard
+
 "is-weakmap@npm:^2.0.2":
   version: 2.0.2
   resolution: "is-weakmap@npm:2.0.2"
@@ -9497,6 +10373,15 @@ __metadata:
   dependencies:
     is-docker: "npm:^2.0.0"
   checksum: 10c0/a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "is-wsl@npm:3.1.1"
+  dependencies:
+    is-inside-container: "npm:^1.0.0"
+  checksum: 10c0/7e5023522bfb8f27de4de960b0d82c4a8146c0bddb186529a3616d78b5bbbfc19ef0c5fc60d0b3a3cc0bf95a415fbdedc18454310ea3049587c879b07ace5107
   languageName: node
   linkType: hard
 
@@ -9625,6 +10510,13 @@ __metadata:
     chalk: "npm:^4.1.2"
     pretty-format: "npm:30.2.0"
   checksum: 10c0/5fac2cd89a10b282c5a68fc6206a95dfff9955ed0b758d24ffb0edcb20fb2f98e1fa5045c5c4205d952712ea864c6a086654f80cdd500cce054a2f5daf5b4419
+  languageName: node
+  linkType: hard
+
+"jose@npm:^6.1.3":
+  version: 6.2.3
+  resolution: "jose@npm:6.2.3"
+  checksum: 10c0/aa91bccba22cc84d86308f833749bcb0b00441e35c24e0ac79abeac5f76dc62d47bdef9c1da6a0c609f5da6478595f52b252085888b89dbdb163861e40ea4188
   languageName: node
   linkType: hard
 
@@ -9757,6 +10649,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
+  languageName: node
+  linkType: hard
+
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -9864,6 +10770,20 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
+  languageName: node
+  linkType: hard
+
+"kleur@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "kleur@npm:3.0.3"
+  checksum: 10c0/cd3a0b8878e7d6d3799e54340efe3591ca787d9f95f109f28129bdd2915e37807bf8918bb295ab86afb8c82196beec5a1adcaf29042ce3f2bd932b038fe3aa4b
+  languageName: node
+  linkType: hard
+
+"kleur@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "kleur@npm:4.1.5"
+  checksum: 10c0/e9de6cb49657b6fa70ba2d1448fd3d691a5c4370d8f7bbf1c2f64c24d461270f2117e1b0afe8cb3114f13bbd8e51de158c2a224953960331904e636a5e4c0f2a
   languageName: node
   linkType: hard
 
@@ -10240,6 +11160,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"log-symbols@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "log-symbols@npm:6.0.0"
+  dependencies:
+    chalk: "npm:^5.3.0"
+    is-unicode-supported: "npm:^1.3.0"
+  checksum: 10c0/36636cacedba8f067d2deb4aad44e91a89d9efb3ead27e1846e7b82c9a10ea2e3a7bd6ce28a7ca616bebc60954ff25c67b0f92d20a6a746bb3cc52c3701891f6
+  languageName: node
+  linkType: hard
+
 "longest-streak@npm:^3.0.0":
   version: 3.1.0
   resolution: "longest-streak@npm:3.1.0"
@@ -10541,6 +11471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10c0/7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "meow@npm:^8.1.2":
   version: 8.1.2
   resolution: "meow@npm:8.1.2"
@@ -10557,6 +11494,13 @@ __metadata:
     type-fest: "npm:^0.18.0"
     yargs-parser: "npm:^20.2.3"
   checksum: 10c0/9a8d90e616f783650728a90f4ea1e5f763c1c5260369e6596b52430f877f4af8ecbaa8c9d952c93bbefd6d5bda4caed6a96a20ba7d27b511d2971909b01922a2
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10c0/95389b7ced3f9b36fbdcf32eb946dc3dd1774c2fdf164609e55b18d03aa499b12bd3aae3a76c1c7185b96279e9803525550d3eb292b5224866060a288f335cb3
   languageName: node
   linkType: hard
 
@@ -10827,12 +11771,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:2.1.35, mime-types@npm:^2.1.12":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 
@@ -10843,6 +11803,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-function@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "mimic-function@npm:5.0.1"
+  checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
+  languageName: node
+  linkType: hard
+
 "min-indent@npm:^1.0.0":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
@@ -10850,7 +11817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.5, minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.2.2":
+"minimatch@npm:10.2.5, minimatch@npm:^10.0.1, minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.2.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -11134,6 +12101,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-domexception@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -11145,6 +12119,17 @@ __metadata:
     encoding:
       optional: true
   checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: "npm:^4.0.0"
+    fetch-blob: "npm:^3.1.4"
+    formdata-polyfill: "npm:^4.0.10"
+  checksum: 10c0/f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
   languageName: node
   linkType: hard
 
@@ -11388,6 +12373,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "npm-run-path@npm:6.0.0"
+  dependencies:
+    path-key: "npm:^4.0.0"
+    unicorn-magic: "npm:^0.3.0"
+  checksum: 10c0/b223c8a0dcd608abf95363ea5c3c0ccc3cd877daf0102eaf1b0f2390d6858d8337fbb7c443af2403b067a7d2c116d10691ecd22ab3c5273c44da1ff8d07753bd
+  languageName: node
+  linkType: hard
+
 "nprogress@npm:^0.2.0":
   version: 0.2.0
   resolution: "nprogress@npm:0.2.0"
@@ -11555,7 +12550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.1.1":
+"object-assign@npm:^4, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
@@ -11573,6 +12568,13 @@ __metadata:
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
   checksum: 10c0/b11f7ccdbc6d406d1f186cdadb9d54738e347b2692a14439ca5ac70c225fa6db46db809711b78589866d47b25fc3e8dee0b4c722ac751e11180f9380e3d8601d
+  languageName: node
+  linkType: hard
+
+"object-treeify@npm:1.1.33":
+  version: 1.1.33
+  resolution: "object-treeify@npm:1.1.33"
+  checksum: 10c0/5b735ac552200bf14f9892ce58295303e8d15a8cc7a0fd4fe6ff99923ab0c196fb70a870ab2a0eefc6820c4acb49e614b88c72d344b9c6bd22584a3efbd386fe
   languageName: node
   linkType: hard
 
@@ -11659,6 +12661,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-finished@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "on-finished@npm:2.4.1"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: 10c0/46fb11b9063782f2d9968863d9cbba33d77aa13c17f895f56129c274318b86500b22af3a160fe9995aa41317efcd22941b6eba747f718ced08d9a73afdb087b4
+  languageName: node
+  linkType: hard
+
 "once@npm:1.4.0, once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -11677,6 +12688,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onetime@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "onetime@npm:7.0.0"
+  dependencies:
+    mimic-function: "npm:^5.0.0"
+  checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
+  languageName: node
+  linkType: hard
+
 "open@npm:8.4.2":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
@@ -11685,6 +12705,20 @@ __metadata:
     is-docker: "npm:^2.1.1"
     is-wsl: "npm:^2.2.0"
   checksum: 10c0/bb6b3a58401dacdb0aad14360626faf3fb7fba4b77816b373495988b724fb48941cad80c1b65d62bb31a17609b2cd91c41a181602caea597ca80dfbcc27e84c9
+  languageName: node
+  linkType: hard
+
+"open@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "open@npm:11.0.0"
+  dependencies:
+    default-browser: "npm:^5.4.0"
+    define-lazy-prop: "npm:^3.0.0"
+    is-in-ssh: "npm:^1.0.0"
+    is-inside-container: "npm:^1.0.0"
+    powershell-utils: "npm:^0.1.0"
+    wsl-utils: "npm:^0.3.0"
+  checksum: 10c0/7aeeda4131268ed90f90e7728dda5c46bb0c6205b27a4be3e86ea33593e30dd393423e20e31c00802a8e635ef59becaee33ef9749a8ceb027567cd253e9e7b1e
   languageName: node
   linkType: hard
 
@@ -11715,6 +12749,23 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     wcwidth: "npm:^1.0.1"
   checksum: 10c0/30d5f3218eb75b0a2028c5fb9aa88e83e38a2f1745ab56839abb06c3ba31bae35f768f4e72c4f9e04e2a66be6a898e9312e8cf85c9333e1e3613eabb8c7cdf57
+  languageName: node
+  linkType: hard
+
+"ora@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "ora@npm:8.2.0"
+  dependencies:
+    chalk: "npm:^5.3.0"
+    cli-cursor: "npm:^5.0.0"
+    cli-spinners: "npm:^2.9.2"
+    is-interactive: "npm:^2.0.0"
+    is-unicode-supported: "npm:^2.0.0"
+    log-symbols: "npm:^6.0.0"
+    stdin-discarder: "npm:^0.2.2"
+    string-width: "npm:^7.2.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/7d9291255db22e293ea164f520b6042a3e906576ab06c9cf408bf9ef5664ba0a9f3bd258baa4ada058cfcc2163ef9b6696d51237a866682ce33295349ba02c3a
   languageName: node
   linkType: hard
 
@@ -12023,6 +13074,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-ms@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "parse-ms@npm:4.0.0"
+  checksum: 10c0/a7900f4f1ebac24cbf5e9708c16fb2fd482517fad353aecd7aefb8c2ba2f85ce017913ccb8925d231770404780df46244ea6fec598b3bde6490882358b4d2d16
+  languageName: node
+  linkType: hard
+
 "parse-path@npm:^7.0.0":
   version: 7.1.0
   resolution: "parse-path@npm:7.1.0"
@@ -12047,6 +13105,20 @@ __metadata:
   dependencies:
     entities: "npm:^6.0.0"
   checksum: 10c0/7fd2e4e247e85241d6f2a464d0085eed599a26d7b0a5233790c49f53473232eb85350e8133344d9b3fd58b89339e7ad7270fe1f89d28abe50674ec97b87f80b5
+  languageName: node
+  linkType: hard
+
+"parseurl@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "parseurl@npm:1.3.3"
+  checksum: 10c0/90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
+  languageName: node
+  linkType: hard
+
+"path-browserify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "path-browserify@npm:1.0.1"
+  checksum: 10c0/8b8c3fd5c66bd340272180590ae4ff139769e9ab79522e2eb82e3d571a89b8117c04147f65ad066dccfb42fcad902e5b7d794b3d35e0fd840491a8ddbedf8c66
   languageName: node
   linkType: hard
 
@@ -12075,6 +13147,13 @@ __metadata:
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-key@npm:4.0.0"
+  checksum: 10c0/794efeef32863a65ac312f3c0b0a99f921f3e827ff63afa5cb09a377e202c262b671f7b3832a4e64731003fa94af0263713962d317b9887bd1e0c48a342efba3
   languageName: node
   linkType: hard
 
@@ -12112,6 +13191,13 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^8.0.0":
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: 10c0/05b115c49b47ad252ce05faa32930f643f23769c68b8bcfe78ad833545140c48bbffb3266986d6c8d5db13a64cf12e07e0d72d9882cab830efeefa553533ebaf
   languageName: node
   linkType: hard
 
@@ -12173,6 +13259,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 10c0/207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
+  languageName: node
+  linkType: hard
+
 "pkg-dir@npm:^4.1.0, pkg-dir@npm:^4.2.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
@@ -12215,7 +13308,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.15, postcss@npm:^8.5.15":
+"postcss-selector-parser@npm:^7.1.0":
+  version: 7.1.4
+  resolution: "postcss-selector-parser@npm:7.1.4"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/3d533d25bab83592e7134be0435e6cb1e2865f5e7d9fde65f1e7e1c75ccc5905168c9f55b05d2a3e10d01914a178433d3a54eab003f5ef6aa9a9d6816926caa2
+  languageName: node
+  linkType: hard
+
+"postcss@npm:8.5.15, postcss@npm:^8.5.15, postcss@npm:^8.5.6":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -12223,6 +13326,13 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
+  languageName: node
+  linkType: hard
+
+"powershell-utils@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "powershell-utils@npm:0.1.0"
+  checksum: 10c0/a64713cf3583259c9ed6be211c06b4b19e8608bcb0f7f6287ffac0a95b8c7582b6b662eea0e201fd659492c8e9f9c5fd0bfc4579645c5add9c1a600075621c95
   languageName: node
   linkType: hard
 
@@ -12270,6 +13380,15 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^17.0.1"
   checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
+  languageName: node
+  linkType: hard
+
+"pretty-ms@npm:^9.2.0":
+  version: 9.3.0
+  resolution: "pretty-ms@npm:9.3.0"
+  dependencies:
+    parse-ms: "npm:^4.0.0"
+  checksum: 10c0/555ea39a1de48a30601938aedb76d682871d33b6dee015281c37108921514b11e1792928b1648c2e5589acc73c8ef0fb5e585fb4c718e340a28b86799e90fb34
   languageName: node
   linkType: hard
 
@@ -12359,6 +13478,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prompts@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "prompts@npm:2.4.2"
+  dependencies:
+    kleur: "npm:^3.0.3"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/16f1ac2977b19fe2cf53f8411cc98db7a3c8b115c479b2ca5c82b5527cd937aa405fa04f9a5960abeb9daef53191b53b4d13e35c1f5d50e8718c76917c5f1ea4
+  languageName: node
+  linkType: hard
+
 "promzard@npm:^2.0.0":
   version: 2.0.0
   resolution: "promzard@npm:2.0.0"
@@ -12400,6 +13529,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-addr@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "proxy-addr@npm:2.0.7"
+  dependencies:
+    forwarded: "npm:0.2.0"
+    ipaddr.js: "npm:1.9.1"
+  checksum: 10c0/c3eed999781a35f7fd935f398b6d8920b6fb00bbc14287bc6de78128ccc1a02c89b95b56742bf7cf0362cc333c61d138532049c7dedc7a328ef13343eff81210
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:2.1.0, proxy-from-env@npm:^2.1.0":
   version: 2.1.0
   resolution: "proxy-from-env@npm:2.1.0"
@@ -12414,6 +13553,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.0, qs@npm:^6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -12425,6 +13573,25 @@ __metadata:
   version: 4.0.1
   resolution: "quick-lru@npm:4.0.1"
   checksum: 10c0/f9b1596fa7595a35c2f9d913ac312fede13d37dc8a747a51557ab36e11ce113bbe88ef4c0154968845559a7709cb6a7e7cbe75f7972182451cd45e7f057a334d
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "range-parser@npm:1.2.1"
+  checksum: 10c0/96c032ac2475c8027b7a4e9fe22dc0dfe0f6d90b85e496e0f016fbdb99d6d066de0112e680805075bd989905e2123b3b3d002765149294dce0c1f7f01fcc2ea0
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
   languageName: node
   linkType: hard
 
@@ -12622,6 +13789,19 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"recast@npm:^0.23.11":
+  version: 0.23.11
+  resolution: "recast@npm:0.23.11"
+  dependencies:
+    ast-types: "npm:^0.16.1"
+    esprima: "npm:~4.0.0"
+    source-map: "npm:~0.6.1"
+    tiny-invariant: "npm:^1.3.3"
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/45b520a8f0868a5a24ecde495be9de3c48e69a54295d82a7331106554b75cfba75d16c909959d056e9ceed47a1be5e061e2db8b9ecbcd6ba44c2f3ef9a47bd18
   languageName: node
   linkType: hard
 
@@ -12937,6 +14117,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "restore-cursor@npm:5.1.0"
+  dependencies:
+    onetime: "npm:^7.0.0"
+    signal-exit: "npm:^4.1.0"
+  checksum: 10c0/c2ba89131eea791d1b25205bdfdc86699767e2b88dee2a590b1a6caa51737deac8bad0260a5ded2f7c074b7db2f3a626bcf1fcf3cdf35974cbeea5e2e6764f60
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -13027,10 +14217,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10c0/3279de7450c8eae2f6e095e9edacbdeec0abb5cb7249c6e719faa0db2dba43574b4fff5892d9220631c9abaff52dd3cad648cfea2aaace845e1a071915ac8867
+  languageName: node
+  linkType: hard
+
 "rrweb-cssom@npm:^0.8.0":
   version: 0.8.0
   resolution: "rrweb-cssom@npm:0.8.0"
   checksum: 10c0/56f2bfd56733adb92c0b56e274c43f864b8dd48784d6fe946ef5ff8d438234015e59ad837fc2ad54714b6421384141c1add4eb569e72054e350d1f8a50b8ac7b
+  languageName: node
+  linkType: hard
+
+"run-applescript@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "run-applescript@npm:7.1.0"
+  checksum: 10c0/ab826c57c20f244b2ee807704b1ef4ba7f566aa766481ae5922aac785e2570809e297c69afcccc3593095b538a8a77d26f2b2e9a1d9dffee24e0e039502d1a03
   languageName: node
   linkType: hard
 
@@ -13215,6 +14425,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: 10c0/fbbbbdc902a913d65605274be23f3d604065cfc3ee3d78bf9fc8af1dc9fc82667c50d3d657f5e601ac657bac9b396b50ee97bd29cd55436320cf1cddebdcec72
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10c0/37986096e8572e2dfaad35a3925fa8da0c0969f8814fd7788e84d4d388bc068cf0c06d1658509788e55bed942a6b6d040a8a267fa92bb9ffb1179f8bacde5fd7
+  languageName: node
+  linkType: hard
+
 "set-function-length@npm:^1.2.2":
   version: 1.2.2
   resolution: "set-function-length@npm:1.2.2"
@@ -13249,6 +14490,56 @@ __metadata:
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/ca5c3ccbba479d07c30460e367e66337cec825560b11e8ba9c5ebe13a2a0d6021ae34eddf94ff3dfe17a3104dc1f191519cb6c48378b503e5c3f36393938776a
+  languageName: node
+  linkType: hard
+
+"setprototypeof@npm:~1.2.0":
+  version: 1.2.0
+  resolution: "setprototypeof@npm:1.2.0"
+  checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
+  languageName: node
+  linkType: hard
+
+"shadcn@npm:4.11.0":
+  version: 4.11.0
+  resolution: "shadcn@npm:4.11.0"
+  dependencies:
+    "@babel/core": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/plugin-transform-typescript": "npm:^7.28.0"
+    "@babel/preset-typescript": "npm:^7.27.1"
+    "@dotenvx/dotenvx": "npm:^1.48.4"
+    "@modelcontextprotocol/sdk": "npm:^1.26.0"
+    "@types/validate-npm-package-name": "npm:^4.0.2"
+    browserslist: "npm:^4.26.2"
+    commander: "npm:^14.0.0"
+    cosmiconfig: "npm:^9.0.0"
+    dedent: "npm:^1.6.0"
+    deepmerge: "npm:^4.3.1"
+    diff: "npm:^8.0.2"
+    execa: "npm:^9.6.0"
+    fast-glob: "npm:^3.3.3"
+    fs-extra: "npm:^11.3.1"
+    fuzzysort: "npm:^3.1.0"
+    https-proxy-agent: "npm:^7.0.6"
+    kleur: "npm:^4.1.5"
+    node-fetch: "npm:^3.3.2"
+    open: "npm:^11.0.0"
+    ora: "npm:^8.2.0"
+    postcss: "npm:^8.5.6"
+    postcss-selector-parser: "npm:^7.1.0"
+    prompts: "npm:^2.4.2"
+    recast: "npm:^0.23.11"
+    stringify-object: "npm:^5.0.0"
+    tailwind-merge: "npm:^3.0.1"
+    ts-morph: "npm:^26.0.0"
+    tsconfig-paths: "npm:^4.2.0"
+    validate-npm-package-name: "npm:^7.0.1"
+    zod: "npm:^3.24.1"
+    zod-to-json-schema: "npm:^3.24.6"
+  bin:
+    shadcn: dist/index.js
+  checksum: 10c0/146a23118a9e1848f90e61d62e36978e0ee9f51dec7063242f7073a8aefd6200791405a860d6311fae714ee6440ba06b14a5c50bcdcd4c269306f6e03338d51f
   languageName: node
   linkType: hard
 
@@ -13446,6 +14737,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sisteransi@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "sisteransi@npm:1.0.5"
+  checksum: 10c0/230ac975cca485b7f6fe2b96a711aa62a6a26ead3e6fb8ba17c5a00d61b8bed0d7adc21f5626b70d7c33c62ff4e63933017a6462942c719d1980bb0b1207ad46
+  languageName: node
+  linkType: hard
+
 "slash@npm:3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -13502,7 +14800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.1":
+"source-map@npm:^0.6.1, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
@@ -13593,10 +14891,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
 "std-env@npm:^4.0.0-rc.1":
   version: 4.1.0
   resolution: "std-env@npm:4.1.0"
   checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
+  languageName: node
+  linkType: hard
+
+"stdin-discarder@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "stdin-discarder@npm:0.2.2"
+  checksum: 10c0/c78375e82e956d7a64be6e63c809c7f058f5303efcaf62ea48350af072bacdb99c06cba39209b45a071c1acbd49116af30df1df9abb448df78a6005b72f10537
   languageName: node
   linkType: hard
 
@@ -13629,6 +14941,17 @@ __metadata:
     emoji-regex: "npm:^9.2.2"
     strip-ansi: "npm:^7.0.1"
   checksum: 10c0/ab9c4264443d35b8b923cbdd513a089a60de339216d3b0ed3be3ba57d6880e1a192b70ae17225f764d7adbf5994e9bb8df253a944736c15a0240eff553c678ca
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "string-width@npm:7.2.0"
+  dependencies:
+    emoji-regex: "npm:^10.3.0"
+    get-east-asian-width: "npm:^1.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
   languageName: node
   linkType: hard
 
@@ -13765,6 +15088,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stringify-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "stringify-object@npm:5.0.0"
+  dependencies:
+    get-own-enumerable-keys: "npm:^1.0.0"
+    is-obj: "npm:^3.0.0"
+    is-regexp: "npm:^3.1.0"
+  checksum: 10c0/f955bb0b41edb0a200bf5ba24d516a2d409c749a01224e14a088ecf07fec3d930ec90da3a681f6798b9d6a1b187cb3bb57f0d17525190006ef3bd609d0300bb9
+  languageName: node
+  linkType: hard
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -13780,6 +15114,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
   languageName: node
   linkType: hard
 
@@ -13801,6 +15144,13 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 10c0/bddf8ccd47acd85c0e09ad7375409d81653f645fda13227a9d459642277c253d877b68f2e5e4d819fe75733b0e626bac7e954c04f3236f6d196f79c94fa4a96f
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-final-newline@npm:4.0.0"
+  checksum: 10c0/b0cf2b62d597a1b0e3ebc42b88767f0a0d45601f89fd379a928a1812c8779440c81abba708082c946445af1d6b62d5f16e2a7cf4f30d9d6587b89425fae801ff
   languageName: node
   linkType: hard
 
@@ -13892,6 +15242,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tailwind-merge@npm:^3.0.1":
+  version: 3.6.0
+  resolution: "tailwind-merge@npm:3.6.0"
+  checksum: 10c0/a728d929f4786bcb48641db4228cc8c006a7545491783a658fb4d24d177dab960620991d17805a047309228de50ab949ca8d9e112c30183da0432367796ae186
+  languageName: node
+  linkType: hard
+
 "tar-stream@npm:2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
@@ -13966,6 +15323,13 @@ __metadata:
   version: 1.3.6
   resolution: "timezone-mock@npm:1.3.6"
   checksum: 10c0/7e554f9378531258330ada94bc4101bb4ece6e501f9e210652fb57751cf2e5d4aeab3dd9fd840a6534316db757ac6bb39338730c5d3f72dcbd4cb315ea482101
+  languageName: node
+  linkType: hard
+
+"tiny-invariant@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "tiny-invariant@npm:1.3.3"
+  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
   languageName: node
   linkType: hard
 
@@ -14051,6 +15415,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"toidentifier@npm:~1.0.1":
+  version: 1.0.1
+  resolution: "toidentifier@npm:1.0.1"
+  checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
   languageName: node
   linkType: hard
 
@@ -14145,7 +15516,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:4.2.0":
+"ts-morph@npm:^26.0.0":
+  version: 26.0.0
+  resolution: "ts-morph@npm:26.0.0"
+  dependencies:
+    "@ts-morph/common": "npm:~0.27.0"
+    code-block-writer: "npm:^13.0.3"
+  checksum: 10c0/c6880d90a1eefe0ce6555bf8c11cc104b1f36f84bd36a37a82b9ae0b974f51fe6b1bc91bb0ec42550158dc1c812329d6433e1237cba64f1ef515c129b321dd5d
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:4.2.0, tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
   dependencies:
@@ -14168,7 +15549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.8.1, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0":
+"tslib@npm:2.8.1, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -14236,6 +15617,17 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
+  languageName: node
+  linkType: hard
+
+"type-is@npm:^2.0.1, type-is@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "type-is@npm:2.1.0"
+  dependencies:
+    content-type: "npm:^2.0.0"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/a6018f8f509de48f2c7429305e3a920e73b374fa93127dd0877ae1c2df65a5d33907caac8afb0c37a9b9fc7c49f29e3f55d668963dc845d966930b667c07f50e
   languageName: node
   linkType: hard
 
@@ -14392,6 +15784,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unicorn-magic@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "unicorn-magic@npm:0.3.0"
+  checksum: 10c0/0a32a997d6c15f1c2a077a15b1c4ca6f268d574cf5b8975e778bb98e6f8db4ef4e86dfcae4e158cd4c7e38fb4dd383b93b13eefddc7f178dea13d3ac8a603271
+  languageName: node
+  linkType: hard
+
 "unified@npm:^11.0.0":
   version: 11.0.5
   resolution: "unified@npm:11.0.5"
@@ -14487,6 +15886,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unpipe@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "unpipe@npm:1.0.0"
+  checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
+  languageName: node
+  linkType: hard
+
 "upath@npm:2.0.1":
   version: 2.0.1
   resolution: "upath@npm:2.0.1"
@@ -14552,6 +15958,20 @@ __metadata:
   version: 6.0.2
   resolution: "validate-npm-package-name@npm:6.0.2"
   checksum: 10c0/c4c23a8b9fa8deee11eea421d94fbe39f742146c06571b62247212579298186b724ebc5152240a415753bdaf9b8849a487e675ec2968d44660f8a65de6cdef9e
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^7.0.1":
+  version: 7.0.2
+  resolution: "validate-npm-package-name@npm:7.0.2"
+  checksum: 10c0/adf32e943148e13e8df13d06b855493908e6ae7a847610e8543c6291cbf42f40e653249a5b2275e2e615e3224c574ade5a9064a9e2d1ab629386284ea99e8f39
+  languageName: node
+  linkType: hard
+
+"vary@npm:^1, vary@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "vary@npm:1.1.2"
+  checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
   languageName: node
   linkType: hard
 
@@ -14742,6 +16162,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
@@ -14861,6 +16288,17 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 10c0/66522872a768b60c2a65a57e8ad184e5372f5b6a9ca6d5f033d4b0dc98aff63995655a7503b9c0a2598936f532120e81dd8cc155e2e92ed662a2b9377cc4374f
+  languageName: node
+  linkType: hard
+
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
+  dependencies:
+    isexe: "npm:^3.1.1"
+  bin:
+    node-which: bin/which.js
+  checksum: 10c0/449fa5c44ed120ccecfe18c433296a4978a7583bf2391c50abce13f76878d2476defde04d0f79db8165bdf432853c1f8389d0485ca6e8ebce3bbcded513d5e6a
   languageName: node
   linkType: hard
 
@@ -14996,6 +16434,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wsl-utils@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "wsl-utils@npm:0.3.1"
+  dependencies:
+    is-wsl: "npm:^3.1.0"
+    powershell-utils: "npm:^0.1.0"
+  checksum: 10c0/b3ba99cc6b71f66457eef598d529beeb8cb57a72646877fe25993894b808c60b82f6d47df5463f0b6e54632272f62f5eaea105c12784fd09b06f500f3f53aa2e
+  languageName: node
+  linkType: hard
+
 "xml-name-validator@npm:^5.0.0":
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
@@ -15105,10 +16553,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yocto-spinner@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "yocto-spinner@npm:1.2.0"
+  dependencies:
+    yoctocolors: "npm:^2.1.1"
+  checksum: 10c0/8d5ee832f022c741a9e2f59fc4c50403517eda405e774b27fbfc64d871a172d4762bc6b50614af0ceff289ebb176ae0e979ead072af9b10b3c176fdb1d1c042e
+  languageName: node
+  linkType: hard
+
 "yoctocolors-cjs@npm:^2.1.3":
   version: 2.1.3
   resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
+  languageName: node
+  linkType: hard
+
+"yoctocolors@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "yoctocolors@npm:2.1.2"
+  checksum: 10c0/b220f30f53ebc2167330c3adc86a3c7f158bcba0236f6c67e25644c3188e2571a6014ffc1321943bb619460259d3d27eb4c9cc58c2d884c1b195805883ec7066
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.24.6, zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.24.1":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To be released in `4.1.0`

### Why the visx chart registry?

The post-4.0 registry work needs a source-first way to give users complete, editable chart starters without turning visx into a chart framework. Teams still own the render tree, data shape, scales, marks, tooltips, layout, and design-system integration, but they should not have to rebuild the same accessibility, theming, responsive sizing, axis, grid, legend, and install metadata from scratch for every primitive chart.

This PR adds a shadcn-compatible GitHub registry for visx charts. Registry items install into apps as plain React source files that compose public visx packages, use shadcn/ui-style CSS variables, include live `@visx/a11y` wiring, and remain fully editable after install.

The goal is to make the first chart in a dashboard fast and polished while preserving the core visx model: low-level primitives, explicit rendering, and no registry runtime or opaque chart framework between users and the installed source.

#### :boom: Breaking Changes

- None.

#### :rocket: Enhancements

- Add private `@visx/registry` source infrastructure with a root GitHub registry entrypoint and package-level source registry.
- Add 16 shadcn-compatible chart starters: `line-chart`, `bar-chart`, `area-chart`, `scatter-chart`, `stacked-bar-chart`, `multi-series-line-chart`, `pie-chart`, `histogram-chart`, `grouped-bar-chart`, `horizontal-stacked-bar-chart`, `stacked-area-chart`, `threshold-chart`, `heatmap-chart`, `radar-chart`, `radial-bar-chart`, and `treemap-chart`.
- Add registry chart support for responsive sizing through `@visx/responsive`, theme tokens through `@visx/theme`, generated SVG semantics/data tables/live announcements through `@visx/a11y`, and install metadata for public visx dependencies.
- Add reusable copied chart UI helpers for legends and bounded tooltips used by the registry chart starters.
- Add `@visx/chart` helpers for numeric domains, responsive width fallback, axis tick thinning/counting, and chart config labels/colors/icons/CSS variables.
- Add generated `id` and `ids` metadata to `useChartA11y` so copied chart source can render stable SVG id relationships explicitly.
- Add axis label offsets to `useAxisStyle` for consistent tick-label and axis-label spacing across registry charts.

#### :memo: Documentation

- Add the `@visx/registry` README with registry-first design notes, item structure, GitHub install guidance, local validation commands, and accessibility/theming expectations.
- Add a newest-first `MIGRATION.md` entry for the shadcn-compatible visx chart registry.
- Update `@visx/chart` README docs for domain helpers, tick helpers, responsive width fallback, and chart config helpers.
- Update `@visx/a11y` README examples to show generated SVG ids.

#### :bug: Bug Fix

- None.

#### :house: Internal

- Add registry validation and install-smoke scripts for root/package registry metadata.
- Add registry render, SSR, empty-state, single-datum, dependency metadata, and install-target tests across all registry items.
- Add `@visx/chart` unit coverage for config helpers, domain helpers, tick helpers, and SSR-safe helper exports.
- Wire `@visx/registry` into workspace dependencies, root Vitest coverage, ESLint parsing, docs generation ignores, and the lockfile.

#### Validation

- `git ls-files --modified --others --exclude-standard | rg -v '^yarn.lock$' | xargs ./node_modules/.bin/prettier --check`
- `git diff --check`
- `../../node_modules/.bin/shadcn registry validate registry.json --cwd ../..` from `packages/visx-registry`
- `../../node_modules/.bin/shadcn registry validate` from `packages/visx-registry`
- `npm exec -- vitest run --project @visx/chart --project @visx/theme --project @visx/registry`
- `./node_modules/.bin/tsc --build packages/visx-chart/tsconfig.json packages/visx-theme/tsconfig.json packages/visx-a11y/tsconfig.json packages/visx-registry/tsconfig.json --force`
- `npm exec -- eslint packages/visx-chart packages/visx-theme packages/visx-a11y packages/visx-registry --quiet`
- `npm exec -- tsx packages/visx-registry/scripts/smokeInstallRegistryItem.ts`
- `npm exec -- tsx --tsconfig ./tsconfig.node.json ./scripts/updateTsReferences.ts`

