### PR TITLE
feat(tooltip): add Floating UI tooltip primitives

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -108,6 +108,29 @@ non-React code.
 **What you need to do:** nothing unless you want to author hook-based primitive charts. Continue
 using existing components as before, or opt into the new hooks from the import paths above.
 
+### `@visx/tooltip/floating` adds modern tooltip primitives
+
+visx 4.1 adds an optional Floating UI-backed tooltip surface under the `@visx/tooltip/floating`
+subpath. It includes low-level `FloatingTooltip` primitives, `useFloatingTooltip`, config-driven
+chart tooltip content, and the `useChartTooltip` plus `ChartTooltip` convenience layer for
+data-driven chart tooltips.
+
+```tsx
+import {
+  ChartTooltip,
+  FloatingTooltip,
+  useChartTooltip,
+  useFloatingTooltip,
+} from '@visx/tooltip/floating';
+```
+
+The new APIs are additive. Existing `@visx/tooltip` root exports, `useTooltip`,
+`useTooltipInPortal`, `Tooltip`, `TooltipWithBounds`, and `withTooltip` remain unchanged.
+
+**What you need to do:** nothing unless you want Floating UI positioning, virtual anchors,
+trigger-based interactions, or config-driven chart tooltip content. Continue using the existing
+tooltip APIs as before, or opt into the new `@visx/tooltip/floating` subpath for new tooltip work.
+
 ### The visx chart registry adds shadcn-compatible chart starters
 
 visx 4.1 introduces a source-first chart registry for installing themed, responsive, accessible

--- a/packages/visx-tooltip/Handbook.md
+++ b/packages/visx-tooltip/Handbook.md
@@ -605,7 +605,9 @@ Use `Root arrow` to include arrow middleware, and render `FloatingTooltip.Arrow`
 </FloatingTooltip.Root>
 ```
 
-When no custom `render` prop is supplied, `Arrow` uses Floating UI's `FloatingArrow`.
+When no custom `render` prop is supplied, `Arrow` uses Floating UI's `FloatingArrow` and forwards
+its SVG props such as `stroke` and `strokeWidth`. Use `Root arrow={{ padding }}` for Floating UI
+arrow middleware padding near the floating element edges.
 
 ## `useFloatingTooltip`
 

--- a/packages/visx-tooltip/Handbook.md
+++ b/packages/visx-tooltip/Handbook.md
@@ -14,23 +14,31 @@ import {
 } from '@visx/tooltip/floating';
 ```
 
-The package exports `./floating` in `packages/visx-tooltip/package.json`. The floating entrypoint starts with `'use client'`, so these APIs are React client APIs.
+The package exports `./floating` in `packages/visx-tooltip/package.json`. The floating entrypoint
+starts with `'use client'`, so these APIs are React client APIs.
 
-The existing root `@visx/tooltip` API is separate. Do not import these new floating APIs from the root package unless a future change explicitly exports them there.
+The existing root `@visx/tooltip` API is separate. Do not import these new floating APIs from the
+root package unless a future change explicitly exports them there.
 
 ## Which Layer To Use
 
-Use `useChartTooltip` plus `ChartTooltip` for most chart tooltips. This is the most convenient layer: the hook owns open state, current anchor, current items, hide delay, and the props needed by `ChartTooltip`.
+Use `useChartTooltip` plus `ChartTooltip` for most chart tooltips. This is the most convenient
+layer: the hook owns open state, current anchor, current items, hide delay, and the props needed by
+`ChartTooltip`.
 
-Use `ChartTooltipContent` when you only want the config-driven content renderer and you already have positioning handled elsewhere.
+Use `ChartTooltipContent` when you only want the config-driven content renderer and you already have
+positioning handled elsewhere.
 
-Use `FloatingTooltip` primitives when you want full positioning composition: root, trigger, portal, positioner, content, and arrow.
+Use `FloatingTooltip` primitives when you want full positioning composition: root, trigger, portal,
+positioner, content, and arrow.
 
-Use `useFloatingTooltip` directly when you want the low-level hook state, Floating UI refs, `getReferenceProps`, and `getFloatingProps`.
+Use `useFloatingTooltip` directly when you want the low-level hook state, Floating UI refs,
+`getReferenceProps`, and `getFloatingProps`.
 
 ## Simplest Discrete Datum Pattern
 
-For bars, points, glyphs, or any mark with a DOM/SVG element, anchor to the element. This avoids coordinate math.
+For bars, points, glyphs, or any mark with a DOM/SVG element, anchor to the element. This avoids
+coordinate math.
 
 ```tsx
 import {
@@ -102,7 +110,8 @@ What is happening:
 
 - `tooltip.show()` opens the tooltip and sets both anchor and items.
 - `anchor: { type: 'element', element }` is a public `TooltipAnchor`.
-- `tooltip.tooltipProps` contains the controlled props that `ChartTooltip` needs: `open`, `anchor`, `items`, plus `floatingOptions`, `offset`, and `placement`.
+- `tooltip.tooltipProps` contains the controlled props that `ChartTooltip` needs: `open`, `anchor`,
+  `items`, plus `floatingOptions`, `offset`, and `placement`.
 - `ChartTooltip` renders in a portal by default.
 
 ## `useChartTooltip`
@@ -154,8 +163,10 @@ Important behavior:
 - `show()` clears any pending hide delay, resolves the anchor, stores the new items, and opens.
 - `hide()` closes immediately unless `hideDelay` is set.
 - `hideDelay` schedules a delayed close; calling `show()` again cancels that pending close.
-- `update()` can replace `items` and/or a full `TooltipAnchor`; it does not accept the `{ x, y }` or shorthand SVG point forms.
-- `floatingOptions` intentionally cannot control `open`, `data`, or `anchor`; those are owned by the chart convenience hook.
+- `update()` can replace `items` and/or a full `TooltipAnchor`; it does not accept the `{ x, y }` or
+  shorthand SVG point forms.
+- `floatingOptions` intentionally cannot control `open`, `data`, or `anchor`; those are owned by the
+  chart convenience hook.
 
 ## Anchor Patterns
 
@@ -176,7 +187,8 @@ If `element` is `null`, the anchor resolves to `null`.
 
 ### Local Container Point
 
-With `useChartTooltip.show()`, a bare `{ x, y }` is shorthand for a CSS-pixel point local to the latest `containerRef` element, or to the explicit `container` option.
+With `useChartTooltip.show()`, a bare `{ x, y }` is shorthand for a CSS-pixel point local to the
+latest `containerRef` element, or to the explicit `container` option.
 
 ```tsx
 <svg
@@ -219,7 +231,8 @@ tooltip.show({
 });
 ```
 
-The `useChartTooltip` shorthand uses `type: 'svg-local-point'` and fills in the SVG element from `containerRef` when the latest container is an SVG element. The full `TooltipAnchor` form is:
+The `useChartTooltip` shorthand uses `type: 'svg-local-point'` and fills in the SVG element from
+`containerRef` when the latest container is an SVG element. The full `TooltipAnchor` form is:
 
 ```ts
 {
@@ -232,7 +245,8 @@ The `useChartTooltip` shorthand uses `type: 'svg-local-point'` and fills in the 
 
 Source behavior:
 
-- If `createSVGPoint()` and `getScreenCTM()` are available, the point is transformed through the screen CTM.
+- If `createSVGPoint()` and `getScreenCTM()` are available, the point is transformed through the
+  screen CTM.
 - Otherwise, it falls back to the SVG element bounding rect plus `x` and `y`.
 - If `svg` is `null`, the anchor resolves to `null`.
 
@@ -245,7 +259,8 @@ const clientPoint = { type: 'point', x: event.clientX, y: event.clientY };
 const pagePoint = { type: 'point', x: event.pageX, y: event.pageY, coordinateSpace: 'page' };
 ```
 
-`coordinateSpace` can be `'client'` or `'page'`. Page coordinates are converted to client coordinates by subtracting window scroll.
+`coordinateSpace` can be `'client'` or `'page'`. Page coordinates are converted to client
+coordinates by subtracting window scroll.
 
 ### Rect Anchor
 
@@ -315,16 +330,20 @@ type ChartTooltipConfig<Datum = unknown> = Record<
 
 Content precedence in the current implementation:
 
-- Label: `config[key].formatLabel(item)` first, then `config[key].label`, then `item.label`, then `item.key`.
-- Value: `config[key].formatValue(value, item)` first, then `item.value`, then `String(item.rawValue)`, then `''`.
-- The value passed to `formatValue` is `item.rawValue` when it is not `undefined`; otherwise it is `item.value`.
+- Label: `config[key].formatLabel(item)` first, then `config[key].label`, then `item.label`, then
+  `item.key`.
+- Value: `config[key].formatValue(value, item)` first, then `item.value`, then
+  `String(item.rawValue)`, then `''`.
+- The value passed to `formatValue` is `item.rawValue` when it is not `undefined`; otherwise it is
+  `item.value`.
 - Color: `config[key].color` first, then `item.color`.
 - Visibility: `item.hidden` and `config[key].hide` both remove an item.
 - Order: config `order` first, then `sortItems`, then original input order.
 
 ## `ChartTooltip`
 
-`ChartTooltip` composes `FloatingTooltip.Root`, `FloatingTooltip.Positioner`, `FloatingTooltip.Content`, and `FloatingTooltip.Portal`.
+`ChartTooltip` composes `FloatingTooltip.Root`, `FloatingTooltip.Positioner`,
+`FloatingTooltip.Content`, and `FloatingTooltip.Portal`.
 
 Required controlled props:
 
@@ -351,20 +370,17 @@ Optional props:
 - `floatingOptions`
 - `renderContent`
 
-`floatingOptions` cannot include `open`, `defaultOpen`, `data`, `defaultData`, `anchor`, or `defaultAnchor`. Pass those as explicit `ChartTooltip` props.
+`floatingOptions` cannot include `open`, `defaultOpen`, `data`, `defaultData`, `anchor`, or
+`defaultAnchor`. Pass those as explicit `ChartTooltip` props.
 
-Explicit `ChartTooltip` props win over overlapping fields inside `floatingOptions`. This is implemented by spreading `floatingOptions` first and then passing explicit `open`, `anchor`, `data`, `placement`, `strategy`, `offset`, and `collisionPadding` to `FloatingTooltip.Root`.
+Explicit `ChartTooltip` props win over overlapping fields inside `floatingOptions`. This is
+implemented by spreading `floatingOptions` first and then passing explicit `open`, `anchor`, `data`,
+`placement`, `strategy`, `offset`, and `collisionPadding` to `FloatingTooltip.Root`.
 
 Disable the portal when you need inline rendering:
 
 ```tsx
-<ChartTooltip
-  open={open}
-  anchor={anchor}
-  items={items}
-  config={config}
-  portal={false}
-/>
+<ChartTooltip open={open} anchor={anchor} items={items} config={config} portal={false} />
 ```
 
 Render custom content while keeping `ChartTooltip` positioning:
@@ -374,9 +390,7 @@ Render custom content while keeping `ChartTooltip` positioning:
   open={open}
   anchor={anchor}
   items={items}
-  renderContent={({ items, state }) => (
-    <div data-side={state.side}>Rows: {items.length}</div>
-  )}
+  renderContent={({ items, state }) => <div data-side={state.side}>Rows: {items.length}</div>}
 />
 ```
 
@@ -469,7 +483,8 @@ Props:
 - `skipDelay`; default `400`
 - `children`
 
-When `delay` is a number, it maps to `{ open: delay, close: closeDelay }`. When `delay` is an object, `open` defaults to `600` and `close` defaults to `closeDelay`.
+When `delay` is a number, it maps to `{ open: delay, close: closeDelay }`. When `delay` is an
+object, `open` defaults to `600` and `close` defaults to `closeDelay`.
 
 ### Root
 
@@ -478,11 +493,13 @@ When `delay` is a number, it maps to `{ open: delay, close: closeDelay }`. When 
 - `forceMount?: boolean`
 - `children: React.ReactNode | ((state) => React.ReactNode)`
 
-Closed content is unmounted by default. With `forceMount`, `state.mounted` stays true while `state.open` can still be false.
+Closed content is unmounted by default. With `forceMount`, `state.mounted` stays true while
+`state.open` can still be false.
 
 ### Trigger
 
-`Trigger` is optional. It wires Floating UI reference props for hover, focus, dismiss, and tooltip role behavior when interactions are enabled by `Root`.
+`Trigger` is optional. It wires Floating UI reference props for hover, focus, dismiss, and tooltip
+role behavior when interactions are enabled by `Root`.
 
 ```tsx
 <FloatingTooltip.Provider delay={700} skipDelay={300}>
@@ -511,9 +528,12 @@ Closed content is unmounted by default. With `forceMount`, `state.mounted` stays
 />
 ```
 
-If `Root` has no explicit `anchor`, the trigger becomes the positioning reference. If `Root` has an explicit `anchor`, the trigger still owns interactions while the explicit anchor owns positioning.
+If `Root` has no explicit `anchor`, the trigger becomes the positioning reference. If `Root` has an
+explicit `anchor`, the trigger still owns interactions while the explicit anchor owns positioning.
 
-`Trigger disabled` sets `aria-disabled`, adds `data-disabled`, and does not wire hover or focus interaction handlers for that trigger. To disable the whole tooltip state machine, use `Root disabled`.
+`Trigger disabled` sets `aria-disabled`, adds `data-disabled`, and does not wire hover or focus
+interaction handlers for that trigger. To disable the whole tooltip state machine, use
+`Root disabled`.
 
 ### Portal
 
@@ -565,7 +585,8 @@ It sets:
 - `data-visx-tooltip-content`
 - `data-state`
 
-`Content` does not assign a default `role`. Floating UI role props are applied through `Positioner`. An explicit `Content role` prop is forwarded.
+`Content` does not assign a default `role`. Floating UI role props are applied through `Positioner`.
+An explicit `Content role` prop is forwarded.
 
 `render` can replace the default element.
 
@@ -662,7 +683,8 @@ Controlled/uncontrolled behavior:
 
 - `open`, `anchor`, and `data` each become controlled when their corresponding prop is provided.
 - `defaultOpen`, `defaultAnchor`, and `defaultData` seed uncontrolled state.
-- `openTooltip(nextData, nextAnchor)` updates uncontrolled data and anchor when provided, then opens.
+- `openTooltip(nextData, nextAnchor)` updates uncontrolled data and anchor when provided, then
+  opens.
 - `closeTooltip()` closes.
 - `setAnchor()` and `setData()` only update uncontrolled state.
 - `id` is used as the default floating element id returned by `getFloatingProps()`.
@@ -722,9 +744,7 @@ When enabled, `useFloatingTooltip` wires:
 Disable all interactions:
 
 ```tsx
-<FloatingTooltip.Root interactions={false}>
-  ...
-</FloatingTooltip.Root>
+<FloatingTooltip.Root interactions={false}>...</FloatingTooltip.Root>
 ```
 
 Disable or configure one interaction:
@@ -742,9 +762,13 @@ Disable or configure one interaction:
 </FloatingTooltip.Root>
 ```
 
-`FloatingTooltip.Trigger` is the usual way to consume these interaction props. In tests, trigger hover opens, focus opens, Escape dismisses, default tooltip role wiring adds `aria-describedby`, and `role="label"` adds `aria-labelledby` instead.
+`FloatingTooltip.Trigger` is the usual way to consume these interaction props. In tests, trigger
+hover opens, focus opens, Escape dismisses, default tooltip role wiring adds `aria-describedby`, and
+`role="label"` adds `aria-labelledby` instead.
 
-When `FloatingTooltip.Root` receives an `id`, that id becomes the default `FloatingTooltip.Positioner` id and the trigger's ARIA target. An explicit `FloatingTooltip.Positioner id` wins over the root id.
+When `FloatingTooltip.Root` receives an `id`, that id becomes the default
+`FloatingTooltip.Positioner` id and the trigger's ARIA target. An explicit
+`FloatingTooltip.Positioner id` wins over the root id.
 
 ## Middleware
 
@@ -795,11 +819,13 @@ Replace all built-in middleware:
 </FloatingTooltip.Root>
 ```
 
-`collisionBoundary` and `collisionPadding` are forwarded into `flip`, `shift`, `size`, and `hide` when those middleware are enabled.
+`collisionBoundary` and `collisionPadding` are forwarded into `flip`, `shift`, `size`, and `hide`
+when those middleware are enabled.
 
 ## Styling Contract
 
-The floating APIs are intentionally minimally styled. Consumers should style via normal classes and data attributes.
+The floating APIs are intentionally minimally styled. Consumers should style via normal classes and
+data attributes.
 
 Useful primitive attributes:
 
@@ -827,7 +853,11 @@ Useful chart content attributes:
 
 These are source-validated caveats, not design guidance.
 
-- `FloatingTooltip.Content` does not assign a default role. `Positioner` receives Floating UI role props when role interactions are enabled.
-- `FloatingTooltip.Trigger disabled` is trigger-scoped; use `Root disabled` to disable the whole tooltip state machine.
-- `ChartTooltip` is controlled; it requires `open`, `anchor`, and `items`. `useChartTooltip` is the convenience state owner if you do not want to wire those yourself.
-- `useChartTooltip.update()` accepts a full `TooltipAnchor`, not the local-point or shorthand SVG-point forms accepted by `show()`.
+- `FloatingTooltip.Content` does not assign a default role. `Positioner` receives Floating UI role
+  props when role interactions are enabled.
+- `FloatingTooltip.Trigger disabled` is trigger-scoped; use `Root disabled` to disable the whole
+  tooltip state machine.
+- `ChartTooltip` is controlled; it requires `open`, `anchor`, and `items`. `useChartTooltip` is the
+  convenience state owner if you do not want to wire those yourself.
+- `useChartTooltip.update()` accepts a full `TooltipAnchor`, not the local-point or shorthand
+  SVG-point forms accepted by `show()`.

--- a/packages/visx-tooltip/Handbook.md
+++ b/packages/visx-tooltip/Handbook.md
@@ -1,0 +1,833 @@
+# @visx/tooltip/floating API Patterns Handbook
+
+## Import Surface
+
+Use the additive floating subpath:
+
+```tsx
+import {
+  ChartTooltip,
+  ChartTooltipContent,
+  FloatingTooltip,
+  useChartTooltip,
+  useFloatingTooltip,
+} from '@visx/tooltip/floating';
+```
+
+The package exports `./floating` in `packages/visx-tooltip/package.json`. The floating entrypoint starts with `'use client'`, so these APIs are React client APIs.
+
+The existing root `@visx/tooltip` API is separate. Do not import these new floating APIs from the root package unless a future change explicitly exports them there.
+
+## Which Layer To Use
+
+Use `useChartTooltip` plus `ChartTooltip` for most chart tooltips. This is the most convenient layer: the hook owns open state, current anchor, current items, hide delay, and the props needed by `ChartTooltip`.
+
+Use `ChartTooltipContent` when you only want the config-driven content renderer and you already have positioning handled elsewhere.
+
+Use `FloatingTooltip` primitives when you want full positioning composition: root, trigger, portal, positioner, content, and arrow.
+
+Use `useFloatingTooltip` directly when you want the low-level hook state, Floating UI refs, `getReferenceProps`, and `getFloatingProps`.
+
+## Simplest Discrete Datum Pattern
+
+For bars, points, glyphs, or any mark with a DOM/SVG element, anchor to the element. This avoids coordinate math.
+
+```tsx
+import {
+  ChartTooltip,
+  useChartTooltip,
+  type ChartTooltipConfig,
+  type ChartTooltipItem,
+} from '@visx/tooltip/floating';
+
+type Datum = {
+  color: string;
+  month: string;
+  revenue: number;
+};
+
+const config = {
+  revenue: {
+    label: 'Revenue',
+    color: (item) => item.datum?.color,
+    formatValue: (value) => `$${Number(value)}k`,
+  },
+} satisfies ChartTooltipConfig<Datum>;
+
+function RevenueBars({ datum }: { datum: Datum }) {
+  const tooltip = useChartTooltip<Datum>({ placement: 'top', offset: 12 });
+
+  const items: ChartTooltipItem<Datum>[] = [
+    {
+      key: 'revenue',
+      label: 'Revenue',
+      rawValue: datum.revenue,
+      datum,
+      color: datum.color,
+    },
+  ];
+
+  return (
+    <>
+      <svg ref={tooltip.containerRef} onPointerLeave={tooltip.hide}>
+        <rect
+          tabIndex={0}
+          onBlur={tooltip.hide}
+          onFocus={(event) =>
+            tooltip.show({
+              anchor: { type: 'element', element: event.currentTarget },
+              items,
+            })
+          }
+          onPointerEnter={(event) =>
+            tooltip.show({
+              anchor: { type: 'element', element: event.currentTarget },
+              items,
+            })
+          }
+        />
+      </svg>
+
+      <ChartTooltip
+        {...tooltip.tooltipProps}
+        label={tooltip.items[0]?.datum?.month}
+        config={config}
+      />
+    </>
+  );
+}
+```
+
+What is happening:
+
+- `tooltip.show()` opens the tooltip and sets both anchor and items.
+- `anchor: { type: 'element', element }` is a public `TooltipAnchor`.
+- `tooltip.tooltipProps` contains the controlled props that `ChartTooltip` needs: `open`, `anchor`, `items`, plus `floatingOptions`, `offset`, and `placement`.
+- `ChartTooltip` renders in a portal by default.
+
+## `useChartTooltip`
+
+`useChartTooltip<Datum>()` is the chart convenience hook.
+
+Options:
+
+```ts
+type UseChartTooltipOptions<Datum> = {
+  defaultOpen?: boolean;
+  defaultItems?: ChartTooltipItem<Datum>[];
+  defaultAnchor?: TooltipAnchor | null;
+  placement?: TooltipPlacement;
+  offset?: number | FloatingTooltipOffset;
+  hideDelay?: number;
+  container?: Element | null;
+  floatingOptions?: Omit<
+    UseFloatingTooltipOptions<ChartTooltipItem<Datum>[]>,
+    'open' | 'defaultOpen' | 'data' | 'defaultData' | 'anchor' | 'defaultAnchor'
+  >;
+};
+```
+
+Return shape:
+
+```ts
+type UseChartTooltipReturn<Datum> = {
+  open: boolean;
+  items: ChartTooltipItem<Datum>[];
+  anchor: TooltipAnchor | null;
+  containerRef: React.RefCallback<HTMLElement | SVGElement>;
+  show: (args: {
+    anchor:
+      | TooltipAnchor
+      | { x: number; y: number }
+      | { type: 'svg-local-point'; x: number; y: number };
+    items: ChartTooltipItem<Datum>[];
+  }) => void;
+  hide: () => void;
+  update: (args: Partial<{ anchor: TooltipAnchor; items: ChartTooltipItem<Datum>[] }>) => void;
+  tooltipProps: ChartTooltipControlledProps<Datum> &
+    Pick<ChartTooltipProps<Datum>, 'floatingOptions' | 'offset' | 'placement'>;
+};
+```
+
+Important behavior:
+
+- `show()` clears any pending hide delay, resolves the anchor, stores the new items, and opens.
+- `hide()` closes immediately unless `hideDelay` is set.
+- `hideDelay` schedules a delayed close; calling `show()` again cancels that pending close.
+- `update()` can replace `items` and/or a full `TooltipAnchor`; it does not accept the `{ x, y }` or shorthand SVG point forms.
+- `floatingOptions` intentionally cannot control `open`, `data`, or `anchor`; those are owned by the chart convenience hook.
+
+## Anchor Patterns
+
+`TooltipAnchor` supports six explicit anchor variants.
+
+### Element Anchor
+
+Use this for bars, dots, buttons, legends, or any element you can place against directly.
+
+```tsx
+tooltip.show({
+  anchor: { type: 'element', element: event.currentTarget },
+  items,
+});
+```
+
+If `element` is `null`, the anchor resolves to `null`.
+
+### Local Container Point
+
+With `useChartTooltip.show()`, a bare `{ x, y }` is shorthand for a CSS-pixel point local to the latest `containerRef` element, or to the explicit `container` option.
+
+```tsx
+<svg
+  ref={tooltip.containerRef}
+  onPointerMove={(event) => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+
+    tooltip.show({
+      anchor: {
+        x: event.clientX - bounds.left,
+        y: event.clientY - bounds.top,
+      },
+      items,
+    });
+  }}
+/>
+```
+
+The resolved anchor is:
+
+```ts
+{
+  type: 'container-point',
+  x,
+  y,
+  container,
+}
+```
+
+If the container is missing, that anchor cannot resolve to a Floating UI reference.
+
+### SVG User-Space Point
+
+Use this when your anchor coordinates are SVG user-space coordinates from scales or glyph positions.
+
+```tsx
+tooltip.show({
+  anchor: { type: 'svg-local-point', x: 40, y: 20 },
+  items,
+});
+```
+
+The `useChartTooltip` shorthand uses `type: 'svg-local-point'` and fills in the SVG element from `containerRef` when the latest container is an SVG element. The full `TooltipAnchor` form is:
+
+```ts
+{
+  type: 'svg-point',
+  x: 40,
+  y: 20,
+  svg,
+}
+```
+
+Source behavior:
+
+- If `createSVGPoint()` and `getScreenCTM()` are available, the point is transformed through the screen CTM.
+- Otherwise, it falls back to the SVG element bounding rect plus `x` and `y`.
+- If `svg` is `null`, the anchor resolves to `null`.
+
+### Client Or Page Point
+
+Use this for viewport or page coordinates.
+
+```ts
+const clientPoint = { type: 'point', x: event.clientX, y: event.clientY };
+const pagePoint = { type: 'point', x: event.pageX, y: event.pageY, coordinateSpace: 'page' };
+```
+
+`coordinateSpace` can be `'client'` or `'page'`. Page coordinates are converted to client coordinates by subtracting window scroll.
+
+### Rect Anchor
+
+Use this when you want to provide a lazily read rectangle.
+
+```ts
+const anchor = {
+  type: 'rect',
+  getRect: () => new DOMRect(120, 80, 0, 0),
+  contextElement: document.body,
+} satisfies TooltipAnchor;
+```
+
+### Virtual Anchor
+
+Use this when you already have a Floating UI-compatible virtual element.
+
+```ts
+const anchor = {
+  type: 'virtual',
+  element: {
+    getBoundingClientRect: () => new DOMRect(120, 80, 0, 0),
+    contextElement: document.body,
+  },
+} satisfies TooltipAnchor;
+```
+
+## `ChartTooltipItem` And `ChartTooltipConfig`
+
+Each chart tooltip row is a `ChartTooltipItem`.
+
+```ts
+type ChartTooltipItem<Datum = unknown> = {
+  key: string;
+  datum?: Datum;
+  index?: number;
+  label?: React.ReactNode;
+  value?: React.ReactNode;
+  rawValue?: unknown;
+  color?: string;
+  x?: number;
+  y?: number;
+  distance?: number;
+  hidden?: boolean;
+  payload?: unknown;
+};
+```
+
+`key` is required. The default rendered row uses the item key for config lookup and data attributes.
+
+`ChartTooltipConfig` is a record keyed by item key:
+
+```ts
+type ChartTooltipConfig<Datum = unknown> = Record<
+  string,
+  {
+    label?: React.ReactNode | ((item: ChartTooltipItem<Datum>) => React.ReactNode);
+    color?: string | ((item: ChartTooltipItem<Datum>) => string | undefined);
+    icon?: React.ComponentType<{ item: ChartTooltipItem<Datum> }>;
+    formatValue?: (value: unknown, item: ChartTooltipItem<Datum>) => React.ReactNode;
+    formatLabel?: (item: ChartTooltipItem<Datum>) => React.ReactNode;
+    hide?: boolean;
+    order?: number;
+  }
+>;
+```
+
+Content precedence in the current implementation:
+
+- Label: `config[key].formatLabel(item)` first, then `config[key].label`, then `item.label`, then `item.key`.
+- Value: `config[key].formatValue(value, item)` first, then `item.value`, then `String(item.rawValue)`, then `''`.
+- The value passed to `formatValue` is `item.rawValue` when it is not `undefined`; otherwise it is `item.value`.
+- Color: `config[key].color` first, then `item.color`.
+- Visibility: `item.hidden` and `config[key].hide` both remove an item.
+- Order: config `order` first, then `sortItems`, then original input order.
+
+## `ChartTooltip`
+
+`ChartTooltip` composes `FloatingTooltip.Root`, `FloatingTooltip.Positioner`, `FloatingTooltip.Content`, and `FloatingTooltip.Portal`.
+
+Required controlled props:
+
+```ts
+type ChartTooltipControlledProps<Datum> = {
+  open: boolean;
+  anchor: TooltipAnchor | null;
+  items: ChartTooltipItem<Datum>[];
+};
+```
+
+Optional props:
+
+- `config`
+- `label`
+- `placement` default: `'top'`
+- `strategy`
+- `offset` default: `8`
+- `collisionPadding`
+- `portal` default: `true`
+- `portalProps`
+- `positionerProps`
+- `contentProps`
+- `floatingOptions`
+- `renderContent`
+
+`floatingOptions` cannot include `open`, `defaultOpen`, `data`, `defaultData`, `anchor`, or `defaultAnchor`. Pass those as explicit `ChartTooltip` props.
+
+Explicit `ChartTooltip` props win over overlapping fields inside `floatingOptions`. This is implemented by spreading `floatingOptions` first and then passing explicit `open`, `anchor`, `data`, `placement`, `strategy`, `offset`, and `collisionPadding` to `FloatingTooltip.Root`.
+
+Disable the portal when you need inline rendering:
+
+```tsx
+<ChartTooltip
+  open={open}
+  anchor={anchor}
+  items={items}
+  config={config}
+  portal={false}
+/>
+```
+
+Render custom content while keeping `ChartTooltip` positioning:
+
+```tsx
+<ChartTooltip
+  open={open}
+  anchor={anchor}
+  items={items}
+  renderContent={({ items, state }) => (
+    <div data-side={state.side}>Rows: {items.length}</div>
+  )}
+/>
+```
+
+## `ChartTooltipContent`
+
+Use this when you want the default config-driven rows without the positioning layer.
+
+```tsx
+<ChartTooltipContent
+  label="Apr"
+  items={items}
+  config={config}
+  indicator="square"
+  renderValue={({ value }) => <strong>{value}</strong>}
+/>
+```
+
+Props:
+
+- `label`
+- `items`
+- `config`
+- `indicator`: `'dot' | 'line' | 'dashed' | 'square' | 'none'`; default is `'dot'`
+- `hideLabel`
+- `hideIndicator`
+- `sortItems`
+- `renderLabel`
+- `renderItem`
+- `renderValue`
+- `getItemKey`
+- `data-testid`; default is `'chart-tooltip-content'`
+- standard `div` attributes
+
+Default data attributes:
+
+- `data-visx-chart-tooltip`
+- `data-visx-chart-tooltip-label`
+- `data-visx-chart-tooltip-items`
+- `data-visx-chart-tooltip-item`
+- `data-visx-chart-tooltip-indicator`
+- `data-visx-chart-tooltip-item-label`
+- `data-visx-chart-tooltip-item-value`
+- `data-item-key`
+
+The default row sets the CSS custom property `--visx-tooltip-item-color` when a color is available.
+
+If no visible items remain, `ChartTooltipContent` returns `null`.
+
+## Low-Level `FloatingTooltip` Primitives
+
+Use the primitive layer when you want full manual composition.
+
+```tsx
+<FloatingTooltip.Root
+  open={open}
+  anchor={{ type: 'point', x: event.clientX, y: event.clientY }}
+  placement="right"
+  offset={12}
+  arrow
+>
+  <FloatingTooltip.Portal>
+    <FloatingTooltip.Positioner className="Tooltip">
+      <FloatingTooltip.Content>
+        <FloatingTooltip.Arrow />
+        {children}
+      </FloatingTooltip.Content>
+    </FloatingTooltip.Positioner>
+  </FloatingTooltip.Portal>
+</FloatingTooltip.Root>
+```
+
+Primitive parts:
+
+- `FloatingTooltip.Provider`
+- `FloatingTooltip.Root`
+- `FloatingTooltip.Trigger`
+- `FloatingTooltip.Portal`
+- `FloatingTooltip.Positioner`
+- `FloatingTooltip.Content`
+- `FloatingTooltip.Arrow`
+
+### Provider
+
+`Provider` wraps Floating UI's delay group.
+
+Props:
+
+- `delay`; default `600`
+- `closeDelay`; default `0`
+- `skipDelay`; default `400`
+- `children`
+
+When `delay` is a number, it maps to `{ open: delay, close: closeDelay }`. When `delay` is an object, `open` defaults to `600` and `close` defaults to `closeDelay`.
+
+### Root
+
+`Root` accepts `UseFloatingTooltipOptions<TData>` plus:
+
+- `forceMount?: boolean`
+- `children: React.ReactNode | ((state) => React.ReactNode)`
+
+Closed content is unmounted by default. With `forceMount`, `state.mounted` stays true while `state.open` can still be false.
+
+### Trigger
+
+`Trigger` is optional. It wires Floating UI reference props for hover, focus, dismiss, and tooltip role behavior when interactions are enabled by `Root`.
+
+```tsx
+<FloatingTooltip.Provider delay={700} skipDelay={300}>
+  <FloatingTooltip.Root>
+    <FloatingTooltip.Trigger render={<button type="button">Export</button>} />
+    <FloatingTooltip.Portal>
+      <FloatingTooltip.Positioner>
+        <FloatingTooltip.Content>Download chart data</FloatingTooltip.Content>
+      </FloatingTooltip.Positioner>
+    </FloatingTooltip.Portal>
+  </FloatingTooltip.Root>
+</FloatingTooltip.Provider>
+```
+
+`Trigger` render forms:
+
+```tsx
+<FloatingTooltip.Trigger render={<button type="button">Export</button>} />
+
+<FloatingTooltip.Trigger
+  render={(props, state) => (
+    <button {...props} type="button" data-open={state.open}>
+      Export
+    </button>
+  )}
+/>
+```
+
+If `Root` has no explicit `anchor`, the trigger becomes the positioning reference. If `Root` has an explicit `anchor`, the trigger still owns interactions while the explicit anchor owns positioning.
+
+`Trigger disabled` sets `aria-disabled`, adds `data-disabled`, and does not wire hover or focus interaction handlers for that trigger. To disable the whole tooltip state machine, use `Root disabled`.
+
+### Portal
+
+`Portal` renders through Floating UI's portal by default.
+
+Props:
+
+- `container?: HTMLElement | ShadowRoot | React.RefObject<HTMLElement | ShadowRoot | null> | null`
+- `disabled?: boolean`
+- `children`
+
+Use `disabled` for inline rendering.
+
+### Positioner
+
+`Positioner` owns Floating UI positioning props and styles.
+
+It renders nothing when `state.mounted` is false.
+
+It sets:
+
+- `data-visx-tooltip`
+- `data-state`
+- `data-side`
+- `data-align`
+- `data-anchor-hidden` when hide middleware reports `referenceHidden`
+- `--visx-tooltip-transform-origin`
+- `--visx-tooltip-arrow-x`
+- `--visx-tooltip-arrow-y`
+
+`render` can replace the default `div`:
+
+```tsx
+<FloatingTooltip.Positioner
+  render={(props, state) => (
+    <section {...props} data-side-from-state={state.side}>
+      {props.children}
+    </section>
+  )}
+>
+  <FloatingTooltip.Content>Tooltip</FloatingTooltip.Content>
+</FloatingTooltip.Positioner>
+```
+
+### Content
+
+`Content` renders a `div` by default and sets:
+
+- `data-visx-tooltip-content`
+- `data-state`
+
+`Content` does not assign a default `role`. Floating UI role props are applied through `Positioner`. An explicit `Content role` prop is forwarded.
+
+`render` can replace the default element.
+
+### Arrow
+
+Use `Root arrow` to include arrow middleware, and render `FloatingTooltip.Arrow` inside content.
+
+```tsx
+<FloatingTooltip.Root open anchor={anchor} arrow>
+  <FloatingTooltip.Positioner>
+    <FloatingTooltip.Content>
+      Tooltip
+      <FloatingTooltip.Arrow width={14} height={20} />
+    </FloatingTooltip.Content>
+  </FloatingTooltip.Positioner>
+</FloatingTooltip.Root>
+```
+
+When no custom `render` prop is supplied, `Arrow` uses Floating UI's `FloatingArrow`.
+
+## `useFloatingTooltip`
+
+`useFloatingTooltip<TData>()` is the low-level hook behind the primitives.
+
+Options:
+
+```ts
+type UseFloatingTooltipOptions<TData = unknown> = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean, details: FloatingTooltipOpenChangeDetails<TData>) => void;
+
+  anchor?: TooltipAnchor | null;
+  defaultAnchor?: TooltipAnchor | null;
+  data?: TData;
+  defaultData?: TData;
+
+  placement?: TooltipPlacement;
+  strategy?: Strategy;
+  offset?: number | FloatingTooltipOffset;
+  collisionPadding?: FloatingTooltipPadding;
+  collisionBoundary?: FloatingTooltipBoundary;
+  flip?: boolean | FloatingTooltipFlipOptions;
+  shift?: boolean | FloatingTooltipShiftOptions;
+  size?: boolean | FloatingTooltipSizeOptions;
+  hideWhenDetached?: boolean | FloatingTooltipHideOptions;
+  arrow?: boolean | FloatingTooltipArrowOptions;
+
+  interactions?: FloatingTooltipInteractions;
+  middleware?: Middleware[];
+  middlewareMode?: 'append' | 'replace';
+  whileElementsMounted?: UseFloatingOptions['whileElementsMounted'];
+
+  id?: string;
+  role?: 'tooltip' | 'label';
+  disabled?: boolean;
+};
+```
+
+Return shape:
+
+```ts
+type UseFloatingTooltipReturn<TData = unknown> = {
+  open: boolean;
+  mounted: boolean;
+  data: TData | undefined;
+  anchor: TooltipAnchor | null;
+  placement: TooltipPlacement;
+  side: TooltipSide;
+  align: TooltipAlign;
+  strategy: Strategy;
+  x: number | null;
+  y: number | null;
+  floatingStyles: React.CSSProperties;
+  middlewareData: MiddlewareData;
+
+  refs: UseFloatingReturn<ReferenceElement>['refs'];
+  context: UseFloatingReturn<ReferenceElement>['context'];
+  arrowRef: React.RefCallback<SVGSVGElement>;
+
+  setAnchor: (anchor: TooltipAnchor | null) => void;
+  setData: (data: TData | undefined) => void;
+  update: () => void;
+  openTooltip: (data?: TData, anchor?: TooltipAnchor | null) => void;
+  closeTooltip: () => void;
+
+  getReferenceProps: <TProps extends React.HTMLProps<Element>>(props?: TProps) => TProps;
+  getFloatingProps: <TProps extends React.HTMLProps<HTMLElement>>(props?: TProps) => TProps;
+  getArrowProps: <TProps extends React.SVGProps<SVGSVGElement>>(props?: TProps) => TProps;
+};
+```
+
+Controlled/uncontrolled behavior:
+
+- `open`, `anchor`, and `data` each become controlled when their corresponding prop is provided.
+- `defaultOpen`, `defaultAnchor`, and `defaultData` seed uncontrolled state.
+- `openTooltip(nextData, nextAnchor)` updates uncontrolled data and anchor when provided, then opens.
+- `closeTooltip()` closes.
+- `setAnchor()` and `setData()` only update uncontrolled state.
+- `id` is used as the default floating element id returned by `getFloatingProps()`.
+- An explicit `id` passed into `getFloatingProps()` overrides the hook option id.
+- `disabled` forces `open` to false and prevents `onOpenChange` handling.
+
+Example:
+
+```tsx
+function HookTooltip() {
+  const tooltip = useFloatingTooltip<{ month: string }>({
+    defaultData: { month: 'Apr' },
+    defaultOpen: true,
+    offset: 8,
+    placement: 'bottom-start',
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        {...tooltip.getReferenceProps({
+          onPointerEnter: () =>
+            tooltip.openTooltip({ month: 'Apr' }, { type: 'point', x: 100, y: 120 }),
+          onPointerLeave: tooltip.closeTooltip,
+        })}
+      >
+        Hook trigger
+      </button>
+
+      {tooltip.mounted && (
+        <div
+          {...tooltip.getFloatingProps({
+            ref: tooltip.refs.setFloating,
+            style: tooltip.floatingStyles,
+          })}
+        >
+          {tooltip.data?.month}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## Interactions
+
+`interactions` defaults to `true`.
+
+When enabled, `useFloatingTooltip` wires:
+
+- hover via Floating UI `useHover`
+- focus via Floating UI `useFocus`
+- dismiss via Floating UI `useDismiss`
+- role via Floating UI `useRole`
+
+Disable all interactions:
+
+```tsx
+<FloatingTooltip.Root interactions={false}>
+  ...
+</FloatingTooltip.Root>
+```
+
+Disable or configure one interaction:
+
+```tsx
+<FloatingTooltip.Root
+  interactions={{
+    hover: false,
+    focus: true,
+    dismiss: true,
+    role: true,
+  }}
+>
+  ...
+</FloatingTooltip.Root>
+```
+
+`FloatingTooltip.Trigger` is the usual way to consume these interaction props. In tests, trigger hover opens, focus opens, Escape dismisses, default tooltip role wiring adds `aria-describedby`, and `role="label"` adds `aria-labelledby` instead.
+
+When `FloatingTooltip.Root` receives an `id`, that id becomes the default `FloatingTooltip.Positioner` id and the trigger's ARIA target. An explicit `FloatingTooltip.Positioner id` wins over the root id.
+
+## Middleware
+
+The built-in middleware order is:
+
+1. `offset`
+2. `flip`
+3. `shift`
+4. `size`
+5. `hide`
+6. `arrow`
+7. caller middleware
+
+Only enabled middleware is included:
+
+- `flip` default: `true`
+- `shift` default: `true`
+- `size` default: `false`
+- `hideWhenDetached` default: `false`
+- `arrow` default: `false`
+- `offset` default: `0`
+
+Append custom middleware:
+
+```tsx
+<ChartTooltip
+  open
+  anchor={{ type: 'point', x: 0, y: 0 }}
+  items={items}
+  floatingOptions={{
+    middleware: [customMiddleware],
+    middlewareMode: 'append',
+    shift: { padding: 8 },
+  }}
+/>
+```
+
+Replace all built-in middleware:
+
+```tsx
+<FloatingTooltip.Root
+  open
+  anchor={{ type: 'point', x: 0, y: 0 }}
+  middleware={[customMiddleware]}
+  middlewareMode="replace"
+>
+  ...
+</FloatingTooltip.Root>
+```
+
+`collisionBoundary` and `collisionPadding` are forwarded into `flip`, `shift`, `size`, and `hide` when those middleware are enabled.
+
+## Styling Contract
+
+The floating APIs are intentionally minimally styled. Consumers should style via normal classes and data attributes.
+
+Useful primitive attributes:
+
+- `[data-visx-tooltip]`
+- `[data-visx-tooltip-content]`
+- `[data-visx-tooltip-arrow]`
+- `[data-visx-tooltip-trigger]`
+- `[data-disabled]`
+- `[data-state='open' | 'closed']`
+- `[data-side='top' | 'right' | 'bottom' | 'left']`
+- `[data-align='start' | 'center' | 'end']`
+- `[data-anchor-hidden]`
+
+Useful chart content attributes:
+
+- `[data-visx-chart-tooltip]`
+- `[data-visx-chart-tooltip-label]`
+- `[data-visx-chart-tooltip-items]`
+- `[data-visx-chart-tooltip-item]`
+- `[data-visx-chart-tooltip-indicator]`
+- `[data-visx-chart-tooltip-item-label]`
+- `[data-visx-chart-tooltip-item-value]`
+
+## Current Source Caveats
+
+These are source-validated caveats, not design guidance.
+
+- `FloatingTooltip.Content` does not assign a default role. `Positioner` receives Floating UI role props when role interactions are enabled.
+- `FloatingTooltip.Trigger disabled` is trigger-scoped; use `Root disabled` to disable the whole tooltip state machine.
+- `ChartTooltip` is controlled; it requires `open`, `anchor`, and `items`. `useChartTooltip` is the convenience state owner if you do not want to wire those yourself.
+- `useChartTooltip.update()` accepts a full `TooltipAnchor`, not the local-point or shorthand SVG-point forms accepted by `show()`.

--- a/packages/visx-tooltip/Readme.md
+++ b/packages/visx-tooltip/Readme.md
@@ -15,8 +15,8 @@ npm install --save @visx/tooltip
 
 ### Modern Floating UI tooltips
 
-`@visx/tooltip` also includes an additive Floating UI-backed surface for modern tooltip
-positioning. Import it from the explicit React subpath:
+`@visx/tooltip` also includes an additive Floating UI-backed surface for modern tooltip positioning.
+Import it from the explicit React subpath:
 
 ```tsx
 import {
@@ -81,12 +81,7 @@ function RevenueChart({ data, width, height }: { data: Datum[]; width: number; h
         onPointerLeave={tooltip.hide}
       >
         {data.map((datum) => (
-          <circle
-            key={datum.month}
-            cx={xScale(datum.month)}
-            cy={yScale(datum.revenue)}
-            r={4}
-          />
+          <circle key={datum.month} cx={xScale(datum.month)} cy={yScale(datum.revenue)} r={4} />
         ))}
       </svg>
 
@@ -311,8 +306,8 @@ To use a `Portal`, simply pass your `Tooltip` as a child: `<Portal><Tooltip {...
 will also need to correct the `left` and `top` positions to be in _page coordinates_, not the
 coordinates of your container which you would use when _not_ using a `Portal`. If reacting to a
 mouse event, you can use `event.pageX/Y`. Alternatively, if you have container coordinates, you can
-convert them to page coordinates using the following (note: `useTooltipInPortal` handles this
-for you):
+convert them to page coordinates using the following (note: `useTooltipInPortal` handles this for
+you):
 
 ```js
 const pageX = containerX + containerBoundingBox.left + window.scrollLeft;

--- a/packages/visx-tooltip/Readme.md
+++ b/packages/visx-tooltip/Readme.md
@@ -13,6 +13,145 @@ visualization and includes hooks, higher-order component (HOC) enhancers, and To
 npm install --save @visx/tooltip
 ```
 
+### Modern Floating UI tooltips
+
+`@visx/tooltip` also includes an additive Floating UI-backed surface for modern tooltip
+positioning. Import it from the explicit React subpath:
+
+```tsx
+import {
+  ChartTooltip,
+  ChartTooltipContent,
+  FloatingTooltip,
+  useChartTooltip,
+  useFloatingTooltip,
+} from '@visx/tooltip/floating';
+```
+
+Existing `@visx/tooltip` exports are unchanged. Use the modern subpath when a chart needs
+collision-aware placement, virtual anchors, SVG or cursor anchoring, arrows, controlled state, or
+config-driven chart tooltip content.
+
+#### Manual chart tooltip
+
+`useChartTooltip()` owns tooltip open state, anchor state, and rendered items. Your chart still owns
+nearest-datum lookup and event handling.
+
+```tsx
+import { localPoint } from '@visx/event';
+import { ChartTooltip, type ChartTooltipConfig, useChartTooltip } from '@visx/tooltip/floating';
+
+type Datum = { month: string; revenue: number };
+
+const tooltipConfig = {
+  revenue: {
+    label: 'Revenue',
+    color: '#3b82f6',
+    formatValue: (value) => `$${Number(value).toLocaleString()}`,
+  },
+} satisfies ChartTooltipConfig<Datum>;
+
+function RevenueChart({ data, width, height }: { data: Datum[]; width: number; height: number }) {
+  const tooltip = useChartTooltip<Datum>({ placement: 'top', offset: 10 });
+
+  return (
+    <>
+      <svg
+        ref={tooltip.containerRef}
+        width={width}
+        height={height}
+        onPointerMove={(event) => {
+          const point = localPoint(event.currentTarget, event);
+          if (!point) return;
+
+          const datum = findNearestDatum(point, data);
+
+          tooltip.show({
+            anchor: point,
+            items: [
+              {
+                key: 'revenue',
+                datum,
+                label: datum.month,
+                rawValue: datum.revenue,
+              },
+            ],
+          });
+        }}
+        onPointerLeave={tooltip.hide}
+      >
+        {data.map((datum) => (
+          <circle
+            key={datum.month}
+            cx={xScale(datum.month)}
+            cy={yScale(datum.revenue)}
+            r={4}
+          />
+        ))}
+      </svg>
+
+      <ChartTooltip {...tooltip.tooltipProps} config={tooltipConfig} />
+    </>
+  );
+}
+```
+
+When `tooltip.show()` receives `{ x, y }`, the coordinates are treated as CSS pixels local to the
+element registered with `containerRef`. If you have SVG user-space coordinates from scales or glyph
+positions, pass a shorthand SVG point instead:
+
+```tsx
+tooltip.show({
+  anchor: { type: 'svg-point', x: xScale(datum.month), y: yScale(datum.revenue) },
+  items: [{ key: 'revenue', datum, rawValue: datum.revenue }],
+});
+```
+
+#### Low-level primitives
+
+Use `FloatingTooltip` directly when you want complete control over positioning and content.
+
+```tsx
+<FloatingTooltip.Root
+  open={open}
+  anchor={{ type: 'point', x: event.clientX, y: event.clientY }}
+  placement="right"
+  offset={12}
+  arrow
+>
+  <FloatingTooltip.Portal>
+    <FloatingTooltip.Positioner className="Tooltip">
+      <FloatingTooltip.Content>
+        <FloatingTooltip.Arrow />
+        {children}
+      </FloatingTooltip.Content>
+    </FloatingTooltip.Positioner>
+  </FloatingTooltip.Portal>
+</FloatingTooltip.Root>
+```
+
+#### DOM trigger tooltip
+
+`FloatingTooltip.Trigger` is optional. When rendered, it wires hover, focus, dismiss, and tooltip
+ARIA props through Floating UI. If `Root` also receives an explicit `anchor`, the trigger owns DOM
+interactions while the anchor owns positioning.
+
+```tsx
+<FloatingTooltip.Provider delay={700} skipDelay={300}>
+  <FloatingTooltip.Root>
+    <FloatingTooltip.Trigger render={<button type="button">Export</button>} />
+    <FloatingTooltip.Portal>
+      <FloatingTooltip.Positioner>
+        <FloatingTooltip.Content>Download chart data</FloatingTooltip.Content>
+      </FloatingTooltip.Positioner>
+    </FloatingTooltip.Portal>
+  </FloatingTooltip.Root>
+</FloatingTooltip.Provider>
+```
+
+Tooltip content should be brief and non-interactive. If content includes links, buttons, form
+controls, or rich navigation, use a popover-style primitive instead of tooltip behavior.
+
 ### Hooks and Enhancers
 
 This package provides two ways to add tooltip **state** logic to your chart components:

--- a/packages/visx-tooltip/Readme.md
+++ b/packages/visx-tooltip/Readme.md
@@ -102,7 +102,7 @@ positions, pass a shorthand SVG point instead:
 
 ```tsx
 tooltip.show({
-  anchor: { type: 'svg-point', x: xScale(datum.month), y: yScale(datum.revenue) },
+  anchor: { type: 'svg-local-point', x: xScale(datum.month), y: yScale(datum.revenue) },
   items: [{ key: 'revenue', datum, rawValue: datum.revenue }],
 });
 ```

--- a/packages/visx-tooltip/package.json
+++ b/packages/visx-tooltip/package.json
@@ -11,6 +11,11 @@
       "types": "./lib/index.d.ts",
       "import": "./esm/index.js",
       "require": "./lib/index.js"
+    },
+    "./floating": {
+      "types": "./lib/floating/index.d.ts",
+      "import": "./esm/floating/index.js",
+      "require": "./lib/floating/index.js"
     }
   },
   "files": [
@@ -35,6 +40,7 @@
   },
   "homepage": "https://github.com/airbnb/visx#readme",
   "dependencies": {
+    "@floating-ui/react": "^0.27.19",
     "@visx/bounds": "workspace:*",
     "classnames": "^2.3.1",
     "react-use-measure": "^2.0.4"

--- a/packages/visx-tooltip/src/floating/ChartTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/ChartTooltip.tsx
@@ -78,15 +78,9 @@ export default function ChartTooltip<Datum = unknown>({
       collisionPadding={collisionPadding}
     >
       {(state) => {
-        const content =
-          renderContent?.({ items, config, state }) ?? (
-            <ChartTooltipContent
-              label={label}
-              items={items}
-              config={config}
-              {...contentProps}
-            />
-          );
+        const content = renderContent?.({ items, config, state }) ?? (
+          <ChartTooltipContent label={label} items={items} config={config} {...contentProps} />
+        );
 
         if (!content) return null;
 
@@ -96,7 +90,11 @@ export default function ChartTooltip<Datum = unknown>({
           </FloatingTooltip.Positioner>
         );
 
-        return portal ? <FloatingTooltip.Portal {...portalProps}>{body}</FloatingTooltip.Portal> : body;
+        return portal ? (
+          <FloatingTooltip.Portal {...portalProps}>{body}</FloatingTooltip.Portal>
+        ) : (
+          body
+        );
       }}
     </FloatingTooltip.Root>
   );

--- a/packages/visx-tooltip/src/floating/ChartTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/ChartTooltip.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import ChartTooltipContent from './ChartTooltipContent';
+import FloatingTooltip from './FloatingTooltip';
+import type {
+  ChartTooltipConfig,
+  ChartTooltipContentProps,
+  ChartTooltipItem,
+} from './ChartTooltipContent';
+import type {
+  FloatingTooltipOffset,
+  FloatingTooltipPadding,
+  FloatingTooltipPortalProps,
+  FloatingTooltipPositionerProps,
+  FloatingTooltipRootState,
+  TooltipAnchor,
+  TooltipPlacement,
+  UseFloatingTooltipOptions,
+} from './types';
+
+export type { ChartTooltipItem } from './ChartTooltipContent';
+
+export type ChartTooltipControlledProps<Datum = unknown> = {
+  open: boolean;
+  anchor: TooltipAnchor | null;
+  items: ChartTooltipItem<Datum>[];
+};
+
+export type ChartTooltipProps<Datum = unknown> = ChartTooltipControlledProps<Datum> & {
+  config?: ChartTooltipConfig<Datum>;
+  label?: React.ReactNode;
+
+  placement?: TooltipPlacement;
+  strategy?: 'absolute' | 'fixed';
+  offset?: number | FloatingTooltipOffset;
+  collisionPadding?: FloatingTooltipPadding;
+  portal?: boolean;
+  portalProps?: Omit<FloatingTooltipPortalProps, 'children'>;
+  positionerProps?: Omit<FloatingTooltipPositionerProps, 'children'>;
+  contentProps?: Omit<ChartTooltipContentProps<Datum>, 'items' | 'config' | 'label'>;
+  floatingOptions?: Omit<
+    UseFloatingTooltipOptions<ChartTooltipItem<Datum>[]>,
+    'open' | 'defaultOpen' | 'data' | 'defaultData' | 'anchor' | 'defaultAnchor'
+  >;
+
+  renderContent?: (params: {
+    items: ChartTooltipItem<Datum>[];
+    config?: ChartTooltipConfig<Datum>;
+    state: FloatingTooltipRootState<ChartTooltipItem<Datum>[]>;
+  }) => React.ReactNode;
+};
+
+export default function ChartTooltip<Datum = unknown>({
+  anchor,
+  collisionPadding,
+  config,
+  contentProps,
+  floatingOptions,
+  items,
+  label,
+  offset = 8,
+  open,
+  placement = 'top',
+  portal = true,
+  portalProps,
+  positionerProps,
+  renderContent,
+  strategy,
+}: ChartTooltipProps<Datum>) {
+  return (
+    <FloatingTooltip.Root
+      {...floatingOptions}
+      open={open}
+      anchor={anchor}
+      data={items}
+      placement={placement}
+      strategy={strategy}
+      offset={offset}
+      collisionPadding={collisionPadding}
+    >
+      {(state) => {
+        const content =
+          renderContent?.({ items, config, state }) ?? (
+            <ChartTooltipContent
+              label={label}
+              items={items}
+              config={config}
+              {...contentProps}
+            />
+          );
+
+        if (!content) return null;
+
+        const body = (
+          <FloatingTooltip.Positioner {...positionerProps}>
+            <FloatingTooltip.Content>{content}</FloatingTooltip.Content>
+          </FloatingTooltip.Positioner>
+        );
+
+        return portal ? <FloatingTooltip.Portal {...portalProps}>{body}</FloatingTooltip.Portal> : body;
+      }}
+    </FloatingTooltip.Root>
+  );
+}

--- a/packages/visx-tooltip/src/floating/ChartTooltipContent.tsx
+++ b/packages/visx-tooltip/src/floating/ChartTooltipContent.tsx
@@ -45,24 +45,22 @@ export type ChartTooltipItemRenderParams<Datum = unknown> = {
   indicator: ChartTooltipIndicator;
 };
 
-export type ChartTooltipValueRenderParams<Datum = unknown> =
-  ChartTooltipItemRenderParams<Datum>;
+export type ChartTooltipValueRenderParams<Datum = unknown> = ChartTooltipItemRenderParams<Datum>;
 
-export type ChartTooltipContentProps<Datum = unknown> =
-  React.HTMLAttributes<HTMLDivElement> & {
-    label?: React.ReactNode;
-    items: ChartTooltipItem<Datum>[];
-    config?: ChartTooltipConfig<Datum>;
-    indicator?: ChartTooltipIndicator;
-    hideLabel?: boolean;
-    hideIndicator?: boolean;
-    sortItems?: (a: ChartTooltipItem<Datum>, b: ChartTooltipItem<Datum>) => number;
-    renderLabel?: (params: ChartTooltipLabelRenderParams<Datum>) => React.ReactNode;
-    renderItem?: (params: ChartTooltipItemRenderParams<Datum>) => React.ReactNode;
-    renderValue?: (params: ChartTooltipValueRenderParams<Datum>) => React.ReactNode;
-    getItemKey?: (item: ChartTooltipItem<Datum>, index: number) => React.Key;
-    'data-testid'?: string;
-  };
+export type ChartTooltipContentProps<Datum = unknown> = React.HTMLAttributes<HTMLDivElement> & {
+  label?: React.ReactNode;
+  items: ChartTooltipItem<Datum>[];
+  config?: ChartTooltipConfig<Datum>;
+  indicator?: ChartTooltipIndicator;
+  hideLabel?: boolean;
+  hideIndicator?: boolean;
+  sortItems?: (a: ChartTooltipItem<Datum>, b: ChartTooltipItem<Datum>) => number;
+  renderLabel?: (params: ChartTooltipLabelRenderParams<Datum>) => React.ReactNode;
+  renderItem?: (params: ChartTooltipItemRenderParams<Datum>) => React.ReactNode;
+  renderValue?: (params: ChartTooltipValueRenderParams<Datum>) => React.ReactNode;
+  getItemKey?: (item: ChartTooltipItem<Datum>, index: number) => React.Key;
+  'data-testid'?: string;
+};
 
 type VisibleItem<Datum> = {
   configEntry?: ChartTooltipConfig<Datum>[string];
@@ -70,10 +68,11 @@ type VisibleItem<Datum> = {
   item: ChartTooltipItem<Datum>;
 };
 
-function getConfigEntry<Datum>(
-  item: ChartTooltipItem<Datum>,
-  config?: ChartTooltipConfig<Datum>,
-) {
+type ChartTooltipItemStyle = React.CSSProperties & {
+  '--visx-tooltip-item-color'?: string;
+};
+
+function getConfigEntry<Datum>(item: ChartTooltipItem<Datum>, config?: ChartTooltipConfig<Datum>) {
   return config?.[item.key];
 }
 
@@ -94,7 +93,7 @@ function getItemValue<Datum>(
   item: ChartTooltipItem<Datum>,
   configEntry?: ChartTooltipConfig<Datum>[string],
 ) {
-  const formatterValue = item.rawValue !== undefined ? item.rawValue : item.value;
+  const formatterValue = item.rawValue === undefined ? item.value : item.rawValue;
 
   if (configEntry?.formatValue) return configEntry.formatValue(formatterValue, item);
   if (item.value != null) return item.value;
@@ -140,6 +139,12 @@ function getVisibleItems<Datum>({
     });
 }
 
+function getItemColorStyle(itemColor?: string): ChartTooltipItemStyle | undefined {
+  if (!itemColor) return undefined;
+
+  return { '--visx-tooltip-item-color': itemColor };
+}
+
 export default function ChartTooltipContent<Datum = unknown>({
   className,
   config,
@@ -166,15 +171,8 @@ export default function ChartTooltipContent<Datum = unknown>({
       : null;
 
   return (
-    <div
-      {...restProps}
-      className={className}
-      data-visx-chart-tooltip=""
-      data-testid={dataTestId}
-    >
-      {renderedLabel != null && (
-        <div data-visx-chart-tooltip-label="">{renderedLabel}</div>
-      )}
+    <div {...restProps} className={className} data-visx-chart-tooltip="" data-testid={dataTestId}>
+      {renderedLabel != null && <div data-visx-chart-tooltip-label="">{renderedLabel}</div>}
       <div data-visx-chart-tooltip-items="">
         {visibleItems.map(({ configEntry, index, item }) => {
           const itemLabel = getItemLabel(item, configEntry);
@@ -201,11 +199,7 @@ export default function ChartTooltipContent<Datum = unknown>({
               data-item-key={item.key}
               data-testid={`item-${item.key}`}
               data-visx-chart-tooltip-item=""
-              style={
-                itemColor
-                  ? ({ '--visx-tooltip-item-color': itemColor } as React.CSSProperties)
-                  : undefined
-              }
+              style={getItemColorStyle(itemColor)}
             >
               {renderItem ? (
                 renderItem(itemParams)

--- a/packages/visx-tooltip/src/floating/ChartTooltipContent.tsx
+++ b/packages/visx-tooltip/src/floating/ChartTooltipContent.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+
+export type ChartTooltipItem<Datum = unknown> = {
+  key: string;
+  datum?: Datum;
+  index?: number;
+  label?: React.ReactNode;
+  value?: React.ReactNode;
+  rawValue?: unknown;
+  color?: string;
+  x?: number;
+  y?: number;
+  distance?: number;
+  hidden?: boolean;
+  payload?: unknown;
+};
+
+export type ChartTooltipConfig<Datum = unknown> = Record<
+  string,
+  {
+    label?: React.ReactNode | ((item: ChartTooltipItem<Datum>) => React.ReactNode);
+    color?: string | ((item: ChartTooltipItem<Datum>) => string | undefined);
+    icon?: React.ComponentType<{ item: ChartTooltipItem<Datum> }>;
+    formatValue?: (value: unknown, item: ChartTooltipItem<Datum>) => React.ReactNode;
+    formatLabel?: (item: ChartTooltipItem<Datum>) => React.ReactNode;
+    hide?: boolean;
+    order?: number;
+  }
+>;
+
+export type ChartTooltipIndicator = 'dot' | 'line' | 'dashed' | 'square' | 'none';
+
+export type ChartTooltipLabelRenderParams<Datum = unknown> = {
+  label: React.ReactNode;
+  items: ChartTooltipItem<Datum>[];
+  config?: ChartTooltipConfig<Datum>;
+};
+
+export type ChartTooltipItemRenderParams<Datum = unknown> = {
+  item: ChartTooltipItem<Datum>;
+  configEntry?: ChartTooltipConfig<Datum>[string];
+  label: React.ReactNode;
+  value: React.ReactNode;
+  color?: string;
+  indicator: ChartTooltipIndicator;
+};
+
+export type ChartTooltipValueRenderParams<Datum = unknown> =
+  ChartTooltipItemRenderParams<Datum>;
+
+export type ChartTooltipContentProps<Datum = unknown> =
+  React.HTMLAttributes<HTMLDivElement> & {
+    label?: React.ReactNode;
+    items: ChartTooltipItem<Datum>[];
+    config?: ChartTooltipConfig<Datum>;
+    indicator?: ChartTooltipIndicator;
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    sortItems?: (a: ChartTooltipItem<Datum>, b: ChartTooltipItem<Datum>) => number;
+    renderLabel?: (params: ChartTooltipLabelRenderParams<Datum>) => React.ReactNode;
+    renderItem?: (params: ChartTooltipItemRenderParams<Datum>) => React.ReactNode;
+    renderValue?: (params: ChartTooltipValueRenderParams<Datum>) => React.ReactNode;
+    getItemKey?: (item: ChartTooltipItem<Datum>, index: number) => React.Key;
+    'data-testid'?: string;
+  };
+
+type VisibleItem<Datum> = {
+  configEntry?: ChartTooltipConfig<Datum>[string];
+  index: number;
+  item: ChartTooltipItem<Datum>;
+};
+
+function getConfigEntry<Datum>(
+  item: ChartTooltipItem<Datum>,
+  config?: ChartTooltipConfig<Datum>,
+) {
+  return config?.[item.key];
+}
+
+function getItemLabel<Datum>(
+  item: ChartTooltipItem<Datum>,
+  configEntry?: ChartTooltipConfig<Datum>[string],
+) {
+  if (configEntry?.formatLabel) return configEntry.formatLabel(item);
+
+  if (typeof configEntry?.label === 'function') return configEntry.label(item);
+  if (configEntry?.label != null) return configEntry.label;
+  if (item.label != null) return item.label;
+
+  return item.key;
+}
+
+function getItemValue<Datum>(
+  item: ChartTooltipItem<Datum>,
+  configEntry?: ChartTooltipConfig<Datum>[string],
+) {
+  const formatterValue = item.rawValue !== undefined ? item.rawValue : item.value;
+
+  if (configEntry?.formatValue) return configEntry.formatValue(formatterValue, item);
+  if (item.value != null) return item.value;
+  if (item.rawValue != null) return String(item.rawValue);
+
+  return '';
+}
+
+function getItemColor<Datum>(
+  item: ChartTooltipItem<Datum>,
+  configEntry?: ChartTooltipConfig<Datum>[string],
+) {
+  if (typeof configEntry?.color === 'function') return configEntry.color(item);
+  if (configEntry?.color) return configEntry.color;
+
+  return item.color;
+}
+
+function getVisibleItems<Datum>({
+  config,
+  items,
+  sortItems,
+}: Pick<ChartTooltipContentProps<Datum>, 'config' | 'items' | 'sortItems'>) {
+  return items
+    .map<VisibleItem<Datum>>((item, index) => ({
+      configEntry: getConfigEntry(item, config),
+      index,
+      item,
+    }))
+    .filter(({ configEntry, item }) => !item.hidden && !configEntry?.hide)
+    .sort((a, b) => {
+      const aOrder = a.configEntry?.order;
+      const bOrder = b.configEntry?.order;
+
+      if (aOrder != null && bOrder != null && aOrder !== bOrder) return aOrder - bOrder;
+      if (aOrder != null && bOrder == null) return -1;
+      if (aOrder == null && bOrder != null) return 1;
+
+      const sorted = sortItems?.(a.item, b.item) ?? 0;
+      if (sorted !== 0) return sorted;
+
+      return a.index - b.index;
+    });
+}
+
+export default function ChartTooltipContent<Datum = unknown>({
+  className,
+  config,
+  getItemKey = (item, index) => item.key ?? index,
+  hideIndicator = false,
+  hideLabel = false,
+  indicator = 'dot',
+  items,
+  label,
+  renderItem,
+  renderLabel,
+  renderValue,
+  sortItems,
+  'data-testid': dataTestId = 'chart-tooltip-content',
+  ...restProps
+}: ChartTooltipContentProps<Datum>) {
+  const visibleItems = getVisibleItems({ config, items, sortItems });
+
+  if (visibleItems.length === 0) return null;
+
+  const renderedLabel =
+    !hideLabel && label != null
+      ? renderLabel?.({ label, items: visibleItems.map(({ item }) => item), config }) ?? label
+      : null;
+
+  return (
+    <div
+      {...restProps}
+      className={className}
+      data-visx-chart-tooltip=""
+      data-testid={dataTestId}
+    >
+      {renderedLabel != null && (
+        <div data-visx-chart-tooltip-label="">{renderedLabel}</div>
+      )}
+      <div data-visx-chart-tooltip-items="">
+        {visibleItems.map(({ configEntry, index, item }) => {
+          const itemLabel = getItemLabel(item, configEntry);
+          const itemValue = getItemValue(item, configEntry);
+          const itemColor = getItemColor(item, configEntry);
+          const Icon = configEntry?.icon;
+          const valueParams = {
+            color: itemColor,
+            configEntry,
+            indicator,
+            item,
+            label: itemLabel,
+            value: itemValue,
+          };
+          const renderedValue = renderValue?.(valueParams) ?? itemValue;
+          const itemParams = {
+            ...valueParams,
+            value: renderedValue,
+          };
+
+          return (
+            <div
+              key={getItemKey(item, index)}
+              data-item-key={item.key}
+              data-testid={`item-${item.key}`}
+              data-visx-chart-tooltip-item=""
+              style={
+                itemColor
+                  ? ({ '--visx-tooltip-item-color': itemColor } as React.CSSProperties)
+                  : undefined
+              }
+            >
+              {renderItem ? (
+                renderItem(itemParams)
+              ) : (
+                <>
+                  {!hideIndicator && indicator !== 'none' && (
+                    <span
+                      aria-hidden
+                      data-indicator={indicator}
+                      data-visx-chart-tooltip-indicator=""
+                    />
+                  )}
+                  {Icon && <Icon item={item} />}
+                  <span data-visx-chart-tooltip-item-label="">{itemLabel}</span>
+                  <span data-visx-chart-tooltip-item-value="">{renderedValue}</span>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
@@ -1,0 +1,225 @@
+import {
+  FloatingArrow,
+  FloatingPortal,
+  type FloatingPortalProps as FloatingUiPortalProps,
+} from '@floating-ui/react';
+import React from 'react';
+import { FloatingTooltipContextProvider, useFloatingTooltipContext } from './context';
+import useFloatingTooltip from './useFloatingTooltip';
+import type {
+  FloatingTooltipArrowProps,
+  FloatingTooltipArrowState,
+  FloatingTooltipContentProps,
+  FloatingTooltipContentState,
+  FloatingTooltipPortalProps,
+  FloatingTooltipPositionerProps,
+  FloatingTooltipPositionerState,
+  FloatingTooltipProviderProps,
+  FloatingTooltipRootProps,
+  FloatingTooltipRootState,
+  FloatingTooltipTriggerProps,
+} from './types';
+
+type RenderElementProps<ElementProps, State> = {
+  defaultElement: React.ReactElement;
+  props: ElementProps;
+  render?: React.ReactElement | ((props: ElementProps, state: State) => React.ReactElement);
+  state: State;
+};
+
+function renderElement<ElementProps, State>({
+  defaultElement,
+  props,
+  render,
+  state,
+}: RenderElementProps<ElementProps, State>) {
+  if (typeof render === 'function') return render(props, state);
+
+  if (React.isValidElement(render)) {
+    return React.cloneElement(render, props as Partial<unknown> & React.Attributes);
+  }
+
+  return React.cloneElement(defaultElement, props as Partial<unknown> & React.Attributes);
+}
+
+function getTransformOrigin(state: FloatingTooltipRootState) {
+  const arrowX = state.middlewareData.arrow?.x;
+  const arrowY = state.middlewareData.arrow?.y;
+
+  switch (state.side) {
+    case 'top':
+      return `${arrowX == null ? '50%' : `${arrowX}px`} bottom`;
+    case 'bottom':
+      return `${arrowX == null ? '50%' : `${arrowX}px`} top`;
+    case 'left':
+      return `right ${arrowY == null ? '50%' : `${arrowY}px`}`;
+    case 'right':
+      return `left ${arrowY == null ? '50%' : `${arrowY}px`}`;
+    default:
+      return '50% 50%';
+  }
+}
+
+function getFloatingCssVariables(state: FloatingTooltipRootState) {
+  const arrowX = state.middlewareData.arrow?.x;
+  const arrowY = state.middlewareData.arrow?.y;
+
+  return {
+    '--visx-tooltip-transform-origin': getTransformOrigin(state),
+    '--visx-tooltip-arrow-x': arrowX == null ? undefined : `${arrowX}px`,
+    '--visx-tooltip-arrow-y': arrowY == null ? undefined : `${arrowY}px`,
+  } as React.CSSProperties;
+}
+
+function getPortalRoot(container: FloatingTooltipPortalProps['container']) {
+  if (!container) return undefined;
+  if ('current' in container) return container.current;
+  return container;
+}
+
+function Provider({ children }: FloatingTooltipProviderProps) {
+  return <>{children}</>;
+}
+
+function Root<TData = unknown>({
+  children,
+  forceMount = false,
+  ...options
+}: FloatingTooltipRootProps<TData>) {
+  const tooltip = useFloatingTooltip<TData>(options);
+  const state = {
+    ...tooltip,
+    mounted: tooltip.open || forceMount,
+  };
+
+  return (
+    <FloatingTooltipContextProvider value={state}>
+      {typeof children === 'function' ? children(state) : children}
+    </FloatingTooltipContextProvider>
+  );
+}
+
+function Trigger(_props: FloatingTooltipTriggerProps) {
+  return null;
+}
+
+function Portal({ children, container, disabled = false }: FloatingTooltipPortalProps) {
+  const state = useFloatingTooltipContext('FloatingTooltip.Portal');
+
+  if (!state.mounted) return null;
+  if (disabled) return <>{children}</>;
+
+  return (
+    <FloatingPortal root={getPortalRoot(container) as FloatingUiPortalProps['root']}>
+      {children}
+    </FloatingPortal>
+  );
+}
+
+function Positioner({
+  children,
+  render,
+  style,
+  ...restProps
+}: FloatingTooltipPositionerProps) {
+  const state = useFloatingTooltipContext('FloatingTooltip.Positioner');
+
+  if (!state.mounted) return null;
+
+  const anchorHidden = Boolean(state.middlewareData.hide?.referenceHidden);
+  const positionerProps = state.getFloatingProps({
+    ...restProps,
+    children,
+    'data-anchor-hidden': anchorHidden ? '' : undefined,
+    'data-align': state.align,
+    'data-side': state.side,
+    'data-state': state.open ? 'open' : 'closed',
+    'data-visx-tooltip': '',
+    ref: state.refs.setFloating,
+    style: {
+      ...state.floatingStyles,
+      ...getFloatingCssVariables(state),
+      ...style,
+    },
+  } as React.HTMLProps<HTMLDivElement>);
+
+  return renderElement<React.HTMLProps<HTMLDivElement>, FloatingTooltipPositionerState>({
+    defaultElement: <div />,
+    props: positionerProps,
+    render,
+    state,
+  });
+}
+
+function Content({ children, render, role = 'tooltip', ...restProps }: FloatingTooltipContentProps) {
+  const state = useFloatingTooltipContext('FloatingTooltip.Content');
+
+  if (!state.mounted) return null;
+
+  const contentProps = {
+    ...restProps,
+    children,
+    'data-state': state.open ? 'open' : 'closed',
+    'data-visx-tooltip-content': '',
+    role,
+  } as React.HTMLProps<HTMLDivElement>;
+
+  return renderElement<React.HTMLProps<HTMLDivElement>, FloatingTooltipContentState>({
+    defaultElement: <div />,
+    props: contentProps,
+    render,
+    state,
+  });
+}
+
+function Arrow({
+  height = 7,
+  padding,
+  render,
+  width = 14,
+  ...restProps
+}: FloatingTooltipArrowProps) {
+  const state = useFloatingTooltipContext('FloatingTooltip.Arrow');
+
+  if (!state.mounted) return null;
+
+  if (render) {
+    const arrowProps = state.getArrowProps({
+      ...restProps,
+      'data-visx-tooltip-arrow': '',
+      ref: state.arrowRef,
+    } as React.SVGProps<SVGSVGElement>);
+
+    return renderElement<React.SVGProps<SVGSVGElement>, FloatingTooltipArrowState>({
+      defaultElement: <svg />,
+      props: arrowProps,
+      render,
+      state,
+    });
+  }
+
+  return (
+    <FloatingArrow
+      {...restProps}
+      data-visx-tooltip-arrow=""
+      ref={state.arrowRef}
+      context={state.context}
+      width={width}
+      height={height}
+      tipRadius={0}
+      strokeWidth={padding}
+    />
+  );
+}
+
+const FloatingTooltip = {
+  Arrow,
+  Content,
+  Portal,
+  Positioner,
+  Provider,
+  Root,
+  Trigger,
+};
+
+export default FloatingTooltip;

--- a/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
@@ -1,5 +1,6 @@
 import {
   FloatingArrow,
+  FloatingDelayGroup,
   FloatingPortal,
   type FloatingPortalProps as FloatingUiPortalProps,
 } from '@floating-ui/react';
@@ -77,8 +78,22 @@ function getPortalRoot(container: FloatingTooltipPortalProps['container']) {
   return container;
 }
 
-function Provider({ children }: FloatingTooltipProviderProps) {
-  return <>{children}</>;
+function Provider({
+  children,
+  closeDelay = 0,
+  delay = 600,
+  skipDelay = 400,
+}: FloatingTooltipProviderProps) {
+  const floatingDelay =
+    typeof delay === 'number'
+      ? { open: delay, close: closeDelay }
+      : { open: delay.open ?? 600, close: delay.close ?? closeDelay };
+
+  return (
+    <FloatingDelayGroup delay={floatingDelay} timeoutMs={skipDelay}>
+      {children}
+    </FloatingDelayGroup>
+  );
 }
 
 function Root<TData = unknown>({
@@ -99,8 +114,23 @@ function Root<TData = unknown>({
   );
 }
 
-function Trigger(_props: FloatingTooltipTriggerProps) {
-  return null;
+function Trigger({ disabled = false, render }: FloatingTooltipTriggerProps) {
+  const state = useFloatingTooltipContext('FloatingTooltip.Trigger');
+  const triggerState = {
+    open: state.open,
+    side: state.side,
+    align: state.align,
+  };
+  const triggerProps = state.getReferenceProps({
+    'aria-disabled': disabled || undefined,
+    'data-state': state.open ? 'open' : 'closed',
+    'data-visx-tooltip-trigger': '',
+    ref: state.refs.setReference,
+  } as React.HTMLProps<Element>);
+
+  if (typeof render === 'function') return render(triggerProps, triggerState);
+
+  return React.cloneElement(render, triggerProps as Partial<unknown> & React.Attributes);
 }
 
 function Portal({ children, container, disabled = false }: FloatingTooltipPortalProps) {

--- a/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
@@ -116,17 +116,31 @@ function Root<TData = unknown>({
 
 function Trigger({ disabled = false, render }: FloatingTooltipTriggerProps) {
   const state = useFloatingTooltipContext('FloatingTooltip.Trigger');
+  const setTriggerReference = React.useCallback(
+    (node: Element | null) => {
+      if (disabled) {
+        state.refs.setPositionReference(node);
+        state.refs.setReference(null);
+        return;
+      }
+
+      state.refs.setReference(node);
+    },
+    [disabled, state.refs],
+  );
   const triggerState = {
     open: state.open,
     side: state.side,
     align: state.align,
   };
-  const triggerProps = state.getReferenceProps({
+  const referenceProps = {
     'aria-disabled': disabled || undefined,
+    'data-disabled': disabled ? '' : undefined,
     'data-state': state.open ? 'open' : 'closed',
     'data-visx-tooltip-trigger': '',
-    ref: state.refs.setReference,
-  } as React.HTMLProps<Element>);
+    ref: setTriggerReference,
+  } as React.HTMLProps<Element>;
+  const triggerProps = disabled ? referenceProps : state.getReferenceProps(referenceProps);
 
   if (typeof render === 'function') return render(triggerProps, triggerState);
 
@@ -148,6 +162,7 @@ function Portal({ children, container, disabled = false }: FloatingTooltipPortal
 
 function Positioner({
   children,
+  id,
   render,
   style,
   ...restProps
@@ -165,6 +180,7 @@ function Positioner({
     'data-side': state.side,
     'data-state': state.open ? 'open' : 'closed',
     'data-visx-tooltip': '',
+    ...(id === undefined ? null : { id }),
     ref: state.refs.setFloating,
     style: {
       ...state.floatingStyles,
@@ -181,7 +197,7 @@ function Positioner({
   });
 }
 
-function Content({ children, render, role = 'tooltip', ...restProps }: FloatingTooltipContentProps) {
+function Content({ children, render, ...restProps }: FloatingTooltipContentProps) {
   const state = useFloatingTooltipContext('FloatingTooltip.Content');
 
   if (!state.mounted) return null;
@@ -191,7 +207,6 @@ function Content({ children, render, role = 'tooltip', ...restProps }: FloatingT
     children,
     'data-state': state.open ? 'open' : 'closed',
     'data-visx-tooltip-content': '',
-    role,
   } as React.HTMLProps<HTMLDivElement>;
 
   return renderElement<React.HTMLProps<HTMLDivElement>, FloatingTooltipContentState>({

--- a/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
@@ -28,6 +28,20 @@ type RenderElementProps<ElementProps, State> = {
   state: State;
 };
 
+type FloatingCssVariables = React.CSSProperties & {
+  '--visx-tooltip-transform-origin'?: string;
+  '--visx-tooltip-arrow-x'?: string;
+  '--visx-tooltip-arrow-y'?: string;
+};
+
+type FloatingDataAttributes = {
+  [key: `data-${string}`]: string | undefined;
+};
+
+type FloatingReferenceProps = React.HTMLProps<Element> & FloatingDataAttributes;
+type FloatingDivProps = React.HTMLProps<HTMLDivElement> & FloatingDataAttributes;
+type FloatingSvgProps = React.SVGProps<SVGSVGElement> & FloatingDataAttributes;
+
 function renderElement<ElementProps, State>({
   defaultElement,
   props,
@@ -61,7 +75,7 @@ function getTransformOrigin(state: FloatingTooltipRootState) {
   }
 }
 
-function getFloatingCssVariables(state: FloatingTooltipRootState) {
+function getFloatingCssVariables(state: FloatingTooltipRootState): FloatingCssVariables {
   const arrowX = state.middlewareData.arrow?.x;
   const arrowY = state.middlewareData.arrow?.y;
 
@@ -69,7 +83,7 @@ function getFloatingCssVariables(state: FloatingTooltipRootState) {
     '--visx-tooltip-transform-origin': getTransformOrigin(state),
     '--visx-tooltip-arrow-x': arrowX == null ? undefined : `${arrowX}px`,
     '--visx-tooltip-arrow-y': arrowY == null ? undefined : `${arrowY}px`,
-  } as React.CSSProperties;
+  };
 }
 
 function getPortalRoot(container: FloatingTooltipPortalProps['container']) {
@@ -133,13 +147,13 @@ function Trigger({ disabled = false, render }: FloatingTooltipTriggerProps) {
     side: state.side,
     align: state.align,
   };
-  const referenceProps = {
+  const referenceProps: FloatingReferenceProps = {
     'aria-disabled': disabled || undefined,
     'data-disabled': disabled ? '' : undefined,
     'data-state': state.open ? 'open' : 'closed',
     'data-visx-tooltip-trigger': '',
     ref: setTriggerReference,
-  } as React.HTMLProps<Element>;
+  };
   const triggerProps = disabled ? referenceProps : state.getReferenceProps(referenceProps);
 
   if (typeof render === 'function') return render(triggerProps, triggerState);
@@ -151,7 +165,7 @@ function Portal({ children, container, disabled = false }: FloatingTooltipPortal
   const state = useFloatingTooltipContext('FloatingTooltip.Portal');
 
   if (!state.mounted) return null;
-  if (disabled) return <>{children}</>;
+  if (disabled) return children;
 
   return (
     <FloatingPortal root={getPortalRoot(container) as FloatingUiPortalProps['root']}>
@@ -160,19 +174,13 @@ function Portal({ children, container, disabled = false }: FloatingTooltipPortal
   );
 }
 
-function Positioner({
-  children,
-  id,
-  render,
-  style,
-  ...restProps
-}: FloatingTooltipPositionerProps) {
+function Positioner({ children, id, render, style, ...restProps }: FloatingTooltipPositionerProps) {
   const state = useFloatingTooltipContext('FloatingTooltip.Positioner');
 
   if (!state.mounted) return null;
 
   const anchorHidden = Boolean(state.middlewareData.hide?.referenceHidden);
-  const positionerProps = state.getFloatingProps({
+  const basePositionerProps: FloatingDivProps = {
     ...restProps,
     children,
     'data-anchor-hidden': anchorHidden ? '' : undefined,
@@ -187,7 +195,8 @@ function Positioner({
       ...getFloatingCssVariables(state),
       ...style,
     },
-  } as React.HTMLProps<HTMLDivElement>);
+  };
+  const positionerProps = state.getFloatingProps(basePositionerProps);
 
   return renderElement<React.HTMLProps<HTMLDivElement>, FloatingTooltipPositionerState>({
     defaultElement: <div />,
@@ -202,12 +211,12 @@ function Content({ children, render, ...restProps }: FloatingTooltipContentProps
 
   if (!state.mounted) return null;
 
-  const contentProps = {
+  const contentProps: FloatingDivProps = {
     ...restProps,
     children,
     'data-state': state.open ? 'open' : 'closed',
     'data-visx-tooltip-content': '',
-  } as React.HTMLProps<HTMLDivElement>;
+  };
 
   return renderElement<React.HTMLProps<HTMLDivElement>, FloatingTooltipContentState>({
     defaultElement: <div />,
@@ -229,11 +238,12 @@ function Arrow({
   if (!state.mounted) return null;
 
   if (render) {
-    const arrowProps = state.getArrowProps({
+    const baseArrowProps: FloatingSvgProps = {
       ...restProps,
       'data-visx-tooltip-arrow': '',
       ref: state.arrowRef,
-    } as React.SVGProps<SVGSVGElement>);
+    };
+    const arrowProps = state.getArrowProps(baseArrowProps);
 
     return renderElement<React.SVGProps<SVGSVGElement>, FloatingTooltipArrowState>({
       defaultElement: <svg />,

--- a/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
+++ b/packages/visx-tooltip/src/floating/FloatingTooltip.tsx
@@ -228,8 +228,9 @@ function Content({ children, render, ...restProps }: FloatingTooltipContentProps
 
 function Arrow({
   height = 7,
-  padding,
+  padding: _padding,
   render,
+  tipRadius = 0,
   width = 14,
   ...restProps
 }: FloatingTooltipArrowProps) {
@@ -240,8 +241,10 @@ function Arrow({
   if (render) {
     const baseArrowProps: FloatingSvgProps = {
       ...restProps,
+      height,
       'data-visx-tooltip-arrow': '',
       ref: state.arrowRef,
+      width,
     };
     const arrowProps = state.getArrowProps(baseArrowProps);
 
@@ -261,8 +264,7 @@ function Arrow({
       context={state.context}
       width={width}
       height={height}
-      tipRadius={0}
-      strokeWidth={padding}
+      tipRadius={tipRadius}
     />
   );
 }

--- a/packages/visx-tooltip/src/floating/anchors.ts
+++ b/packages/visx-tooltip/src/floating/anchors.ts
@@ -1,0 +1,127 @@
+import type { ReferenceElement } from '@floating-ui/react';
+import type { TooltipAnchor, TooltipVirtualElement } from './types';
+
+type MatrixLike = {
+  a?: number;
+  b?: number;
+  c?: number;
+  d?: number;
+  e?: number;
+  f?: number;
+};
+
+type SvgPointLike = {
+  x: number;
+  y: number;
+  matrixTransform(matrix: MatrixLike): { x: number; y: number };
+};
+
+function createRect(left: number, top: number, width = 0, height = 0): DOMRect | ClientRect {
+  if (typeof DOMRect === 'function') {
+    return new DOMRect(left, top, width, height);
+  }
+
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+  } as DOMRect;
+}
+
+function createPointVirtualElement(
+  x: number,
+  y: number,
+  contextElement?: Element | null,
+): TooltipVirtualElement {
+  return {
+    getBoundingClientRect: () => createRect(x, y),
+    contextElement: contextElement ?? undefined,
+  };
+}
+
+function getScrollX() {
+  return window.scrollX || window.pageXOffset || 0;
+}
+
+function getScrollY() {
+  return window.scrollY || window.pageYOffset || 0;
+}
+
+function isSvgSvgElement(element: SVGSVGElement | SVGGraphicsElement): element is SVGSVGElement {
+  return element.ownerSVGElement == null;
+}
+
+function getSvgPointReference(
+  x: number,
+  y: number,
+  svg: SVGSVGElement | SVGGraphicsElement,
+): TooltipVirtualElement {
+  return {
+    getBoundingClientRect: () => {
+      const ownerSvg = isSvgSvgElement(svg) ? svg : svg.ownerSVGElement;
+      const createSVGPoint = ownerSvg?.createSVGPoint?.bind(ownerSvg);
+      const getScreenCTM = svg.getScreenCTM?.bind(svg) ?? ownerSvg?.getScreenCTM?.bind(ownerSvg);
+      const screenCTM = getScreenCTM?.();
+
+      if (createSVGPoint && screenCTM) {
+        const point = createSVGPoint() as SvgPointLike;
+        point.x = x;
+        point.y = y;
+        const transformed = point.matrixTransform(screenCTM);
+        return createRect(transformed.x, transformed.y);
+      }
+
+      const bounds = svg.getBoundingClientRect();
+      return createRect(bounds.left + x, bounds.top + y);
+    },
+    contextElement: svg,
+  };
+}
+
+export function getTooltipAnchorReference(anchor: TooltipAnchor | null | undefined) {
+  if (!anchor) return null;
+
+  switch (anchor.type) {
+    case 'element':
+      return anchor.element as ReferenceElement | null;
+
+    case 'point': {
+      const x = anchor.coordinateSpace === 'page' ? anchor.x - getScrollX() : anchor.x;
+      const y = anchor.coordinateSpace === 'page' ? anchor.y - getScrollY() : anchor.y;
+      return createPointVirtualElement(x, y) as ReferenceElement;
+    }
+
+    case 'container-point': {
+      if (!anchor.container) return null;
+
+      const container = anchor.container;
+      return {
+        getBoundingClientRect: () => {
+          const bounds = container.getBoundingClientRect();
+          return createRect(bounds.left + anchor.x, bounds.top + anchor.y);
+        },
+        contextElement: container,
+      } as ReferenceElement;
+    }
+
+    case 'svg-point':
+      return anchor.svg ? (getSvgPointReference(anchor.x, anchor.y, anchor.svg) as ReferenceElement) : null;
+
+    case 'rect':
+      return {
+        getBoundingClientRect: anchor.getRect,
+        contextElement: anchor.contextElement ?? undefined,
+      } as ReferenceElement;
+
+    case 'virtual':
+      return anchor.element as ReferenceElement;
+
+    default:
+      return null;
+  }
+}

--- a/packages/visx-tooltip/src/floating/anchors.ts
+++ b/packages/visx-tooltip/src/floating/anchors.ts
@@ -21,7 +21,7 @@ function createRect(left: number, top: number, width = 0, height = 0): DOMRect |
     return new DOMRect(left, top, width, height);
   }
 
-  return {
+  const rect: DOMRect = {
     x: left,
     y: top,
     left,
@@ -30,7 +30,19 @@ function createRect(left: number, top: number, width = 0, height = 0): DOMRect |
     height,
     right: left + width,
     bottom: top + height,
-  } as DOMRect;
+    toJSON: () => ({
+      x: left,
+      y: top,
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    }),
+  };
+
+  return rect;
 }
 
 function createPointVirtualElement(
@@ -83,43 +95,50 @@ function getSvgPointReference(
   };
 }
 
-export function getTooltipAnchorReference(anchor: TooltipAnchor | null | undefined) {
+export function getTooltipAnchorReference(
+  anchor: TooltipAnchor | null | undefined,
+): ReferenceElement | null {
   if (!anchor) return null;
 
   switch (anchor.type) {
     case 'element':
-      return anchor.element as ReferenceElement | null;
+      return anchor.element;
 
     case 'point': {
       const x = anchor.coordinateSpace === 'page' ? anchor.x - getScrollX() : anchor.x;
       const y = anchor.coordinateSpace === 'page' ? anchor.y - getScrollY() : anchor.y;
-      return createPointVirtualElement(x, y) as ReferenceElement;
+      return createPointVirtualElement(x, y);
     }
 
     case 'container-point': {
       if (!anchor.container) return null;
 
-      const container = anchor.container;
-      return {
+      const { container } = anchor;
+      const reference: TooltipVirtualElement = {
         getBoundingClientRect: () => {
           const bounds = container.getBoundingClientRect();
           return createRect(bounds.left + anchor.x, bounds.top + anchor.y);
         },
         contextElement: container,
-      } as ReferenceElement;
+      };
+
+      return reference;
     }
 
     case 'svg-point':
-      return anchor.svg ? (getSvgPointReference(anchor.x, anchor.y, anchor.svg) as ReferenceElement) : null;
+      return anchor.svg ? getSvgPointReference(anchor.x, anchor.y, anchor.svg) : null;
 
-    case 'rect':
-      return {
+    case 'rect': {
+      const reference: TooltipVirtualElement = {
         getBoundingClientRect: anchor.getRect,
         contextElement: anchor.contextElement ?? undefined,
-      } as ReferenceElement;
+      };
+
+      return reference;
+    }
 
     case 'virtual':
-      return anchor.element as ReferenceElement;
+      return anchor.element;
 
     default:
       return null;

--- a/packages/visx-tooltip/src/floating/context.tsx
+++ b/packages/visx-tooltip/src/floating/context.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext } from 'react';
+import type { FloatingTooltipRootState } from './types';
+
+const FloatingTooltipContext = createContext<FloatingTooltipRootState<any> | null>(null);
+
+export type FloatingTooltipContextProviderProps = {
+  children: React.ReactNode;
+  value: FloatingTooltipRootState<any>;
+};
+
+export function FloatingTooltipContextProvider({
+  children,
+  value,
+}: FloatingTooltipContextProviderProps) {
+  return (
+    <FloatingTooltipContext.Provider value={value}>{children}</FloatingTooltipContext.Provider>
+  );
+}
+
+export function useFloatingTooltipContext(componentName: string) {
+  const context = useContext(FloatingTooltipContext);
+
+  if (!context) {
+    throw new Error(`${componentName} must be rendered inside FloatingTooltip.Root.`);
+  }
+
+  return context;
+}

--- a/packages/visx-tooltip/src/floating/index.ts
+++ b/packages/visx-tooltip/src/floating/index.ts
@@ -8,10 +8,7 @@ export { default as useChartTooltip } from './useChartTooltip';
 export { default as useFloatingTooltip } from './useFloatingTooltip';
 export { buildFloatingTooltipMiddleware } from './middleware';
 
-export type {
-  ChartTooltipControlledProps,
-  ChartTooltipProps,
-} from './ChartTooltip';
+export type { ChartTooltipControlledProps, ChartTooltipProps } from './ChartTooltip';
 
 export type {
   ChartTooltipConfig,

--- a/packages/visx-tooltip/src/floating/index.ts
+++ b/packages/visx-tooltip/src/floating/index.ts
@@ -1,0 +1,36 @@
+'use client';
+
+export { getTooltipAnchorReference } from './anchors';
+
+export type {
+  FloatingTooltipArrowOptions,
+  FloatingTooltipArrowProps,
+  FloatingTooltipArrowState,
+  FloatingTooltipBoundary,
+  FloatingTooltipContentProps,
+  FloatingTooltipContentState,
+  FloatingTooltipFlipOptions,
+  FloatingTooltipHideOptions,
+  FloatingTooltipInteractions,
+  FloatingTooltipOffset,
+  FloatingTooltipOpenChangeDetails,
+  FloatingTooltipPadding,
+  FloatingTooltipPortalProps,
+  FloatingTooltipPositionerProps,
+  FloatingTooltipPositionerState,
+  FloatingTooltipProviderProps,
+  FloatingTooltipRootProps,
+  FloatingTooltipRootState,
+  FloatingTooltipShiftOptions,
+  FloatingTooltipSizeOptions,
+  FloatingTooltipTriggerProps,
+  FloatingTooltipTriggerState,
+  TooltipAlign,
+  TooltipAnchor,
+  TooltipCoordinateSpace,
+  TooltipPlacement,
+  TooltipSide,
+  TooltipVirtualElement,
+  UseFloatingTooltipOptions,
+  UseFloatingTooltipReturn,
+} from './types';

--- a/packages/visx-tooltip/src/floating/index.ts
+++ b/packages/visx-tooltip/src/floating/index.ts
@@ -1,9 +1,20 @@
 'use client';
 
 export { getTooltipAnchorReference } from './anchors';
+export { default as ChartTooltipContent } from './ChartTooltipContent';
 export { default as FloatingTooltip } from './FloatingTooltip';
 export { default as useFloatingTooltip } from './useFloatingTooltip';
 export { buildFloatingTooltipMiddleware } from './middleware';
+
+export type {
+  ChartTooltipConfig,
+  ChartTooltipContentProps,
+  ChartTooltipIndicator,
+  ChartTooltipItem,
+  ChartTooltipItemRenderParams,
+  ChartTooltipLabelRenderParams,
+  ChartTooltipValueRenderParams,
+} from './ChartTooltipContent';
 
 export type {
   FloatingTooltipArrowOptions,

--- a/packages/visx-tooltip/src/floating/index.ts
+++ b/packages/visx-tooltip/src/floating/index.ts
@@ -1,6 +1,9 @@
 'use client';
 
 export { getTooltipAnchorReference } from './anchors';
+export { default as FloatingTooltip } from './FloatingTooltip';
+export { default as useFloatingTooltip } from './useFloatingTooltip';
+export { buildFloatingTooltipMiddleware } from './middleware';
 
 export type {
   FloatingTooltipArrowOptions,

--- a/packages/visx-tooltip/src/floating/index.ts
+++ b/packages/visx-tooltip/src/floating/index.ts
@@ -1,10 +1,17 @@
 'use client';
 
 export { getTooltipAnchorReference } from './anchors';
+export { default as ChartTooltip } from './ChartTooltip';
 export { default as ChartTooltipContent } from './ChartTooltipContent';
 export { default as FloatingTooltip } from './FloatingTooltip';
+export { default as useChartTooltip } from './useChartTooltip';
 export { default as useFloatingTooltip } from './useFloatingTooltip';
 export { buildFloatingTooltipMiddleware } from './middleware';
+
+export type {
+  ChartTooltipControlledProps,
+  ChartTooltipProps,
+} from './ChartTooltip';
 
 export type {
   ChartTooltipConfig,
@@ -15,6 +22,13 @@ export type {
   ChartTooltipLabelRenderParams,
   ChartTooltipValueRenderParams,
 } from './ChartTooltipContent';
+
+export type {
+  ChartTooltipLocalPoint,
+  ChartTooltipSvgPoint,
+  UseChartTooltipOptions,
+  UseChartTooltipReturn,
+} from './useChartTooltip';
 
 export type {
   FloatingTooltipArrowOptions,

--- a/packages/visx-tooltip/src/floating/middleware.ts
+++ b/packages/visx-tooltip/src/floating/middleware.ts
@@ -1,0 +1,104 @@
+import {
+  arrow as arrowMiddleware,
+  flip as flipMiddleware,
+  hide as hideMiddleware,
+  offset as offsetMiddleware,
+  shift as shiftMiddleware,
+  size as sizeMiddleware,
+  type Middleware,
+} from '@floating-ui/react';
+import type { UseFloatingTooltipOptions } from './types';
+
+type BuildFloatingTooltipMiddlewareOptions = Pick<
+  UseFloatingTooltipOptions,
+  | 'arrow'
+  | 'collisionBoundary'
+  | 'collisionPadding'
+  | 'flip'
+  | 'hideWhenDetached'
+  | 'middleware'
+  | 'middlewareMode'
+  | 'offset'
+  | 'shift'
+  | 'size'
+> & {
+  arrowElement?: Element | null;
+};
+
+function getCollisionOptions({
+  collisionBoundary,
+  collisionPadding,
+}: Pick<BuildFloatingTooltipMiddlewareOptions, 'collisionBoundary' | 'collisionPadding'>) {
+  return {
+    boundary: collisionBoundary,
+    padding: collisionPadding,
+  };
+}
+
+export function buildFloatingTooltipMiddleware({
+  arrow,
+  arrowElement,
+  collisionBoundary,
+  collisionPadding,
+  flip = true,
+  hideWhenDetached = false,
+  middleware,
+  middlewareMode = 'append',
+  offset = 0,
+  shift = true,
+  size = false,
+}: BuildFloatingTooltipMiddlewareOptions = {}) {
+  const callerMiddleware = middleware ?? [];
+
+  if (middlewareMode === 'replace') return callerMiddleware;
+
+  const collisionOptions = getCollisionOptions({ collisionBoundary, collisionPadding });
+  const builtInMiddleware: Middleware[] = [offsetMiddleware(offset)];
+
+  if (flip) {
+    builtInMiddleware.push(
+      flipMiddleware({
+        ...collisionOptions,
+        ...(typeof flip === 'object' ? flip : null),
+      }),
+    );
+  }
+
+  if (shift) {
+    builtInMiddleware.push(
+      shiftMiddleware({
+        ...collisionOptions,
+        ...(typeof shift === 'object' ? shift : null),
+      }),
+    );
+  }
+
+  if (size) {
+    builtInMiddleware.push(
+      sizeMiddleware({
+        ...collisionOptions,
+        ...(typeof size === 'object' ? size : null),
+      }),
+    );
+  }
+
+  if (hideWhenDetached) {
+    builtInMiddleware.push(
+      hideMiddleware({
+        ...collisionOptions,
+        ...(typeof hideWhenDetached === 'object' ? hideWhenDetached : null),
+      }),
+    );
+  }
+
+  if (arrow && arrowElement) {
+    builtInMiddleware.push(
+      arrowMiddleware({
+        element: arrowElement,
+        padding: typeof arrow === 'object' ? arrow.padding : undefined,
+      }),
+    );
+  }
+
+  return [...builtInMiddleware, ...callerMiddleware];
+}

--- a/packages/visx-tooltip/src/floating/types.ts
+++ b/packages/visx-tooltip/src/floating/types.ts
@@ -15,6 +15,7 @@ import type {
   SizeOptions,
   Strategy,
   UseDismissProps,
+  FloatingArrowProps as FloatingUiArrowProps,
   UseFloatingOptions,
   UseFloatingReturn,
   UseFocusProps,
@@ -183,10 +184,11 @@ export type FloatingTooltipContentProps = React.HTMLAttributes<HTMLDivElement> &
 
 export type FloatingTooltipArrowState = FloatingTooltipRootState;
 
-export type FloatingTooltipArrowProps = Omit<React.SVGProps<SVGSVGElement>, 'ref'> & {
-  width?: number;
-  height?: number;
-  padding?: number;
+export type FloatingTooltipArrowProps = Omit<
+  FloatingUiArrowProps,
+  'context' | 'padding' | 'ref'
+> & {
+  padding?: never;
   render?:
     | React.ReactElement
     | ((

--- a/packages/visx-tooltip/src/floating/types.ts
+++ b/packages/visx-tooltip/src/floating/types.ts
@@ -167,6 +167,7 @@ export type FloatingTooltipPortalProps = {
 export type FloatingTooltipPositionerState = FloatingTooltipRootState;
 
 export type FloatingTooltipPositionerProps = React.HTMLAttributes<HTMLDivElement> & {
+  'data-testid'?: string;
   render?:
     | React.ReactElement
     | ((

--- a/packages/visx-tooltip/src/floating/types.ts
+++ b/packages/visx-tooltip/src/floating/types.ts
@@ -1,0 +1,201 @@
+import type React from 'react';
+import type {
+  Boundary,
+  Delay,
+  FlipOptions,
+  HideOptions,
+  Middleware,
+  MiddlewareData,
+  OffsetOptions,
+  OpenChangeReason,
+  Padding,
+  Placement,
+  ReferenceElement,
+  ShiftOptions,
+  SizeOptions,
+  Strategy,
+  UseDismissProps,
+  UseFloatingOptions,
+  UseFloatingReturn,
+  UseFocusProps,
+  UseHoverProps,
+  UseRoleProps,
+  VirtualElement,
+} from '@floating-ui/react';
+
+export type TooltipPlacement = Placement;
+export type TooltipSide = 'top' | 'right' | 'bottom' | 'left';
+export type TooltipAlign = 'start' | 'center' | 'end';
+export type TooltipCoordinateSpace = 'client' | 'page';
+export type TooltipVirtualElement = VirtualElement;
+
+export type TooltipAnchor =
+  | { type: 'element'; element: Element | null }
+  | { type: 'point'; x: number; y: number; coordinateSpace?: TooltipCoordinateSpace }
+  | { type: 'container-point'; x: number; y: number; container: Element | null }
+  | { type: 'svg-point'; x: number; y: number; svg: SVGSVGElement | SVGGraphicsElement | null }
+  | { type: 'rect'; getRect: () => DOMRect | ClientRect; contextElement?: Element | null }
+  | { type: 'virtual'; element: TooltipVirtualElement };
+
+export type FloatingTooltipOffset = OffsetOptions;
+export type FloatingTooltipPadding = Padding;
+export type FloatingTooltipBoundary = Boundary;
+export type FloatingTooltipFlipOptions = FlipOptions;
+export type FloatingTooltipShiftOptions = ShiftOptions;
+export type FloatingTooltipSizeOptions = SizeOptions;
+export type FloatingTooltipHideOptions = HideOptions;
+
+export type FloatingTooltipArrowOptions = {
+  padding?: FloatingTooltipPadding;
+};
+
+export type FloatingTooltipInteractions =
+  | boolean
+  | {
+      hover?: boolean | UseHoverProps;
+      focus?: boolean | UseFocusProps;
+      dismiss?: boolean | UseDismissProps;
+      role?: boolean | UseRoleProps;
+    };
+
+export type FloatingTooltipOpenChangeDetails<TData = unknown> = {
+  data: TData | undefined;
+  anchor: TooltipAnchor | null;
+  event?: Event;
+  reason?: OpenChangeReason;
+};
+
+export type UseFloatingTooltipOptions<TData = unknown> = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (
+    open: boolean,
+    details: FloatingTooltipOpenChangeDetails<TData>,
+  ) => void;
+
+  anchor?: TooltipAnchor | null;
+  defaultAnchor?: TooltipAnchor | null;
+  data?: TData;
+  defaultData?: TData;
+
+  placement?: TooltipPlacement;
+  strategy?: Strategy;
+  offset?: number | FloatingTooltipOffset;
+  collisionPadding?: FloatingTooltipPadding;
+  collisionBoundary?: FloatingTooltipBoundary;
+  flip?: boolean | FloatingTooltipFlipOptions;
+  shift?: boolean | FloatingTooltipShiftOptions;
+  size?: boolean | FloatingTooltipSizeOptions;
+  hideWhenDetached?: boolean | FloatingTooltipHideOptions;
+  arrow?: boolean | FloatingTooltipArrowOptions;
+  trackCursorAxis?: 'none' | 'x' | 'y' | 'both';
+
+  interactions?: FloatingTooltipInteractions;
+  middleware?: Middleware[];
+  middlewareMode?: 'append' | 'replace';
+  whileElementsMounted?: UseFloatingOptions['whileElementsMounted'];
+
+  id?: string;
+  role?: 'tooltip' | 'label' | 'description';
+  disabled?: boolean;
+};
+
+export type UseFloatingTooltipReturn<TData = unknown> = {
+  open: boolean;
+  mounted: boolean;
+  data: TData | undefined;
+  anchor: TooltipAnchor | null;
+  placement: TooltipPlacement;
+  side: TooltipSide;
+  align: TooltipAlign;
+  strategy: Strategy;
+  x: number | null;
+  y: number | null;
+  floatingStyles: React.CSSProperties;
+  middlewareData: MiddlewareData;
+
+  refs: UseFloatingReturn<ReferenceElement>['refs'];
+  context: UseFloatingReturn<ReferenceElement>['context'];
+  arrowRef: React.RefCallback<SVGSVGElement>;
+
+  setAnchor: (anchor: TooltipAnchor | null) => void;
+  setData: (data: TData | undefined) => void;
+  update: () => void;
+  openTooltip: (data?: TData, anchor?: TooltipAnchor | null) => void;
+  closeTooltip: () => void;
+
+  getReferenceProps: <TProps extends React.HTMLProps<Element>>(props?: TProps) => TProps;
+  getFloatingProps: <TProps extends React.HTMLProps<HTMLElement>>(props?: TProps) => TProps;
+  getArrowProps: <TProps extends React.SVGProps<SVGSVGElement>>(props?: TProps) => TProps;
+};
+
+export type FloatingTooltipProviderProps = {
+  delay?: Delay;
+  closeDelay?: number;
+  skipDelay?: number;
+  children: React.ReactNode;
+};
+
+export type FloatingTooltipRootState<TData = unknown> = UseFloatingTooltipReturn<TData>;
+
+export type FloatingTooltipRootProps<TData = unknown> = UseFloatingTooltipOptions<TData> & {
+  forceMount?: boolean;
+  children:
+    | React.ReactNode
+    | ((state: FloatingTooltipRootState<TData>) => React.ReactNode);
+};
+
+export type FloatingTooltipTriggerState = {
+  open: boolean;
+  side: TooltipSide;
+  align: TooltipAlign;
+};
+
+export type FloatingTooltipTriggerProps = {
+  render:
+    | React.ReactElement
+    | ((props: React.HTMLProps<Element>, state: FloatingTooltipTriggerState) => React.ReactElement);
+  disabled?: boolean;
+};
+
+export type FloatingTooltipPortalProps = {
+  container?: HTMLElement | ShadowRoot | React.RefObject<HTMLElement | ShadowRoot | null> | null;
+  disabled?: boolean;
+  children: React.ReactNode;
+};
+
+export type FloatingTooltipPositionerState = FloatingTooltipRootState;
+
+export type FloatingTooltipPositionerProps = React.HTMLAttributes<HTMLDivElement> & {
+  render?:
+    | React.ReactElement
+    | ((
+        props: React.HTMLProps<HTMLDivElement>,
+        state: FloatingTooltipPositionerState,
+      ) => React.ReactElement);
+};
+
+export type FloatingTooltipContentState = FloatingTooltipRootState;
+
+export type FloatingTooltipContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  render?:
+    | React.ReactElement
+    | ((
+        props: React.HTMLProps<HTMLDivElement>,
+        state: FloatingTooltipContentState,
+      ) => React.ReactElement);
+};
+
+export type FloatingTooltipArrowState = FloatingTooltipRootState;
+
+export type FloatingTooltipArrowProps = Omit<React.SVGProps<SVGSVGElement>, 'ref'> & {
+  width?: number;
+  height?: number;
+  padding?: number;
+  render?:
+    | React.ReactElement
+    | ((
+        props: React.SVGProps<SVGSVGElement>,
+        state: FloatingTooltipArrowState,
+      ) => React.ReactElement);
+};

--- a/packages/visx-tooltip/src/floating/types.ts
+++ b/packages/visx-tooltip/src/floating/types.ts
@@ -68,10 +68,7 @@ export type FloatingTooltipOpenChangeDetails<TData = unknown> = {
 export type UseFloatingTooltipOptions<TData = unknown> = {
   open?: boolean;
   defaultOpen?: boolean;
-  onOpenChange?: (
-    open: boolean,
-    details: FloatingTooltipOpenChangeDetails<TData>,
-  ) => void;
+  onOpenChange?: (open: boolean, details: FloatingTooltipOpenChangeDetails<TData>) => void;
 
   anchor?: TooltipAnchor | null;
   defaultAnchor?: TooltipAnchor | null;
@@ -139,9 +136,7 @@ export type FloatingTooltipRootState<TData = unknown> = UseFloatingTooltipReturn
 
 export type FloatingTooltipRootProps<TData = unknown> = UseFloatingTooltipOptions<TData> & {
   forceMount?: boolean;
-  children:
-    | React.ReactNode
-    | ((state: FloatingTooltipRootState<TData>) => React.ReactNode);
+  children: React.ReactNode | ((state: FloatingTooltipRootState<TData>) => React.ReactNode);
 };
 
 export type FloatingTooltipTriggerState = {

--- a/packages/visx-tooltip/src/floating/types.ts
+++ b/packages/visx-tooltip/src/floating/types.ts
@@ -88,7 +88,6 @@ export type UseFloatingTooltipOptions<TData = unknown> = {
   size?: boolean | FloatingTooltipSizeOptions;
   hideWhenDetached?: boolean | FloatingTooltipHideOptions;
   arrow?: boolean | FloatingTooltipArrowOptions;
-  trackCursorAxis?: 'none' | 'x' | 'y' | 'both';
 
   interactions?: FloatingTooltipInteractions;
   middleware?: Middleware[];
@@ -96,7 +95,7 @@ export type UseFloatingTooltipOptions<TData = unknown> = {
   whileElementsMounted?: UseFloatingOptions['whileElementsMounted'];
 
   id?: string;
-  role?: 'tooltip' | 'label' | 'description';
+  role?: 'tooltip' | 'label';
   disabled?: boolean;
 };
 

--- a/packages/visx-tooltip/src/floating/useChartTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useChartTooltip.ts
@@ -59,7 +59,7 @@ function isTooltipAnchor(
 }
 
 function isSvgElement(element: Element | null): element is SVGSVGElement | SVGGraphicsElement {
-  return Boolean(element && element.namespaceURI === 'http://www.w3.org/2000/svg');
+  return element?.namespaceURI === 'http://www.w3.org/2000/svg';
 }
 
 export default function useChartTooltip<Datum = unknown>({

--- a/packages/visx-tooltip/src/floating/useChartTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useChartTooltip.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import type {
+  ChartTooltipItem,
+  ChartTooltipProps,
+  ChartTooltipControlledProps,
+} from './ChartTooltip';
+import type {
+  FloatingTooltipOffset,
+  TooltipAnchor,
+  TooltipPlacement,
+  UseFloatingTooltipOptions,
+} from './types';
+
+export type ChartTooltipLocalPoint = {
+  x: number;
+  y: number;
+};
+
+export type ChartTooltipSvgPoint = {
+  type: 'svg-point';
+  x: number;
+  y: number;
+};
+
+export type UseChartTooltipOptions<Datum = unknown> = {
+  defaultOpen?: boolean;
+  defaultItems?: ChartTooltipItem<Datum>[];
+  defaultAnchor?: TooltipAnchor | null;
+  placement?: TooltipPlacement;
+  offset?: number | FloatingTooltipOffset;
+  hideDelay?: number;
+  container?: Element | null;
+  floatingOptions?: Omit<
+    UseFloatingTooltipOptions<ChartTooltipItem<Datum>[]>,
+    'open' | 'defaultOpen' | 'data' | 'defaultData' | 'anchor' | 'defaultAnchor'
+  >;
+};
+
+export type UseChartTooltipReturn<Datum = unknown> = {
+  open: boolean;
+  items: ChartTooltipItem<Datum>[];
+  anchor: TooltipAnchor | null;
+  containerRef: React.RefCallback<HTMLElement | SVGElement>;
+  show: (args: {
+    anchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint;
+    items: ChartTooltipItem<Datum>[];
+  }) => void;
+  hide: () => void;
+  update: (args: Partial<{ anchor: TooltipAnchor; items: ChartTooltipItem<Datum>[] }>) => void;
+  tooltipProps: ChartTooltipControlledProps<Datum> &
+    Pick<ChartTooltipProps<Datum>, 'floatingOptions' | 'offset' | 'placement'>;
+};
+
+function isTooltipAnchor(anchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint) {
+  return 'type' in anchor && (anchor.type !== 'svg-point' || 'svg' in anchor);
+}
+
+function isSvgElement(element: Element | null): element is SVGSVGElement | SVGGraphicsElement {
+  return Boolean(element && element.namespaceURI === 'http://www.w3.org/2000/svg');
+}
+
+export default function useChartTooltip<Datum = unknown>({
+  container,
+  defaultAnchor = null,
+  defaultItems = [],
+  defaultOpen = false,
+  floatingOptions,
+  hideDelay,
+  offset,
+  placement,
+}: UseChartTooltipOptions<Datum> = {}): UseChartTooltipReturn<Datum> {
+  const [open, setOpen] = useState(defaultOpen);
+  const [items, setItems] = useState(defaultItems);
+  const [anchor, setAnchor] = useState<TooltipAnchor | null>(defaultAnchor);
+  const [containerElement, setContainerElement] = useState<HTMLElement | SVGElement | null>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const latestContainer = container ?? containerElement;
+
+  const clearHideTimeout = useCallback(() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearHideTimeout, [clearHideTimeout]);
+
+  const containerRef = useCallback((node: HTMLElement | SVGElement | null) => {
+    setContainerElement(node);
+  }, []);
+
+  const resolveAnchor = useCallback(
+    (nextAnchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint): TooltipAnchor => {
+      if (isTooltipAnchor(nextAnchor)) return nextAnchor as TooltipAnchor;
+
+      if ('type' in nextAnchor && nextAnchor.type === 'svg-point') {
+        return {
+          type: 'svg-point',
+          x: nextAnchor.x,
+          y: nextAnchor.y,
+          svg: isSvgElement(latestContainer) ? latestContainer : null,
+        };
+      }
+
+      return {
+        type: 'container-point',
+        x: nextAnchor.x,
+        y: nextAnchor.y,
+        container: latestContainer,
+      };
+    },
+    [latestContainer],
+  );
+
+  const show = useCallback(
+    ({
+      anchor: nextAnchor,
+      items: nextItems,
+    }: {
+      anchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint;
+      items: ChartTooltipItem<Datum>[];
+    }) => {
+      clearHideTimeout();
+      setAnchor(resolveAnchor(nextAnchor));
+      setItems(nextItems);
+      setOpen(true);
+    },
+    [clearHideTimeout, resolveAnchor],
+  );
+
+  const hide = useCallback(() => {
+    clearHideTimeout();
+
+    if (hideDelay == null) {
+      setOpen(false);
+      return;
+    }
+
+    hideTimeoutRef.current = setTimeout(() => {
+      setOpen(false);
+      hideTimeoutRef.current = null;
+    }, hideDelay);
+  }, [clearHideTimeout, hideDelay]);
+
+  const update = useCallback(
+    ({
+      anchor: nextAnchor,
+      items: nextItems,
+    }: Partial<{ anchor: TooltipAnchor; items: ChartTooltipItem<Datum>[] }>) => {
+      if (nextAnchor !== undefined) setAnchor(nextAnchor);
+      if (nextItems !== undefined) setItems(nextItems);
+    },
+    [],
+  );
+
+  const tooltipProps = useMemo(
+    () => ({
+      open,
+      anchor,
+      items,
+      floatingOptions,
+      offset,
+      placement,
+    }),
+    [anchor, floatingOptions, items, offset, open, placement],
+  );
+
+  return {
+    open,
+    items,
+    anchor,
+    containerRef,
+    show,
+    hide,
+    update,
+    tooltipProps,
+  };
+}

--- a/packages/visx-tooltip/src/floating/useChartTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useChartTooltip.ts
@@ -18,7 +18,7 @@ export type ChartTooltipLocalPoint = {
 };
 
 export type ChartTooltipSvgPoint = {
-  type: 'svg-point';
+  type: 'svg-local-point';
   x: number;
   y: number;
 };
@@ -52,8 +52,10 @@ export type UseChartTooltipReturn<Datum = unknown> = {
     Pick<ChartTooltipProps<Datum>, 'floatingOptions' | 'offset' | 'placement'>;
 };
 
-function isTooltipAnchor(anchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint) {
-  return 'type' in anchor && (anchor.type !== 'svg-point' || 'svg' in anchor);
+function isTooltipAnchor(
+  anchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint,
+): anchor is TooltipAnchor {
+  return 'type' in anchor && anchor.type !== 'svg-local-point';
 }
 
 function isSvgElement(element: Element | null): element is SVGSVGElement | SVGGraphicsElement {
@@ -93,9 +95,9 @@ export default function useChartTooltip<Datum = unknown>({
 
   const resolveAnchor = useCallback(
     (nextAnchor: TooltipAnchor | ChartTooltipLocalPoint | ChartTooltipSvgPoint): TooltipAnchor => {
-      if (isTooltipAnchor(nextAnchor)) return nextAnchor as TooltipAnchor;
+      if (isTooltipAnchor(nextAnchor)) return nextAnchor;
 
-      if ('type' in nextAnchor && nextAnchor.type === 'svg-point') {
+      if ('type' in nextAnchor && nextAnchor.type === 'svg-local-point') {
         return {
           type: 'svg-point',
           x: nextAnchor.x,

--- a/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
@@ -1,0 +1,187 @@
+import { autoUpdate, useFloating } from '@floating-ui/react';
+import type { OpenChangeReason, ReferenceElement } from '@floating-ui/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getTooltipAnchorReference } from './anchors';
+import { buildFloatingTooltipMiddleware } from './middleware';
+import type {
+  FloatingTooltipOpenChangeDetails,
+  TooltipAlign,
+  TooltipAnchor,
+  TooltipSide,
+  UseFloatingTooltipOptions,
+  UseFloatingTooltipReturn,
+} from './types';
+
+function getSideAndAlign(placement: string): { side: TooltipSide; align: TooltipAlign } {
+  const [side, align = 'center'] = placement.split('-');
+
+  return {
+    side: side as TooltipSide,
+    align: align as TooltipAlign,
+  };
+}
+
+export default function useFloatingTooltip<TData = unknown>({
+  anchor: anchorProp,
+  arrow = false,
+  collisionBoundary,
+  collisionPadding,
+  data: dataProp,
+  defaultAnchor = null,
+  defaultData,
+  defaultOpen = false,
+  disabled = false,
+  flip = true,
+  hideWhenDetached = false,
+  middleware,
+  middlewareMode = 'append',
+  offset = 0,
+  onOpenChange,
+  open: openProp,
+  placement = 'top',
+  shift = true,
+  size = false,
+  strategy = 'absolute',
+  whileElementsMounted = autoUpdate,
+}: UseFloatingTooltipOptions<TData> = {}): UseFloatingTooltipReturn<TData> {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const [uncontrolledAnchor, setUncontrolledAnchor] = useState<TooltipAnchor | null>(defaultAnchor);
+  const [uncontrolledData, setUncontrolledData] = useState<TData | undefined>(defaultData);
+  const [arrowElement, setArrowElement] = useState<SVGSVGElement | null>(null);
+
+  const isOpenControlled = openProp != null;
+  const isAnchorControlled = anchorProp !== undefined;
+  const isDataControlled = dataProp !== undefined;
+
+  const open = disabled ? false : isOpenControlled ? Boolean(openProp) : uncontrolledOpen;
+  const anchor = isAnchorControlled ? anchorProp ?? null : uncontrolledAnchor;
+  const data = isDataControlled ? dataProp : uncontrolledData;
+
+  const builtMiddleware = useMemo(
+    () =>
+      buildFloatingTooltipMiddleware({
+        arrow,
+        arrowElement,
+        collisionBoundary,
+        collisionPadding,
+        flip,
+        hideWhenDetached,
+        middleware,
+        middlewareMode,
+        offset,
+        shift,
+        size,
+      }),
+    [
+      arrow,
+      arrowElement,
+      collisionBoundary,
+      collisionPadding,
+      flip,
+      hideWhenDetached,
+      middleware,
+      middlewareMode,
+      offset,
+      shift,
+      size,
+    ],
+  );
+
+  const handleOpenChange = useCallback(
+    (
+      nextOpen: boolean,
+      event?: Event,
+      reason?: OpenChangeReason,
+      details?: Partial<FloatingTooltipOpenChangeDetails<TData>>,
+    ) => {
+      if (disabled) return;
+      if (!isOpenControlled) setUncontrolledOpen(nextOpen);
+
+      onOpenChange?.(nextOpen, {
+        data,
+        anchor,
+        ...details,
+        event,
+        reason,
+      });
+    },
+    [anchor, data, disabled, isOpenControlled, onOpenChange],
+  );
+
+  const floating = useFloating<ReferenceElement>({
+    middleware: builtMiddleware,
+    onOpenChange: (nextOpen, event, reason) => handleOpenChange(nextOpen, event, reason),
+    open,
+    placement,
+    strategy,
+    whileElementsMounted,
+  });
+
+  const positionReference = useMemo(() => getTooltipAnchorReference(anchor), [anchor]);
+
+  useEffect(() => {
+    floating.refs.setPositionReference(positionReference);
+  }, [floating.refs, positionReference]);
+
+  const setAnchor = useCallback(
+    (nextAnchor: TooltipAnchor | null) => {
+      if (!isAnchorControlled) setUncontrolledAnchor(nextAnchor);
+    },
+    [isAnchorControlled],
+  );
+
+  const setData = useCallback(
+    (nextData: TData | undefined) => {
+      if (!isDataControlled) setUncontrolledData(nextData);
+    },
+    [isDataControlled],
+  );
+
+  const openTooltip = useCallback(
+    (nextData?: TData, nextAnchor?: TooltipAnchor | null) => {
+      const resolvedData = nextData === undefined ? data : nextData;
+      const resolvedAnchor = nextAnchor === undefined ? anchor : nextAnchor;
+
+      if (nextData !== undefined && !isDataControlled) setUncontrolledData(nextData);
+      if (nextAnchor !== undefined && !isAnchorControlled) setUncontrolledAnchor(nextAnchor);
+
+      handleOpenChange(true, undefined, undefined, {
+        data: resolvedData,
+        anchor: resolvedAnchor,
+      });
+    },
+    [anchor, data, handleOpenChange, isAnchorControlled, isDataControlled],
+  );
+
+  const closeTooltip = useCallback(() => {
+    handleOpenChange(false);
+  }, [handleOpenChange]);
+
+  const { align, side } = getSideAndAlign(floating.placement);
+
+  return {
+    open,
+    mounted: open,
+    data,
+    anchor,
+    placement: floating.placement,
+    side,
+    align,
+    strategy,
+    x: floating.x,
+    y: floating.y,
+    floatingStyles: floating.floatingStyles,
+    middlewareData: floating.middlewareData,
+    refs: floating.refs,
+    context: floating.context,
+    arrowRef: setArrowElement,
+    setAnchor,
+    setData,
+    update: floating.update,
+    openTooltip,
+    closeTooltip,
+    getReferenceProps: (props) => props ?? ({} as never),
+    getFloatingProps: (props) => props ?? ({} as never),
+    getArrowProps: (props) => props ?? ({} as never),
+  };
+}

--- a/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
@@ -1,6 +1,16 @@
-import { autoUpdate, useFloating } from '@floating-ui/react';
+import {
+  autoUpdate,
+  useDelayGroup,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
 import type { OpenChangeReason, ReferenceElement } from '@floating-ui/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type React from 'react';
 import { getTooltipAnchorReference } from './anchors';
 import { buildFloatingTooltipMiddleware } from './middleware';
 import type {
@@ -33,12 +43,14 @@ export default function useFloatingTooltip<TData = unknown>({
   disabled = false,
   flip = true,
   hideWhenDetached = false,
+  interactions = true,
   middleware,
   middlewareMode = 'append',
   offset = 0,
   onOpenChange,
   open: openProp,
   placement = 'top',
+  role = 'tooltip',
   shift = true,
   size = false,
   strategy = 'absolute',
@@ -117,6 +129,44 @@ export default function useFloatingTooltip<TData = unknown>({
     whileElementsMounted,
   });
 
+  const interactionOptions = typeof interactions === 'object' ? interactions : {};
+  const interactionsEnabled = interactions !== false && !disabled;
+  const hoverOptions = interactionOptions.hover;
+  const focusOptions = interactionOptions.focus;
+  const dismissOptions = interactionOptions.dismiss;
+  const roleOptions = interactionOptions.role;
+
+  const hoverEnabled = interactionsEnabled && hoverOptions !== false;
+  const focusEnabled = interactionsEnabled && focusOptions !== false;
+  const dismissEnabled = interactionsEnabled && dismissOptions !== false;
+  const roleEnabled = interactionsEnabled && roleOptions !== false && role === 'tooltip';
+  const delayGroup = useDelayGroup(floating.context, { enabled: hoverEnabled });
+
+  const hoverProps = useHover(floating.context, {
+    delay: delayGroup.delay,
+    enabled: hoverEnabled,
+    ...(typeof hoverOptions === 'object' ? hoverOptions : null),
+  });
+  const focusProps = useFocus(floating.context, {
+    enabled: focusEnabled,
+    ...(typeof focusOptions === 'object' ? focusOptions : null),
+  });
+  const dismissProps = useDismiss(floating.context, {
+    enabled: dismissEnabled,
+    ...(typeof dismissOptions === 'object' ? dismissOptions : null),
+  });
+  const roleProps = useRole(floating.context, {
+    enabled: roleEnabled,
+    role: 'tooltip',
+    ...(typeof roleOptions === 'object' ? roleOptions : null),
+  });
+  const { getFloatingProps, getReferenceProps } = useInteractions([
+    hoverProps,
+    focusProps,
+    dismissProps,
+    roleProps,
+  ]);
+
   const positionReference = useMemo(() => getTooltipAnchorReference(anchor), [anchor]);
 
   useEffect(() => {
@@ -180,8 +230,11 @@ export default function useFloatingTooltip<TData = unknown>({
     update: floating.update,
     openTooltip,
     closeTooltip,
-    getReferenceProps: (props) => props ?? ({} as never),
-    getFloatingProps: (props) => props ?? ({} as never),
-    getArrowProps: (props) => props ?? ({} as never),
+    getReferenceProps: <TProps extends React.HTMLProps<Element>>(props?: TProps) =>
+      getReferenceProps(props) as TProps,
+    getFloatingProps: <TProps extends React.HTMLProps<HTMLElement>>(props?: TProps) =>
+      getFloatingProps(props) as TProps,
+    getArrowProps: <TProps extends React.SVGProps<SVGSVGElement>>(props?: TProps) =>
+      props ?? ({} as TProps),
   };
 }

--- a/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
@@ -9,7 +9,7 @@ import {
   useRole,
 } from '@floating-ui/react';
 import type { OpenChangeReason, ReferenceElement } from '@floating-ui/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type React from 'react';
 import { getTooltipAnchorReference } from './anchors';
 import { buildFloatingTooltipMiddleware } from './middleware';
@@ -31,6 +31,28 @@ function getSideAndAlign(placement: string): { side: TooltipSide; align: Tooltip
   };
 }
 
+function getFloatingPropsWithDefaultId<TProps extends React.HTMLProps<HTMLElement>>(
+  props: TProps | undefined,
+  id: string | undefined,
+) {
+  let nextProps = props;
+
+  if (
+    nextProps &&
+    nextProps.id === undefined &&
+    Object.prototype.hasOwnProperty.call(nextProps, 'id')
+  ) {
+    const { id: _id, ...restProps } = nextProps;
+    nextProps = restProps as TProps;
+  }
+
+  if (id != null && nextProps?.id == null) {
+    return { ...nextProps, id } as TProps;
+  }
+
+  return nextProps;
+}
+
 export default function useFloatingTooltip<TData = unknown>({
   anchor: anchorProp,
   arrow = false,
@@ -43,6 +65,7 @@ export default function useFloatingTooltip<TData = unknown>({
   disabled = false,
   flip = true,
   hideWhenDetached = false,
+  id,
   interactions = true,
   middleware,
   middlewareMode = 'append',
@@ -60,6 +83,10 @@ export default function useFloatingTooltip<TData = unknown>({
   const [uncontrolledAnchor, setUncontrolledAnchor] = useState<TooltipAnchor | null>(defaultAnchor);
   const [uncontrolledData, setUncontrolledData] = useState<TData | undefined>(defaultData);
   const [arrowElement, setArrowElement] = useState<SVGSVGElement | null>(null);
+  const [domReference, setDomReference] = useState<ReferenceElement | null>(null);
+  const [fallbackPositionReference, setFallbackPositionReference] =
+    useState<ReferenceElement | null>(null);
+  const hasManagedPositionReferenceRef = useRef(false);
 
   const isOpenControlled = openProp != null;
   const isAnchorControlled = anchorProp !== undefined;
@@ -139,7 +166,7 @@ export default function useFloatingTooltip<TData = unknown>({
   const hoverEnabled = interactionsEnabled && hoverOptions !== false;
   const focusEnabled = interactionsEnabled && focusOptions !== false;
   const dismissEnabled = interactionsEnabled && dismissOptions !== false;
-  const roleEnabled = interactionsEnabled && roleOptions !== false && role === 'tooltip';
+  const roleEnabled = interactionsEnabled && roleOptions !== false;
   const delayGroup = useDelayGroup(floating.context, { enabled: hoverEnabled });
 
   const hoverProps = useHover(floating.context, {
@@ -157,7 +184,7 @@ export default function useFloatingTooltip<TData = unknown>({
   });
   const roleProps = useRole(floating.context, {
     enabled: roleEnabled,
-    role: 'tooltip',
+    role,
     ...(typeof roleOptions === 'object' ? roleOptions : null),
   });
   const { getFloatingProps, getReferenceProps } = useInteractions([
@@ -167,11 +194,42 @@ export default function useFloatingTooltip<TData = unknown>({
     roleProps,
   ]);
 
-  const positionReference = useMemo(() => getTooltipAnchorReference(anchor), [anchor]);
+  const explicitPositionReference = useMemo(() => getTooltipAnchorReference(anchor), [anchor]);
+  const fallbackReference = fallbackPositionReference ?? domReference;
+  const positionReference = anchor != null ? explicitPositionReference : fallbackReference;
+  const hasManagedPositionReference = anchor != null || fallbackReference != null;
 
   useEffect(() => {
-    floating.refs.setPositionReference(positionReference);
-  }, [floating.refs, positionReference]);
+    if (hasManagedPositionReference || hasManagedPositionReferenceRef.current) {
+      floating.refs.setPositionReference(positionReference);
+      hasManagedPositionReferenceRef.current = hasManagedPositionReference;
+    }
+  }, [floating.refs, hasManagedPositionReference, positionReference]);
+
+  const setReference = useCallback(
+    (nextReference: ReferenceElement | null) => {
+      setDomReference(nextReference);
+      floating.refs.setReference(nextReference);
+    },
+    [floating.refs],
+  );
+
+  const setPositionReference = useCallback(
+    (nextReference: ReferenceElement | null) => {
+      setFallbackPositionReference(nextReference);
+      floating.refs.setPositionReference(nextReference);
+    },
+    [floating.refs],
+  );
+
+  const refs = useMemo(
+    () => ({
+      ...floating.refs,
+      setReference,
+      setPositionReference,
+    }),
+    [floating.refs, setPositionReference, setReference],
+  );
 
   const setAnchor = useCallback(
     (nextAnchor: TooltipAnchor | null) => {
@@ -208,6 +266,11 @@ export default function useFloatingTooltip<TData = unknown>({
   }, [handleOpenChange]);
 
   const { align, side } = getSideAndAlign(floating.placement);
+  const getFloatingPropsWithId = useCallback(
+    <TProps extends React.HTMLProps<HTMLElement>>(props?: TProps) =>
+      getFloatingProps(getFloatingPropsWithDefaultId(props, id)) as TProps,
+    [getFloatingProps, id],
+  );
 
   return {
     open,
@@ -222,7 +285,7 @@ export default function useFloatingTooltip<TData = unknown>({
     y: floating.y,
     floatingStyles: floating.floatingStyles,
     middlewareData: floating.middlewareData,
-    refs: floating.refs,
+    refs,
     context: floating.context,
     arrowRef: setArrowElement,
     setAnchor,
@@ -232,8 +295,7 @@ export default function useFloatingTooltip<TData = unknown>({
     closeTooltip,
     getReferenceProps: <TProps extends React.HTMLProps<Element>>(props?: TProps) =>
       getReferenceProps(props) as TProps,
-    getFloatingProps: <TProps extends React.HTMLProps<HTMLElement>>(props?: TProps) =>
-      getFloatingProps(props) as TProps,
+    getFloatingProps: getFloatingPropsWithId,
     getArrowProps: <TProps extends React.SVGProps<SVGSVGElement>>(props?: TProps) =>
       props ?? ({} as TProps),
   };

--- a/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
+++ b/packages/visx-tooltip/src/floating/useFloatingTooltip.ts
@@ -47,7 +47,8 @@ function getFloatingPropsWithDefaultId<TProps extends React.HTMLProps<HTMLElemen
   }
 
   if (id != null && nextProps?.id == null) {
-    return { ...nextProps, id } as TProps;
+    const propsWithId = { ...nextProps, id };
+    return propsWithId as TProps;
   }
 
   return nextProps;
@@ -196,7 +197,7 @@ export default function useFloatingTooltip<TData = unknown>({
 
   const explicitPositionReference = useMemo(() => getTooltipAnchorReference(anchor), [anchor]);
   const fallbackReference = fallbackPositionReference ?? domReference;
-  const positionReference = anchor != null ? explicitPositionReference : fallbackReference;
+  const positionReference = anchor == null ? fallbackReference : explicitPositionReference;
   const hasManagedPositionReference = anchor != null || fallbackReference != null;
 
   useEffect(() => {
@@ -296,7 +297,9 @@ export default function useFloatingTooltip<TData = unknown>({
     getReferenceProps: <TProps extends React.HTMLProps<Element>>(props?: TProps) =>
       getReferenceProps(props) as TProps,
     getFloatingProps: getFloatingPropsWithId,
-    getArrowProps: <TProps extends React.SVGProps<SVGSVGElement>>(props?: TProps) =>
-      props ?? ({} as TProps),
+    getArrowProps: <TProps extends React.SVGProps<SVGSVGElement>>(props?: TProps) => {
+      const emptyProps = {};
+      return props ?? (emptyProps as TProps);
+    },
   };
 }

--- a/packages/visx-tooltip/test/ChartTooltip.test.tsx
+++ b/packages/visx-tooltip/test/ChartTooltip.test.tsx
@@ -17,6 +17,7 @@ const item: ChartTooltipItem<Datum> = {
 
 function HookProbe({ hideDelay }: { hideDelay?: number }) {
   const tooltip = useChartTooltip<Datum>({ hideDelay, placement: 'right', offset: 12 });
+  const handleHide = tooltip.hide;
 
   return (
     <div>
@@ -26,10 +27,7 @@ function HookProbe({ hideDelay }: { hideDelay?: number }) {
       <output data-testid="state">
         {String(tooltip.open)}|{tooltip.anchor?.type}|{tooltip.items.length}
       </output>
-      <button
-        type="button"
-        onClick={() => tooltip.show({ anchor: { x: 4, y: 8 }, items: [item] })}
-      >
+      <button type="button" onClick={() => tooltip.show({ anchor: { x: 4, y: 8 }, items: [item] })}>
         show local
       </button>
       <button
@@ -40,13 +38,10 @@ function HookProbe({ hideDelay }: { hideDelay?: number }) {
       >
         show svg
       </button>
-      <button
-        type="button"
-        onClick={() => tooltip.update({ items: [{ ...item, rawValue: 20 }] })}
-      >
+      <button type="button" onClick={() => tooltip.update({ items: [{ ...item, rawValue: 20 }] })}>
         update
       </button>
-      <button type="button" onClick={tooltip.hide}>
+      <button type="button" onClick={handleHide}>
         hide
       </button>
       <ChartTooltip {...tooltip.tooltipProps} label="Value" />

--- a/packages/visx-tooltip/test/ChartTooltip.test.tsx
+++ b/packages/visx-tooltip/test/ChartTooltip.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ChartTooltip, useChartTooltip } from '../src/floating';
+import type { ChartTooltipItem } from '../src/floating';
+
+type Datum = {
+  label: string;
+  value: number;
+};
+
+const item: ChartTooltipItem<Datum> = {
+  key: 'value',
+  datum: { label: 'A', value: 10 },
+  rawValue: 10,
+};
+
+function HookProbe({ hideDelay }: { hideDelay?: number }) {
+  const tooltip = useChartTooltip<Datum>({ hideDelay, placement: 'right', offset: 12 });
+
+  return (
+    <div>
+      <svg ref={tooltip.containerRef} data-testid="svg">
+        <circle />
+      </svg>
+      <output data-testid="state">
+        {String(tooltip.open)}|{tooltip.anchor?.type}|{tooltip.items.length}
+      </output>
+      <button
+        type="button"
+        onClick={() => tooltip.show({ anchor: { x: 4, y: 8 }, items: [item] })}
+      >
+        show local
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          tooltip.show({ anchor: { type: 'svg-point', x: 10, y: 20 }, items: [item] })
+        }
+      >
+        show svg
+      </button>
+      <button
+        type="button"
+        onClick={() => tooltip.update({ items: [{ ...item, rawValue: 20 }] })}
+      >
+        update
+      </button>
+      <button type="button" onClick={tooltip.hide}>
+        hide
+      </button>
+      <ChartTooltip {...tooltip.tooltipProps} label="Value" />
+    </div>
+  );
+}
+
+describe('useChartTooltip()', () => {
+  it('converts local CSS pixel points into container-point anchors', () => {
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'show local' }));
+
+    expect(screen.getByTestId('state')).toHaveTextContent('true|container-point|1');
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('converts shorthand SVG points using the latest container ref', () => {
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'show svg' }));
+
+    expect(screen.getByTestId('state')).toHaveTextContent('true|svg-point|1');
+  });
+
+  it('updates items without replacing the current anchor', () => {
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'show local' }));
+    fireEvent.click(screen.getByRole('button', { name: 'update' }));
+
+    expect(screen.getByTestId('state')).toHaveTextContent('true|container-point|1');
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+
+  it('supports hide delay and cancels pending hide when shown again', () => {
+    vi.useFakeTimers();
+
+    render(<HookProbe hideDelay={100} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'show local' }));
+    fireEvent.click(screen.getByRole('button', { name: 'hide' }));
+    fireEvent.click(screen.getByRole('button', { name: 'show svg' }));
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.getByTestId('state')).toHaveTextContent('true|svg-point|1');
+
+    vi.useRealTimers();
+  });
+});
+
+describe('<ChartTooltip />', () => {
+  it('renders through a portal by default and inline when portal is false', () => {
+    const anchor = { type: 'point', x: 0, y: 0 } as const;
+    const { container, rerender } = render(
+      <div>
+        <ChartTooltip open anchor={anchor} items={[item]} label="Value" />
+      </div>,
+    );
+
+    expect(container).not.toHaveTextContent('10');
+    expect(document.body).toHaveTextContent('10');
+
+    rerender(
+      <div>
+        <ChartTooltip open anchor={anchor} items={[item]} label="Value" portal={false} />
+      </div>,
+    );
+
+    expect(container).toHaveTextContent('10');
+  });
+
+  it('supports renderContent and forwards positioning/content props', () => {
+    render(
+      <ChartTooltip
+        open
+        anchor={{ type: 'point', x: 0, y: 0 }}
+        items={[item]}
+        placement="right"
+        positionerProps={{ 'data-testid': 'positioner', className: 'custom-positioner' }}
+        contentProps={{ indicator: 'square' }}
+        renderContent={({ items }) => <strong>custom {items.length}</strong>}
+        portal={false}
+      />,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveClass('custom-positioner');
+    expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'right');
+    expect(screen.getByText('custom 1')).toBeInTheDocument();
+  });
+
+  it('lets explicit props win over floatingOptions', () => {
+    render(
+      <ChartTooltip
+        open
+        anchor={{ type: 'point', x: 0, y: 0 }}
+        items={[item]}
+        placement="left"
+        floatingOptions={{ placement: 'bottom' }}
+        positionerProps={{ 'data-testid': 'positioner' }}
+        portal={false}
+      />,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'left');
+  });
+});

--- a/packages/visx-tooltip/test/ChartTooltip.test.tsx
+++ b/packages/visx-tooltip/test/ChartTooltip.test.tsx
@@ -35,7 +35,7 @@ function HookProbe({ hideDelay }: { hideDelay?: number }) {
       <button
         type="button"
         onClick={() =>
-          tooltip.show({ anchor: { type: 'svg-point', x: 10, y: 20 }, items: [item] })
+          tooltip.show({ anchor: { type: 'svg-local-point', x: 10, y: 20 }, items: [item] })
         }
       >
         show svg
@@ -138,6 +138,10 @@ describe('<ChartTooltip />', () => {
 
     expect(screen.getByTestId('positioner')).toHaveClass('custom-positioner');
     expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'right');
+    expect(screen.getByTestId('positioner')).toHaveAttribute('role', 'tooltip');
+    expect(screen.getByText('custom 1').closest('[data-visx-tooltip-content]')).not.toHaveAttribute(
+      'role',
+    );
     expect(screen.getByText('custom 1')).toBeInTheDocument();
   });
 
@@ -155,5 +159,34 @@ describe('<ChartTooltip />', () => {
     );
 
     expect(screen.getByTestId('positioner')).toHaveAttribute('data-side', 'left');
+  });
+
+  it('forwards floatingOptions id and lets positionerProps id win', () => {
+    const anchor = { type: 'point', x: 0, y: 0 } as const;
+    const { rerender } = render(
+      <ChartTooltip
+        open
+        anchor={anchor}
+        items={[item]}
+        floatingOptions={{ id: 'chart-tooltip-id' }}
+        positionerProps={{ 'data-testid': 'positioner' }}
+        portal={false}
+      />,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'chart-tooltip-id');
+
+    rerender(
+      <ChartTooltip
+        open
+        anchor={anchor}
+        items={[item]}
+        floatingOptions={{ id: 'chart-tooltip-id' }}
+        positionerProps={{ 'data-testid': 'positioner', id: 'positioner-id' }}
+        portal={false}
+      />,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'positioner-id');
   });
 });

--- a/packages/visx-tooltip/test/ChartTooltipContent.test.tsx
+++ b/packages/visx-tooltip/test/ChartTooltipContent.test.tsx
@@ -87,10 +87,7 @@ describe('<ChartTooltipContent />', () => {
     ]);
 
     rerender(
-      <ChartTooltipContent
-        items={items}
-        sortItems={(a, b) => b.key.localeCompare(a.key)}
-      />,
+      <ChartTooltipContent items={items} sortItems={(a, b) => b.key.localeCompare(a.key)} />,
     );
 
     expect(screen.getAllByTestId(/^item-/).map((item) => item.dataset.itemKey)).toEqual([

--- a/packages/visx-tooltip/test/ChartTooltipContent.test.tsx
+++ b/packages/visx-tooltip/test/ChartTooltipContent.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ChartTooltipContent } from '../src/floating';
+import type { ChartTooltipConfig, ChartTooltipItem } from '../src/floating';
+
+type Datum = {
+  series: string;
+  value: number;
+};
+
+function Icon({ item }: { item: ChartTooltipItem<Datum> }) {
+  return <span data-testid={`icon-${item.key}`}>icon</span>;
+}
+
+const items: ChartTooltipItem<Datum>[] = [
+  {
+    key: 'revenue',
+    datum: { series: 'revenue', value: 10 },
+    label: 'Revenue item',
+    rawValue: 10,
+    value: 'ten',
+    color: 'blue',
+  },
+  {
+    key: 'expenses',
+    datum: { series: 'expenses', value: 4 },
+    rawValue: 4,
+    color: 'red',
+  },
+  {
+    key: 'hidden',
+    rawValue: 1,
+    hidden: true,
+  },
+];
+
+describe('<ChartTooltipContent />', () => {
+  it('filters hidden items and hidden config entries', () => {
+    const config = {
+      expenses: { hide: true },
+    } satisfies ChartTooltipConfig<Datum>;
+
+    render(<ChartTooltipContent items={items} config={config} />);
+
+    expect(screen.getByText('Revenue item')).toBeInTheDocument();
+    expect(screen.queryByText('expenses')).not.toBeInTheDocument();
+    expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+  });
+
+  it('applies label, value, color, icon, and formatter precedence from config', () => {
+    const config = {
+      revenue: {
+        label: 'Revenue config',
+        color: () => 'green',
+        icon: Icon,
+        formatLabel: (item) => `${item.key} formatted label`,
+        formatValue: (value) => `$${value}`,
+      },
+      expenses: {
+        label: (item) => `${item.key} label`,
+        formatValue: (value) => `${Number(value) * 2}`,
+      },
+    } satisfies ChartTooltipConfig<Datum>;
+
+    render(<ChartTooltipContent items={items} config={config} />);
+
+    expect(screen.getByText('revenue formatted label')).toBeInTheDocument();
+    expect(screen.getByText('$10')).toBeInTheDocument();
+    expect(screen.getByTestId('item-revenue')).toHaveStyle('--visx-tooltip-item-color: green');
+    expect(screen.getByTestId('icon-revenue')).toBeInTheDocument();
+    expect(screen.getByText('expenses label')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('orders by config order, then custom sorter, then input order', () => {
+    const config = {
+      expenses: { order: 0 },
+      revenue: { order: 1 },
+    } satisfies ChartTooltipConfig<Datum>;
+
+    const { rerender } = render(<ChartTooltipContent items={items} config={config} />);
+
+    expect(screen.getAllByTestId(/^item-/).map((item) => item.dataset.itemKey)).toEqual([
+      'expenses',
+      'revenue',
+    ]);
+
+    rerender(
+      <ChartTooltipContent
+        items={items}
+        sortItems={(a, b) => b.key.localeCompare(a.key)}
+      />,
+    );
+
+    expect(screen.getAllByTestId(/^item-/).map((item) => item.dataset.itemKey)).toEqual([
+      'revenue',
+      'expenses',
+    ]);
+  });
+
+  it('supports custom label, item, and value renderers', () => {
+    render(
+      <ChartTooltipContent
+        label="March"
+        items={items.slice(0, 1)}
+        renderLabel={({ label }) => <h2>{label}</h2>}
+        renderValue={({ value }) => <strong>value: {value}</strong>}
+        renderItem={({ item, label, value }) => (
+          <p data-testid="custom-item">
+            {item.key}:{label}:{value}
+          </p>
+        )}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'March' })).toBeInTheDocument();
+    expect(screen.getByTestId('custom-item')).toHaveTextContent('revenue:Revenue item:value: ten');
+  });
+
+  it('returns null when no visible items remain', () => {
+    const { container } = render(
+      <ChartTooltipContent
+        items={[{ key: 'only', hidden: true }]}
+        config={{ only: { hide: true } }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('uses getItemKey for row keys and renders basic data attributes', () => {
+    render(
+      <ChartTooltipContent
+        label="Total"
+        items={items.slice(0, 2)}
+        getItemKey={(item) => `row-${item.key}`}
+      />,
+    );
+
+    expect(screen.getByTestId('chart-tooltip-content')).toHaveAttribute(
+      'data-visx-chart-tooltip',
+      '',
+    );
+    expect(screen.getByText('Total')).toHaveAttribute('data-visx-chart-tooltip-label', '');
+    expect(screen.getByTestId('item-revenue')).toHaveAttribute('data-item-key', 'revenue');
+  });
+});

--- a/packages/visx-tooltip/test/floating.typecheck.tsx
+++ b/packages/visx-tooltip/test/floating.typecheck.tsx
@@ -1,5 +1,6 @@
 import {
   ChartTooltip,
+  FloatingTooltip,
   useChartTooltip,
   type ChartTooltipConfig,
   type ChartTooltipItem,
@@ -63,4 +64,31 @@ const floatingOptionsCannotUseDescriptionRole = (
   />
 );
 
-export { HookUsage, floatingOptionsCannotControlState, floatingOptionsCannotUseDescriptionRole };
+const arrowStrokeWidthUsesFloatingUiProps = (
+  <FloatingTooltip.Root open anchor={null} arrow>
+    <FloatingTooltip.Positioner>
+      <FloatingTooltip.Content>
+        <FloatingTooltip.Arrow strokeWidth={2} />
+      </FloatingTooltip.Content>
+    </FloatingTooltip.Positioner>
+  </FloatingTooltip.Root>
+);
+
+const arrowPaddingIsMiddlewareOnly = (
+  <FloatingTooltip.Root open anchor={null} arrow={{ padding: 4 }}>
+    <FloatingTooltip.Positioner>
+      <FloatingTooltip.Content>
+        {/* @ts-expect-error Arrow does not alias padding to strokeWidth */}
+        <FloatingTooltip.Arrow padding={2} />
+      </FloatingTooltip.Content>
+    </FloatingTooltip.Positioner>
+  </FloatingTooltip.Root>
+);
+
+export {
+  HookUsage,
+  arrowPaddingIsMiddlewareOnly,
+  arrowStrokeWidthUsesFloatingUiProps,
+  floatingOptionsCannotControlState,
+  floatingOptionsCannotUseDescriptionRole,
+};

--- a/packages/visx-tooltip/test/floating.typecheck.tsx
+++ b/packages/visx-tooltip/test/floating.typecheck.tsx
@@ -1,0 +1,54 @@
+import {
+  ChartTooltip,
+  useChartTooltip,
+  type ChartTooltipConfig,
+  type ChartTooltipItem,
+} from '../src/floating';
+
+type Datum = {
+  month: string;
+  revenue: number;
+};
+
+const item: ChartTooltipItem<Datum> = {
+  key: 'revenue',
+  datum: { month: 'Jan', revenue: 10 },
+  rawValue: 10,
+};
+
+const config = {
+  revenue: {
+    label: 'Revenue',
+    formatValue: (value, tooltipItem) => `${tooltipItem.datum?.month}: ${value}`,
+  },
+} satisfies ChartTooltipConfig<Datum>;
+
+function HookUsage() {
+  const tooltip = useChartTooltip<Datum>();
+
+  tooltip.show({
+    anchor: { x: 0, y: 0 },
+    items: [item],
+  });
+
+  tooltip.show({
+    anchor: { type: 'svg-point', x: 0, y: 0 },
+    items: [item],
+  });
+
+  return <ChartTooltip {...tooltip.tooltipProps} config={config} />;
+}
+
+const floatingOptionsCannotControlState = (
+  <ChartTooltip
+    open
+    anchor={null}
+    items={[item]}
+    floatingOptions={{
+      // @ts-expect-error controlled open state lives on ChartTooltip props
+      open: false,
+    }}
+  />
+);
+
+export { HookUsage, floatingOptionsCannotControlState };

--- a/packages/visx-tooltip/test/floating.typecheck.tsx
+++ b/packages/visx-tooltip/test/floating.typecheck.tsx
@@ -32,7 +32,7 @@ function HookUsage() {
   });
 
   tooltip.show({
-    anchor: { type: 'svg-point', x: 0, y: 0 },
+    anchor: { type: 'svg-local-point', x: 0, y: 0 },
     items: [item],
   });
 
@@ -51,4 +51,16 @@ const floatingOptionsCannotControlState = (
   />
 );
 
-export { HookUsage, floatingOptionsCannotControlState };
+const floatingOptionsCannotUseDescriptionRole = (
+  <ChartTooltip
+    open
+    anchor={null}
+    items={[item]}
+    floatingOptions={{
+      // @ts-expect-error description is not a supported Floating UI role value for this API
+      role: 'description',
+    }}
+  />
+);
+
+export { HookUsage, floatingOptionsCannotControlState, floatingOptionsCannotUseDescriptionRole };

--- a/packages/visx-tooltip/test/floatingAnchors.test.ts
+++ b/packages/visx-tooltip/test/floatingAnchors.test.ts
@@ -1,0 +1,185 @@
+import { getTooltipAnchorReference } from '../src/floating/anchors';
+import type { TooltipAnchor, TooltipVirtualElement } from '../src/floating';
+
+function rect(left: number, top: number, width = 0, height = 0) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+  } as DOMRect;
+}
+
+describe('floating tooltip anchors', () => {
+  it('returns a DOM element anchor directly', () => {
+    const element = document.createElement('button');
+
+    expect(getTooltipAnchorReference({ type: 'element', element })).toBe(element);
+    expect(getTooltipAnchorReference({ type: 'element', element: null })).toBeNull();
+  });
+
+  it('uses client point coordinates directly', () => {
+    const reference = getTooltipAnchorReference({
+      type: 'point',
+      x: 12,
+      y: 24,
+      coordinateSpace: 'client',
+    });
+
+    expect(reference?.getBoundingClientRect()).toMatchObject({
+      left: 12,
+      top: 24,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('converts page point coordinates into client coordinates', () => {
+    const scrollX = vi.spyOn(window, 'scrollX', 'get').mockReturnValue(5);
+    const scrollY = vi.spyOn(window, 'scrollY', 'get').mockReturnValue(7);
+
+    const reference = getTooltipAnchorReference({
+      type: 'point',
+      x: 25,
+      y: 37,
+      coordinateSpace: 'page',
+    });
+
+    expect(reference?.getBoundingClientRect()).toMatchObject({
+      left: 20,
+      top: 30,
+      width: 0,
+      height: 0,
+    });
+
+    scrollX.mockRestore();
+    scrollY.mockRestore();
+  });
+
+  it('converts container-local CSS pixel coordinates into client coordinates', () => {
+    const container = document.createElement('div');
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue(rect(100, 200, 300, 400));
+
+    const reference = getTooltipAnchorReference({
+      type: 'container-point',
+      x: 25,
+      y: 50,
+      container,
+    });
+
+    expect(reference?.contextElement).toBe(container);
+    expect(reference?.getBoundingClientRect()).toMatchObject({
+      left: 125,
+      top: 250,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('returns null for a container point without a container', () => {
+    expect(
+      getTooltipAnchorReference({
+        type: 'container-point',
+        x: 25,
+        y: 50,
+        container: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('converts SVG user-space coordinates through the screen CTM', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const point = {
+      x: 0,
+      y: 0,
+      matrixTransform(matrix: { a: number; d: number; e: number; f: number }) {
+        return {
+          x: this.x * matrix.a + matrix.e,
+          y: this.y * matrix.d + matrix.f,
+        };
+      },
+    };
+
+    Object.assign(svg, {
+      createSVGPoint: () => point,
+      getScreenCTM: () => ({ a: 2, d: 3, e: 10, f: 20 }),
+    });
+
+    const reference = getTooltipAnchorReference({
+      type: 'svg-point',
+      x: 5,
+      y: 7,
+      svg,
+    });
+
+    expect(reference?.contextElement).toBe(svg);
+    expect(reference?.getBoundingClientRect()).toMatchObject({
+      left: 20,
+      top: 41,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('falls back to the SVG element bounding rect when screen CTM is unavailable', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue(rect(50, 60));
+
+    const reference = getTooltipAnchorReference({
+      type: 'svg-point',
+      x: 4,
+      y: 6,
+      svg,
+    });
+
+    expect(reference?.getBoundingClientRect()).toMatchObject({
+      left: 54,
+      top: 66,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('returns null for an SVG point without an SVG element', () => {
+    expect(
+      getTooltipAnchorReference({
+        type: 'svg-point',
+        x: 4,
+        y: 6,
+        svg: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('creates virtual references from rect and virtual anchors', () => {
+    const getRect = vi.fn(() => rect(1, 2, 3, 4));
+    const contextElement = document.createElement('div');
+    const rectReference = getTooltipAnchorReference({ type: 'rect', getRect, contextElement });
+
+    expect(rectReference?.contextElement).toBe(contextElement);
+    expect(rectReference?.getBoundingClientRect()).toMatchObject({ left: 1, top: 2 });
+    expect(getRect).toHaveBeenCalledTimes(1);
+
+    const element: TooltipVirtualElement = {
+      getBoundingClientRect: () => rect(5, 6, 7, 8),
+      contextElement,
+    };
+
+    expect(getTooltipAnchorReference({ type: 'virtual', element })).toBe(element);
+  });
+
+  it('narrows all public anchor variants', () => {
+    const anchors = [
+      { type: 'point', x: 0, y: 0 },
+      { type: 'container-point', x: 0, y: 0, container: document.body },
+      { type: 'svg-point', x: 0, y: 0, svg: document.createElementNS('http://www.w3.org/2000/svg', 'svg') },
+      { type: 'rect', getRect: () => rect(0, 0) },
+    ] satisfies TooltipAnchor[];
+
+    expect(anchors).toHaveLength(4);
+  });
+});

--- a/packages/visx-tooltip/test/floatingAnchors.test.ts
+++ b/packages/visx-tooltip/test/floatingAnchors.test.ts
@@ -1,8 +1,12 @@
 import { getTooltipAnchorReference } from '../src/floating/anchors';
 import type { TooltipAnchor, TooltipVirtualElement } from '../src/floating';
 
-function rect(left: number, top: number, width = 0, height = 0) {
-  return {
+function rect(left: number, top: number, width = 0, height = 0): DOMRect | ClientRect {
+  if (typeof DOMRect === 'function') {
+    return new DOMRect(left, top, width, height);
+  }
+
+  const clientRect: DOMRect = {
     x: left,
     y: top,
     left,
@@ -11,7 +15,19 @@ function rect(left: number, top: number, width = 0, height = 0) {
     height,
     right: left + width,
     bottom: top + height,
-  } as DOMRect;
+    toJSON: () => ({
+      x: left,
+      y: top,
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    }),
+  };
+
+  return clientRect;
 }
 
 describe('floating tooltip anchors', () => {
@@ -176,7 +192,12 @@ describe('floating tooltip anchors', () => {
     const anchors = [
       { type: 'point', x: 0, y: 0 },
       { type: 'container-point', x: 0, y: 0, container: document.body },
-      { type: 'svg-point', x: 0, y: 0, svg: document.createElementNS('http://www.w3.org/2000/svg', 'svg') },
+      {
+        type: 'svg-point',
+        x: 0,
+        y: 0,
+        svg: document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+      },
       { type: 'rect', getRect: () => rect(0, 0) },
     ] satisfies TooltipAnchor[];
 

--- a/packages/visx-tooltip/test/floatingInteractions.test.tsx
+++ b/packages/visx-tooltip/test/floatingInteractions.test.tsx
@@ -4,8 +4,12 @@ import '@testing-library/jest-dom';
 import { FloatingTooltip } from '../src/floating';
 import type { TooltipAnchor } from '../src/floating';
 
-function rect(left: number, top: number, width = 0, height = 0) {
-  return {
+function rect(left: number, top: number, width = 0, height = 0): DOMRect | ClientRect {
+  if (typeof DOMRect === 'function') {
+    return new DOMRect(left, top, width, height);
+  }
+
+  const clientRect: DOMRect = {
     x: left,
     y: top,
     left,
@@ -14,24 +18,36 @@ function rect(left: number, top: number, width = 0, height = 0) {
     height,
     right: left + width,
     bottom: top + height,
-  } as DOMRect;
+    toJSON: () => ({
+      x: left,
+      y: top,
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    }),
+  };
+
+  return clientRect;
 }
 
 function TriggerTooltip({
   anchor,
   defaultOpen = false,
+  floatingRole,
   id,
   onOpenChange,
   positionerId,
-  role,
   triggerDisabled = false,
 }: {
   anchor?: TooltipAnchor;
   defaultOpen?: boolean;
+  floatingRole?: 'tooltip' | 'label';
   id?: string;
   onOpenChange?: ReturnType<typeof vi.fn>;
   positionerId?: string;
-  role?: 'tooltip' | 'label';
   triggerDisabled?: boolean;
 }) {
   return (
@@ -42,7 +58,7 @@ function TriggerTooltip({
         defaultOpen={defaultOpen}
         id={id}
         onOpenChange={onOpenChange}
-        role={role}
+        role={floatingRole}
       >
         <FloatingTooltip.Trigger
           disabled={triggerDisabled}
@@ -173,7 +189,7 @@ describe('<FloatingTooltip.Trigger />', () => {
   });
 
   it('supports label role ARIA wiring', async () => {
-    render(<TriggerTooltip id="export-tooltip" role="label" />);
+    render(<TriggerTooltip id="export-tooltip" floatingRole="label" />);
 
     const trigger = screen.getByRole('button', { name: 'Export' });
     fireEvent.focus(trigger);
@@ -200,9 +216,7 @@ describe('<FloatingTooltip.Trigger />', () => {
   it('uses the trigger as the positioning reference when no explicit anchor exists', async () => {
     const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
     rectSpy.mockImplementation(function getRect() {
-      return this.textContent === 'Export'
-        ? rect(120, 160, 40, 20)
-        : rect(0, 0, 80, 30);
+      return this.textContent === 'Export' ? rect(120, 160, 40, 20) : rect(0, 0, 80, 30);
     });
 
     render(<TriggerTooltip />);

--- a/packages/visx-tooltip/test/floatingInteractions.test.tsx
+++ b/packages/visx-tooltip/test/floatingInteractions.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FloatingTooltip } from '../src/floating';
+import type { TooltipAnchor } from '../src/floating';
+
+function TriggerTooltip({
+  anchor,
+  defaultOpen = false,
+  onOpenChange,
+}: {
+  anchor?: TooltipAnchor;
+  defaultOpen?: boolean;
+  onOpenChange?: ReturnType<typeof vi.fn>;
+}) {
+  return (
+    <FloatingTooltip.Provider delay={0} closeDelay={0} skipDelay={0}>
+      <FloatingTooltip.Root
+        anchor={anchor}
+        data="trigger data"
+        defaultOpen={defaultOpen}
+        onOpenChange={onOpenChange}
+      >
+        <FloatingTooltip.Trigger
+          render={(props, state) => (
+            <button {...props} type="button" data-open={state.open}>
+              Export
+            </button>
+          )}
+        />
+        <FloatingTooltip.Portal disabled>
+          <FloatingTooltip.Positioner data-testid="positioner">
+            <FloatingTooltip.Content>Download chart data</FloatingTooltip.Content>
+          </FloatingTooltip.Positioner>
+        </FloatingTooltip.Portal>
+      </FloatingTooltip.Root>
+    </FloatingTooltip.Provider>
+  );
+}
+
+describe('<FloatingTooltip.Trigger />', () => {
+  it('renders through the render prop and opens on hover', async () => {
+    render(<TriggerTooltip />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    expect(trigger).toHaveAttribute('data-visx-tooltip-trigger', '');
+    expect(trigger).toHaveAttribute('data-open', 'false');
+    expect(screen.queryByText('Download chart data')).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Download chart data')).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('data-open', 'true');
+    });
+  });
+
+  it('opens on focus', async () => {
+    render(<TriggerTooltip />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Download chart data')).toBeInTheDocument();
+    });
+  });
+
+  it('dismisses on Escape', async () => {
+    render(<TriggerTooltip defaultOpen />);
+
+    expect(screen.getByText('Download chart data')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Download chart data')).not.toBeInTheDocument();
+    });
+  });
+
+  it('wires trigger ARIA props to the positioned tooltip element', async () => {
+    render(<TriggerTooltip />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      const describedBy = trigger.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy as string)).toBe(screen.getByTestId('positioner'));
+    });
+  });
+
+  it('uses the trigger as the positioning reference when no explicit anchor exists', async () => {
+    render(<TriggerTooltip />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('positioner')).toBeInTheDocument();
+      expect(screen.getByText('Download chart data')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps an explicit anchor while using the trigger for interactions', async () => {
+    const onOpenChange = vi.fn();
+    const anchor = { type: 'point', x: 10, y: 20 } satisfies TooltipAnchor;
+
+    render(<TriggerTooltip anchor={anchor} onOpenChange={onOpenChange} />);
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          anchor,
+          data: 'trigger data',
+          reason: 'hover',
+        }),
+      );
+    });
+  });
+});

--- a/packages/visx-tooltip/test/floatingInteractions.test.tsx
+++ b/packages/visx-tooltip/test/floatingInteractions.test.tsx
@@ -4,14 +4,35 @@ import '@testing-library/jest-dom';
 import { FloatingTooltip } from '../src/floating';
 import type { TooltipAnchor } from '../src/floating';
 
+function rect(left: number, top: number, width = 0, height = 0) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+  } as DOMRect;
+}
+
 function TriggerTooltip({
   anchor,
   defaultOpen = false,
+  id,
   onOpenChange,
+  positionerId,
+  role,
+  triggerDisabled = false,
 }: {
   anchor?: TooltipAnchor;
   defaultOpen?: boolean;
+  id?: string;
   onOpenChange?: ReturnType<typeof vi.fn>;
+  positionerId?: string;
+  role?: 'tooltip' | 'label';
+  triggerDisabled?: boolean;
 }) {
   return (
     <FloatingTooltip.Provider delay={0} closeDelay={0} skipDelay={0}>
@@ -19,9 +40,12 @@ function TriggerTooltip({
         anchor={anchor}
         data="trigger data"
         defaultOpen={defaultOpen}
+        id={id}
         onOpenChange={onOpenChange}
+        role={role}
       >
         <FloatingTooltip.Trigger
+          disabled={triggerDisabled}
           render={(props, state) => (
             <button {...props} type="button" data-open={state.open}>
               Export
@@ -29,7 +53,7 @@ function TriggerTooltip({
           )}
         />
         <FloatingTooltip.Portal disabled>
-          <FloatingTooltip.Positioner data-testid="positioner">
+          <FloatingTooltip.Positioner data-testid="positioner" id={positionerId}>
             <FloatingTooltip.Content>Download chart data</FloatingTooltip.Content>
           </FloatingTooltip.Positioner>
         </FloatingTooltip.Portal>
@@ -66,6 +90,51 @@ describe('<FloatingTooltip.Trigger />', () => {
     });
   });
 
+  it('does not wire interactions for disabled triggers', async () => {
+    const onOpenChange = vi.fn();
+    let triggerProps: React.HTMLProps<Element> | undefined;
+
+    render(
+      <FloatingTooltip.Provider delay={0} closeDelay={0} skipDelay={0}>
+        <FloatingTooltip.Root data="trigger data" onOpenChange={onOpenChange}>
+          <FloatingTooltip.Trigger
+            disabled
+            render={(props, state) => {
+              triggerProps = props;
+
+              return (
+                <button {...props} type="button" data-open={state.open}>
+                  Export
+                </button>
+              );
+            }}
+          />
+          <FloatingTooltip.Portal disabled>
+            <FloatingTooltip.Positioner data-testid="positioner">
+              <FloatingTooltip.Content>Download chart data</FloatingTooltip.Content>
+            </FloatingTooltip.Positioner>
+          </FloatingTooltip.Portal>
+        </FloatingTooltip.Root>
+      </FloatingTooltip.Provider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger).toHaveAttribute('data-disabled', '');
+    expect(triggerProps?.onMouseEnter).toBeUndefined();
+    expect(triggerProps?.onFocus).toBeUndefined();
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(trigger).toHaveAttribute('data-open', 'false');
+      expect(screen.queryByText('Download chart data')).not.toBeInTheDocument();
+    });
+  });
+
   it('dismisses on Escape', async () => {
     render(<TriggerTooltip defaultOpen />);
 
@@ -91,7 +160,51 @@ describe('<FloatingTooltip.Trigger />', () => {
     });
   });
 
+  it('uses a stable root id for trigger ARIA wiring', async () => {
+    render(<TriggerTooltip id="export-tooltip" />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'export-tooltip');
+      expect(trigger).toHaveAttribute('aria-describedby', 'export-tooltip');
+    });
+  });
+
+  it('supports label role ARIA wiring', async () => {
+    render(<TriggerTooltip id="export-tooltip" role="label" />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'export-tooltip');
+      expect(trigger).toHaveAttribute('aria-labelledby', 'export-tooltip');
+      expect(trigger).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
+  it('lets a positioner id override the root id for trigger ARIA wiring', async () => {
+    render(<TriggerTooltip id="export-tooltip" positionerId="custom-positioner-id" />);
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'custom-positioner-id');
+      expect(trigger).toHaveAttribute('aria-describedby', 'custom-positioner-id');
+    });
+  });
+
   it('uses the trigger as the positioning reference when no explicit anchor exists', async () => {
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
+    rectSpy.mockImplementation(function getRect() {
+      return this.textContent === 'Export'
+        ? rect(120, 160, 40, 20)
+        : rect(0, 0, 80, 30);
+    });
+
     render(<TriggerTooltip />);
 
     const trigger = screen.getByRole('button', { name: 'Export' });
@@ -100,7 +213,10 @@ describe('<FloatingTooltip.Trigger />', () => {
     await waitFor(() => {
       expect(screen.getByTestId('positioner')).toBeInTheDocument();
       expect(screen.getByText('Download chart data')).toBeInTheDocument();
+      expect(screen.getByTestId('positioner').style.transform).not.toBe('translate(0px, 0px)');
     });
+
+    rectSpy.mockRestore();
   });
 
   it('keeps an explicit anchor while using the trigger for interactions', async () => {

--- a/packages/visx-tooltip/test/floatingPrimitives.test.tsx
+++ b/packages/visx-tooltip/test/floatingPrimitives.test.tsx
@@ -6,8 +6,12 @@ import { buildFloatingTooltipMiddleware } from '../src/floating/middleware';
 import { FloatingTooltip, useFloatingTooltip } from '../src/floating';
 import type { TooltipAnchor } from '../src/floating';
 
-function rect(left: number, top: number, width = 0, height = 0) {
-  return {
+function rect(left: number, top: number, width = 0, height = 0): DOMRect | ClientRect {
+  if (typeof DOMRect === 'function') {
+    return new DOMRect(left, top, width, height);
+  }
+
+  const clientRect: DOMRect = {
     x: left,
     y: top,
     left,
@@ -16,7 +20,19 @@ function rect(left: number, top: number, width = 0, height = 0) {
     height,
     right: left + width,
     bottom: top + height,
-  } as DOMRect;
+    toJSON: () => ({
+      x: left,
+      y: top,
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    }),
+  };
+
+  return clientRect;
 }
 
 function HookProbe({
@@ -39,16 +55,20 @@ function HookProbe({
     onOpenChange,
     open,
   });
+  const handleClose = tooltip.closeTooltip;
 
   return (
     <div>
       <output data-testid="state">
         {String(tooltip.open)}|{tooltip.data}|{tooltip.anchor?.type}|{tooltip.side}|{tooltip.align}
       </output>
-      <button type="button" onClick={() => tooltip.openTooltip('next', { type: 'point', x: 3, y: 4 })}>
+      <button
+        type="button"
+        onClick={() => tooltip.openTooltip('next', { type: 'point', x: 3, y: 4 })}
+      >
         open
       </button>
-      <button type="button" onClick={tooltip.closeTooltip}>
+      <button type="button" onClick={handleClose}>
         close
       </button>
     </div>
@@ -273,14 +293,14 @@ describe('<FloatingTooltip /> manual primitives', () => {
     rerender(
       <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }}>
         <FloatingTooltip.Positioner>
-          <FloatingTooltip.Content data-testid="content" role="note">
+          <FloatingTooltip.Content data-testid="content" role="status">
             Tooltip
           </FloatingTooltip.Content>
         </FloatingTooltip.Positioner>
       </FloatingTooltip.Root>,
     );
 
-    expect(screen.getByTestId('content')).toHaveAttribute('role', 'note');
+    expect(screen.getByTestId('content')).toHaveAttribute('role', 'status');
   });
 
   it('uses the root id for the positioner and lets positioner props override it', () => {

--- a/packages/visx-tooltip/test/floatingPrimitives.test.tsx
+++ b/packages/visx-tooltip/test/floatingPrimitives.test.tsx
@@ -1,0 +1,302 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { autoUpdate, type Middleware } from '@floating-ui/react';
+import { buildFloatingTooltipMiddleware } from '../src/floating/middleware';
+import { FloatingTooltip, useFloatingTooltip } from '../src/floating';
+import type { TooltipAnchor } from '../src/floating';
+
+function rect(left: number, top: number, width = 0, height = 0) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+  } as DOMRect;
+}
+
+function HookProbe({
+  anchor,
+  data,
+  open,
+  onOpenChange,
+}: {
+  anchor?: TooltipAnchor | null;
+  data?: string;
+  open?: boolean;
+  onOpenChange?: ReturnType<typeof vi.fn>;
+}) {
+  const tooltip = useFloatingTooltip<string>({
+    anchor,
+    data,
+    defaultAnchor: { type: 'point', x: 1, y: 2 },
+    defaultData: 'default',
+    defaultOpen: true,
+    onOpenChange,
+    open,
+  });
+
+  return (
+    <div>
+      <output data-testid="state">
+        {String(tooltip.open)}|{tooltip.data}|{tooltip.anchor?.type}|{tooltip.side}|{tooltip.align}
+      </output>
+      <button type="button" onClick={() => tooltip.openTooltip('next', { type: 'point', x: 3, y: 4 })}>
+        open
+      </button>
+      <button type="button" onClick={tooltip.closeTooltip}>
+        close
+      </button>
+    </div>
+  );
+}
+
+describe('useFloatingTooltip()', () => {
+  it('supports uncontrolled open, anchor, and data state', () => {
+    render(<HookProbe />);
+
+    expect(screen.getByTestId('state')).toHaveTextContent('true|default|point|top|center');
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('false|default|point|top|center');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('true|next|point|top|center');
+  });
+
+  it('honors controlled state and reports open changes', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <HookProbe
+        open={false}
+        data="controlled"
+        anchor={{ type: 'point', x: 10, y: 20 }}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByTestId('state')).toHaveTextContent('false|controlled|point|top|center');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open' }));
+
+    expect(screen.getByTestId('state')).toHaveTextContent('false|controlled|point|top|center');
+    expect(onOpenChange).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        data: 'next',
+        anchor: expect.objectContaining({ type: 'point', x: 3, y: 4 }),
+      }),
+    );
+  });
+
+  it('exposes an update function and Floating UI refs', () => {
+    let result: ReturnType<typeof useFloatingTooltip> | null = null;
+
+    function Probe() {
+      result = useFloatingTooltip({ defaultOpen: true });
+      return null;
+    }
+
+    render(<Probe />);
+
+    expect(result?.refs).toBeDefined();
+    expect(result?.context).toBeDefined();
+    expect(() => act(() => result?.update())).not.toThrow();
+  });
+});
+
+describe('buildFloatingTooltipMiddleware()', () => {
+  it('builds middleware in the documented order', () => {
+    const arrowElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const custom: Middleware = { name: 'custom', fn: ({ x, y }) => ({ x, y }) };
+
+    const middleware = buildFloatingTooltipMiddleware({
+      offset: 8,
+      collisionPadding: 4,
+      flip: true,
+      shift: true,
+      size: true,
+      hideWhenDetached: true,
+      arrow: true,
+      arrowElement,
+      middleware: [custom],
+      middlewareMode: 'append',
+    });
+
+    expect(middleware.map(({ name }) => name)).toEqual([
+      'offset',
+      'flip',
+      'shift',
+      'size',
+      'hide',
+      'arrow',
+      'custom',
+    ]);
+  });
+
+  it('allows callers to replace built-in middleware', () => {
+    const custom: Middleware = { name: 'custom', fn: ({ x, y }) => ({ x, y }) };
+
+    expect(
+      buildFloatingTooltipMiddleware({
+        middleware: [custom],
+        middlewareMode: 'replace',
+        offset: 8,
+        flip: true,
+        shift: true,
+      }).map(({ name }) => name),
+    ).toEqual(['custom']);
+  });
+});
+
+describe('<FloatingTooltip /> manual primitives', () => {
+  it('unmounts closed content by default and keeps it mounted with forceMount', () => {
+    const anchor = { type: 'point', x: 0, y: 0 } satisfies TooltipAnchor;
+
+    const { rerender } = render(
+      <FloatingTooltip.Root open={false} anchor={anchor}>
+        <FloatingTooltip.Positioner data-testid="positioner">
+          <FloatingTooltip.Content>Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.queryByText('Tooltip')).not.toBeInTheDocument();
+
+    rerender(
+      <FloatingTooltip.Root open={false} forceMount anchor={anchor}>
+        <FloatingTooltip.Positioner data-testid="positioner">
+          <FloatingTooltip.Content>Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('data-state', 'closed');
+    expect(screen.getByText('Tooltip')).toBeInTheDocument();
+  });
+
+  it('renders open content with placement data attributes and CSS variables', () => {
+    render(
+      <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }} placement="bottom-start">
+        <FloatingTooltip.Positioner data-testid="positioner">
+          <FloatingTooltip.Content data-testid="content">Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    const positioner = screen.getByTestId('positioner');
+
+    expect(positioner).toHaveAttribute('data-visx-tooltip', '');
+    expect(positioner).toHaveAttribute('data-state', 'open');
+    expect(positioner).toHaveAttribute('data-side', 'bottom');
+    expect(positioner).toHaveAttribute('data-align', 'start');
+    expect(positioner.style.getPropertyValue('--visx-tooltip-transform-origin')).toBeTruthy();
+    expect(screen.getByTestId('content')).toHaveAttribute('role', 'tooltip');
+  });
+
+  it('supports render replacement for the positioner and content', () => {
+    render(
+      <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }}>
+        <FloatingTooltip.Positioner
+          render={(props, state) => (
+            <section {...props} data-testid="positioner" data-side-from-state={state.side}>
+              {props.children}
+            </section>
+          )}
+        >
+          <FloatingTooltip.Content
+            render={(props) => (
+              <article {...props} data-testid="content">
+                Rendered
+              </article>
+            )}
+          />
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('data-side-from-state', 'top');
+    expect(screen.getByTestId('content').tagName).toBe('ARTICLE');
+  });
+
+  it('renders in place when portal is disabled and into body by default', () => {
+    const { container, rerender } = render(
+      <div data-testid="host">
+        <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }}>
+          <FloatingTooltip.Portal disabled>
+            <FloatingTooltip.Positioner>
+              <FloatingTooltip.Content>Inline</FloatingTooltip.Content>
+            </FloatingTooltip.Positioner>
+          </FloatingTooltip.Portal>
+        </FloatingTooltip.Root>
+      </div>,
+    );
+
+    expect(container).toHaveTextContent('Inline');
+
+    rerender(
+      <div data-testid="host">
+        <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }}>
+          <FloatingTooltip.Portal>
+            <FloatingTooltip.Positioner>
+              <FloatingTooltip.Content>Portaled</FloatingTooltip.Content>
+            </FloatingTooltip.Positioner>
+          </FloatingTooltip.Portal>
+        </FloatingTooltip.Root>
+      </div>,
+    );
+
+    expect(container).not.toHaveTextContent('Portaled');
+    expect(document.body).toHaveTextContent('Portaled');
+  });
+
+  it('renders an SVG arrow with custom dimensions', () => {
+    render(
+      <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }} arrow>
+        <FloatingTooltip.Positioner>
+          <FloatingTooltip.Content>
+            Tooltip
+            <FloatingTooltip.Arrow data-testid="arrow" width={14} height={20} />
+          </FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    const arrow = screen.getByTestId('arrow');
+    expect(arrow.tagName).toBe('svg');
+    expect(arrow).toHaveAttribute('width', '14');
+    expect(arrow).toHaveAttribute('viewBox', '0 0 14 20');
+  });
+
+  it('marks the anchor as hidden when Floating UI hide middleware reports it', async () => {
+    const getRect = () => rect(0, 0);
+
+    render(
+      <FloatingTooltip.Root
+        open
+        anchor={{ type: 'rect', getRect }}
+        middleware={[{ name: 'hide', fn: () => ({ data: { referenceHidden: true } }) }]}
+        middlewareMode="replace"
+      >
+        <FloatingTooltip.Positioner data-testid="positioner">
+          <FloatingTooltip.Content>Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('positioner')).toHaveAttribute('data-anchor-hidden', '');
+    });
+  });
+
+  it('uses autoUpdate by default while elements are mounted', () => {
+    const tooltip = useFloatingTooltip;
+
+    expect(autoUpdate).toBeDefined();
+    expect(tooltip).toBeDefined();
+  });
+});

--- a/packages/visx-tooltip/test/floatingPrimitives.test.tsx
+++ b/packages/visx-tooltip/test/floatingPrimitives.test.tsx
@@ -399,6 +399,22 @@ describe('<FloatingTooltip /> manual primitives', () => {
     expect(arrow).toHaveAttribute('viewBox', '0 0 14 20');
   });
 
+  it('forwards Floating UI arrow stroke props', () => {
+    render(
+      <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }} arrow>
+        <FloatingTooltip.Positioner>
+          <FloatingTooltip.Content>
+            Tooltip
+            <FloatingTooltip.Arrow data-testid="arrow" width={14} height={20} strokeWidth={2} />
+          </FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('arrow')).toHaveAttribute('width', '18');
+    expect(screen.getByTestId('arrow').querySelector('path')).toHaveAttribute('stroke-width', '5');
+  });
+
   it('marks the anchor as hidden when Floating UI hide middleware reports it', async () => {
     const getRect = () => rect(0, 0);
 

--- a/packages/visx-tooltip/test/floatingPrimitives.test.tsx
+++ b/packages/visx-tooltip/test/floatingPrimitives.test.tsx
@@ -107,6 +107,66 @@ describe('useFloatingTooltip()', () => {
     expect(result?.context).toBeDefined();
     expect(() => act(() => result?.update())).not.toThrow();
   });
+
+  it('uses id as the default floating element id', () => {
+    function Probe() {
+      const tooltip = useFloatingTooltip({ defaultOpen: true, id: 'tooltip-root-id' });
+
+      return (
+        <div
+          {...tooltip.getFloatingProps({
+            'data-testid': 'floating',
+            ref: tooltip.refs.setFloating,
+          })}
+        />
+      );
+    }
+
+    render(<Probe />);
+
+    expect(screen.getByTestId('floating')).toHaveAttribute('id', 'tooltip-root-id');
+  });
+
+  it('lets explicit floating props override the default id', () => {
+    function Probe() {
+      const tooltip = useFloatingTooltip({ defaultOpen: true, id: 'tooltip-root-id' });
+
+      return (
+        <div
+          {...tooltip.getFloatingProps({
+            'data-testid': 'floating',
+            id: 'positioner-id',
+            ref: tooltip.refs.setFloating,
+          })}
+        />
+      );
+    }
+
+    render(<Probe />);
+
+    expect(screen.getByTestId('floating')).toHaveAttribute('id', 'positioner-id');
+  });
+
+  it('clears explicit position references when anchor becomes null', async () => {
+    let result: ReturnType<typeof useFloatingTooltip> | null = null;
+
+    function Probe({ anchor }: { anchor: TooltipAnchor | null }) {
+      result = useFloatingTooltip({ anchor, open: true });
+      return null;
+    }
+
+    const { rerender } = render(<Probe anchor={{ type: 'point', x: 10, y: 20 }} />);
+
+    await waitFor(() => {
+      expect(result?.refs.reference.current).toBeTruthy();
+    });
+
+    rerender(<Probe anchor={null} />);
+
+    await waitFor(() => {
+      expect(result?.refs.reference.current).toBeNull();
+    });
+  });
 });
 
 describe('buildFloatingTooltipMiddleware()', () => {
@@ -195,7 +255,54 @@ describe('<FloatingTooltip /> manual primitives', () => {
     expect(positioner).toHaveAttribute('data-side', 'bottom');
     expect(positioner).toHaveAttribute('data-align', 'start');
     expect(positioner.style.getPropertyValue('--visx-tooltip-transform-origin')).toBeTruthy();
-    expect(screen.getByTestId('content')).toHaveAttribute('role', 'tooltip');
+    expect(positioner).toHaveAttribute('role', 'tooltip');
+    expect(screen.getByTestId('content')).not.toHaveAttribute('role');
+  });
+
+  it('forwards explicit content roles without assigning a default role', () => {
+    const { rerender } = render(
+      <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }}>
+        <FloatingTooltip.Positioner>
+          <FloatingTooltip.Content data-testid="content">Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('content')).not.toHaveAttribute('role');
+
+    rerender(
+      <FloatingTooltip.Root open anchor={{ type: 'point', x: 0, y: 0 }}>
+        <FloatingTooltip.Positioner>
+          <FloatingTooltip.Content data-testid="content" role="note">
+            Tooltip
+          </FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('content')).toHaveAttribute('role', 'note');
+  });
+
+  it('uses the root id for the positioner and lets positioner props override it', () => {
+    const { rerender } = render(
+      <FloatingTooltip.Root open id="tooltip-root-id" anchor={{ type: 'point', x: 0, y: 0 }}>
+        <FloatingTooltip.Positioner data-testid="positioner">
+          <FloatingTooltip.Content>Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'tooltip-root-id');
+
+    rerender(
+      <FloatingTooltip.Root open id="tooltip-root-id" anchor={{ type: 'point', x: 0, y: 0 }}>
+        <FloatingTooltip.Positioner data-testid="positioner" id="positioner-id">
+          <FloatingTooltip.Content>Tooltip</FloatingTooltip.Content>
+        </FloatingTooltip.Positioner>
+      </FloatingTooltip.Root>,
+    );
+
+    expect(screen.getByTestId('positioner')).toHaveAttribute('id', 'positioner-id');
   });
 
   it('supports render replacement for the positioner and content', () => {

--- a/packages/visx-tooltip/test/tsconfig.floating-typecheck.json
+++ b/packages/visx-tooltip/test/tsconfig.floating-typecheck.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "extends": "../../../tsconfig.options.json",
+  "files": ["floating.typecheck.tsx"],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,6 +2053,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.5"
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/5c098e0d7b58c9bc769f276cca1766994c2c9c70c92d091a61bba8b3e9be53c011e0a79a8457fc2fb2f3d91697a26eb52e0a4962ef936dc963b45f58613c212f
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "@floating-ui/react-dom@npm:2.1.8"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.6"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10c0/26260ca4bb23b57c73b824062505abf977a008ce6e0463bdacca74f7e49853c4cd1d2bbf1a77c6caa17fa37dfffda2c6c4cd07a8737ebd7474aaff7818401d75
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:^0.27.19":
+  version: 0.27.19
+  resolution: "@floating-ui/react@npm:0.27.19"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10c0/2a2cdfd3e67e0606833b63f922ad2a9037974f22b944e1cb8c0991b4c40450f8413d69745c0bbf4646e5ba283747f60d2fdc9a8d289b68b24448e59d81a3a96d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: 10c0/f4bcea1559bdbb721ecc8e8ead423ac58d6a5b6e70b602cf0810ba6ad4ed1c77211b207faa88b278a9042f0c743133de08a203ed6741c1b6443423332884d5b3
+  languageName: node
+  linkType: hard
+
 "@gar/promise-retry@npm:^1.0.0":
   version: 1.0.3
   resolution: "@gar/promise-retry@npm:1.0.3"
@@ -5158,6 +5210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@visx/tooltip@workspace:packages/visx-tooltip"
   dependencies:
+    "@floating-ui/react": "npm:^0.27.19"
     "@juggle/resize-observer": "npm:^3.3.1"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
@@ -15239,6 +15292,13 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     object.getownpropertydescriptors: "npm:^2.1.8"
   checksum: 10c0/03058b52d1d45af5499972d0190c75e6083437ed9aec5e1f9f1f332a4391bc7a055a0ab84a77c79fb8ce75c98e8a06b4e4b3291bfa4523de50b81af4493c3ebe
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^6.0.0":
+  version: 6.4.0
+  resolution: "tabbable@npm:6.4.0"
+  checksum: 10c0/d931427f4a96b801fd8801ba296a702119e06f70ad262fed8abc5271225c9f1ca51b89fdec4fb2f22e1d35acb3d2881db0a17cedc758272e9ecb540d00299d76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To be released in `4.1.0`

### Why Floating UI tooltips?

The post-4.0 registry and primitive chart work needs a modern tooltip foundation that can handle collision-aware placement, virtual anchors, SVG coordinates, arrows, portals, and controlled chart state without changing the existing `@visx/tooltip` APIs.

This PR adds an additive `@visx/tooltip/floating` subpath backed by [Floating UI](https://floating-ui.com/). The new surface keeps the visx model intact: users still own the chart render tree, nearest-datum lookup, mark events, and content composition, while visx provides low-level positioning primitives and a convenient chart-tooltip layer.

The goal is to make modern dashboard tooltips easier to build consistently across registry charts and product code, while preserving the existing legacy tooltip package behavior for current consumers.

#### :boom: Breaking Changes

- None.

#### :rocket: Enhancements

- Add the `@visx/tooltip/floating` client subpath with Floating UI-backed tooltip exports.
- Add anchor utilities for element, client/page point, container-local point, SVG point, rect, and virtual-element positioning.
- Add `useFloatingTooltip` for controlled/uncontrolled open state, anchor state, data state, middleware configuration, ids, role wiring, and imperative open/close/update behavior.
- Add low-level `FloatingTooltip` primitives: `Provider`, `Root`, `Trigger`, `Portal`, `Positioner`, `Content`, and `Arrow`.
- Add trigger interactions for hover, focus, dismiss, delay groups, ARIA wiring, disabled triggers, explicit-anchor-plus-trigger positioning, and `role="label"` support.
- Add `ChartTooltipContent` with config-driven labels, values, colors, icons, hidden items, ordering, formatter precedence, custom renderers, and item keys.
- Add `useChartTooltip` and `ChartTooltip` as a convenience layer for chart-local anchors, SVG-local anchors, hide delays, controlled props, portals, and custom content.
- Add `@floating-ui/react` as an `@visx/tooltip` dependency.

#### :memo: Documentation

- Document the modern floating tooltip API in `packages/visx-tooltip/Readme.md`.
- Add `packages/visx-tooltip/Handbook.md` with source-validated API patterns, coordinate-space guidance, chart tooltip recipes, primitive usage, interaction notes, middleware notes, and styling contracts.
- Add a `MIGRATION.md` 4.1 note for the additive `@visx/tooltip/floating` APIs.

#### :bug: Bug Fix

- None.

#### :house: Internal

- Add focused tests for floating anchor conversion, primitive behavior, trigger interactions, chart tooltip content, chart tooltip convenience APIs, and type-level API constraints.
- Add regression coverage for default ids, positioner id overrides, stale reference clearing, disabled trigger behavior, label-role ARIA wiring, and content role forwarding.
- Add a floating typecheck fixture for `@visx/tooltip/floating` usage and invalid controlled `floatingOptions`.

#### Validation

- `yarn vitest run --config packages/visx-tooltip/vitest.config.ts packages/visx-tooltip/test/floatingPrimitives.test.tsx packages/visx-tooltip/test/floatingInteractions.test.tsx packages/visx-tooltip/test/ChartTooltip.test.tsx`
- `PKG=@visx/tooltip yarn type:pkg`
- `yarn tsc -p packages/visx-tooltip/test/tsconfig.floating-typecheck.json --pretty false`
- `yarn vitest run --config packages/visx-tooltip/vitest.config.ts`
- `yarn build`
- `yarn test`
- `yarn type:update-refs && git diff --exit-code`
- `yarn docs:generate`
- `git diff --check && git diff --cached --check`
