### PR TITLE
fix(release): retry GitHub compare requests

### DIFF
--- a/scripts/performRelease/fetchCommitsSinceTag.ts
+++ b/scripts/performRelease/fetchCommitsSinceTag.ts
@@ -1,14 +1,17 @@
 import type { GithubClient } from '../utils/getGitHubClient';
 import getRepoContext from '../utils/getRepoContext';
+import runGithubRequestWithRetries from './runGithubRequestWithRetries';
 
 export default async function fetchCommitsSinceTag(client: GithubClient, tagSha: string) {
   console.log('Fetching commits since sha', tagSha);
 
   const { owner, repo } = getRepoContext();
-  return client.request('GET /repos/{owner}/{repo}/compare/{base}...{head}', {
-    owner,
-    repo,
-    base: tagSha,
-    head: 'HEAD',
-  });
+  return runGithubRequestWithRetries(`Fetch commits since ${tagSha}`, () =>
+    client.request('GET /repos/{owner}/{repo}/compare/{base}...{head}', {
+      owner,
+      repo,
+      base: tagSha,
+      head: 'HEAD',
+    }),
+  );
 }

--- a/scripts/performRelease/runGithubRequestWithRetries.ts
+++ b/scripts/performRelease/runGithubRequestWithRetries.ts
@@ -23,11 +23,27 @@ function getErrorMessage(error: unknown) {
   }
 }
 
-function isRateLimitError(error: unknown) {
+function getErrorStatus(error: unknown) {
   const status =
     typeof error === 'object' && error !== null && 'status' in error ? error.status : null;
 
-  return status === 429 || /rate limit|secondary limit/i.test(getErrorMessage(error));
+  return typeof status === 'number' ? status : null;
+}
+
+function isRetryableGitHubRequestError(error: unknown) {
+  const status = getErrorStatus(error);
+  const message = getErrorMessage(error);
+
+  return (
+    status === 429 ||
+    status === 500 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504 ||
+    /rate limit|secondary limit|premature close|socket hang up|econnreset|etimedout|eai_again|fetch failed/i.test(
+      message,
+    )
+  );
 }
 
 export async function pauseBetweenGitHubRequests() {
@@ -44,12 +60,14 @@ export default async function runGithubRequestWithRetries<T>(
   } catch (error) {
     const delayMs = RETRY_DELAYS_MS[attempt];
 
-    if (!isRateLimitError(error) || delayMs === undefined) {
+    if (!isRetryableGitHubRequestError(error) || delayMs === undefined) {
       throw error;
     }
 
     console.warn(
-      `${label} hit a GitHub rate limit. Retrying in ${delayMs / 1000}s: ${getErrorMessage(error)}`,
+      `${label} hit a retryable GitHub request error. Retrying in ${
+        delayMs / 1000
+      }s: ${getErrorMessage(error)}`,
     );
     await wait(delayMs);
     return runGithubRequestWithRetries(label, request, attempt + 1);


### PR DESCRIPTION
### Why retry release compare requests?

The push workflow for `feat(tooltip): add Floating UI tooltip primitives (#2020)` failed in the release step while fetching commits from GitHub's compare endpoint.

This PR hardens that fetch path so transient GitHub response/body failures use the same retry helper as the rest of the release metadata requests.

#### :boom: Breaking Changes

- None.

#### :rocket: Enhancements

- None.

#### :memo: Documentation

- None.

#### :bug: Bug Fix

- Retry the release compare request used to fetch commits since the latest tag.
- Treat transient GitHub request failures such as `Premature close`, socket resets, timeout-style errors, and 5xx responses as retryable.

#### :house: Internal

- Reuse the release script's existing GitHub request retry helper for `fetchCommitsSinceTag`.

#### Validation

- `yarn lint`
- `git diff --check`
