### PR TITLE
fix(release): use local commits for release window

### DIFF
--- a/scripts/performRelease/fetchCommitsSinceTag.ts
+++ b/scripts/performRelease/fetchCommitsSinceTag.ts
@@ -1,17 +1,17 @@
-import type { GithubClient } from '../utils/getGitHubClient';
-import getRepoContext from '../utils/getRepoContext';
-import runGithubRequestWithRetries from './runGithubRequestWithRetries';
+import childProcess from 'child_process';
+import util from 'util';
 
-export default async function fetchCommitsSinceTag(client: GithubClient, tagSha: string) {
+const execFile = util.promisify(childProcess.execFile);
+
+export default async function fetchCommitsSinceTag(tagSha: string) {
   console.log('Fetching commits since sha', tagSha);
 
-  const { owner, repo } = getRepoContext();
-  return runGithubRequestWithRetries(`Fetch commits since ${tagSha}`, () =>
-    client.request('GET /repos/{owner}/{repo}/compare/{base}...{head}', {
-      owner,
-      repo,
-      base: tagSha,
-      head: 'HEAD',
-    }),
-  );
+  const { stdout } = await execFile('git', ['rev-list', '--reverse', `${tagSha}..HEAD`]);
+  const commits = stdout
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((sha) => ({ sha }));
+
+  return { data: { commits } };
 }

--- a/scripts/performRelease/index.ts
+++ b/scripts/performRelease/index.ts
@@ -81,14 +81,13 @@ async function performRelease() {
   console.log('Most recent non-alpha tag found is', mostRecentNonAlphaTag.name);
 
   // get commits since most recent alpha / non-alpha tag
-  const commitsSinceLastTagRequest = await fetchCommitsSinceTag(client, mostRecentTag.commit.sha);
-  const commitsSinceNonAlphaTagRequest = await fetchCommitsSinceTag(
-    client,
+  const commitsSinceLastTagResponse = await fetchCommitsSinceTag(mostRecentTag.commit.sha);
+  const commitsSinceNonAlphaTagResponse = await fetchCommitsSinceTag(
     mostRecentNonAlphaTag.commit.sha,
   );
 
-  const commitsSinceNonAlphaTag = commitsSinceNonAlphaTagRequest.data.commits;
-  const commitsSinceLastTag = commitsSinceLastTagRequest.data.commits;
+  const commitsSinceNonAlphaTag = commitsSinceNonAlphaTagResponse.data.commits;
+  const commitsSinceLastTag = commitsSinceLastTagResponse.data.commits;
 
   if (commitsSinceLastTag.length === 0) {
     console.log(`No commits found since last release tag. Exiting.`);


### PR DESCRIPTION
### Why use local commits for the release window?

The push workflow for PR #2021 still failed in the release step after retrying GitHub's compare endpoint three times.

The workflow checks out full git history with `fetch-depth: '0'`, so the release script does not need the compare endpoint just to enumerate commit SHAs between the latest reachable tag and `HEAD`.

#### :boom: Breaking Changes

- None.

#### :rocket: Enhancements

- None.

#### :memo: Documentation

- None.

#### :bug: Bug Fix

- Use local `git rev-list --reverse <tag>..HEAD` output to build the release commit window instead of fetching the same commit list from GitHub's compare endpoint.

#### :house: Internal

- Keep GitHub API usage for commit-to-PR lookup, release creation, and release comments, where GitHub metadata is still needed.

#### Validation

- `yarn lint`
- `git diff --check`
