### PR TITLE
fix(release): harden master push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: push-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,24 +46,59 @@ jobs:
       - name: Generate docs
         run: yarn docs:generate
 
-      - name: Commit package sizes
+      - name: Check current HEAD is latest master
+        id: latest-master
         if: github.repository_owner == 'airbnb'
+        run: |
+          latest_sha="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+          head_sha="$(git rev-parse HEAD)"
+          if [ "$latest_sha" = "$head_sha" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping mutable steps because origin/master is at $latest_sha and this run is at $head_sha."
+          fi
+
+      - name: Commit package sizes
+        if: github.repository_owner == 'airbnb' && steps.latest-master.outputs.is_latest == 'true'
         # note: `git diff-index --quiet HEAD`
-        #       has exit code 0 if there are changes vs HEAD, else nothing to commit
+        #       has exit code 0 if there are no changes vs HEAD, else there is something to commit
         run: |
           yarn build:sizes
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git diff-index --quiet HEAD || git commit -m "build(${GITHUB_SHA}): auto-commit package sizes"
-          git push
+          if git diff-index --quiet HEAD; then
+            echo "No package size changes to commit."
+          else
+            git commit -m "build(${GITHUB_SHA}): auto-commit package sizes"
+            latest_sha="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+            if [ "$latest_sha" != "$GITHUB_SHA" ]; then
+              echo "Skipping package size push because origin/master advanced to $latest_sha."
+              exit 0
+            fi
+            if ! git push; then
+              latest_sha="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+              if [ "$latest_sha" != "$GITHUB_SHA" ]; then
+                echo "Skipping package size push because origin/master advanced to $latest_sha."
+                exit 0
+              fi
+              exit 1
+            fi
+          fi
 
       - name: Release
-        if: github.repository_owner == 'airbnb'
+        if: github.repository_owner == 'airbnb' && steps.latest-master.outputs.is_latest == 'true'
         # the following configurations are needed for lerna to
         #   - have git credentials for committing tags
         #   - use OIDC trusted publishing for npm (no token required)
         run: |
+          latest_sha="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+          head_sha="$(git rev-parse HEAD)"
+          if [ "$latest_sha" != "$head_sha" ]; then
+            echo "Skipping release because origin/master is at $latest_sha and this run is at $head_sha."
+            exit 0
+          fi
           git config user.name github-actions
           git config user.email github-actions@github.com
           yarn build:release
@@ -67,6 +106,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and deploy gallery
+        if: github.repository_owner == 'airbnb' && steps.latest-master.outputs.is_latest == 'true'
         # below we
         # - setup git credentials provided via actions/checkout@v6
         # - initialize gh-pages-branch as an orphan branch so we don't build history
@@ -79,6 +119,12 @@ jobs:
         # - commit the demo site within gh-pages-root-dir/ onto the gh-pages-branch
         # - push gh-pages-branch to visx as gh-pages. we overwrite history every time so it must be forced
         run: |
+          latest_sha="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+          head_sha="$(git rev-parse HEAD)"
+          if [ "$latest_sha" != "$head_sha" ]; then
+            echo "Skipping gallery deploy because origin/master is at $latest_sha and this run is at $head_sha."
+            exit 0
+          fi
           git config user.name github-actions
           git config user.email github-actions@github.com
           git checkout --orphan gh-pages-branch

--- a/scripts/performRelease/fetchPRsForCommits.ts
+++ b/scripts/performRelease/fetchPRsForCommits.ts
@@ -1,3 +1,6 @@
+import childProcess from 'child_process';
+import util from 'util';
+
 import type { GithubClient } from '../utils/getGitHubClient';
 import getRepoContext from '../utils/getRepoContext';
 import runGithubRequestWithRetries, {
@@ -5,42 +8,86 @@ import runGithubRequestWithRetries, {
 } from './runGithubRequestWithRetries';
 import type { PR } from './types';
 
+const execFile = util.promisify(childProcess.execFile);
+// GitHub squash merges append the PR number to the commit subject. Verify the
+// fetched PR's merge commit before using its labels to drive release behavior.
+const PR_NUMBER_MATCHER = /\(#(\d+)\)\s*$/;
+
+async function getCommitSubject(sha: string) {
+  const { stdout } = await execFile('git', ['show', '-s', '--format=%s', sha]);
+
+  return stdout.trim();
+}
+
+function getPullRequestNumberFromSubject(subject: string) {
+  const match = subject.match(PR_NUMBER_MATCHER);
+
+  return match ? Number(match[1]) : null;
+}
+
 export default async function fetchPRsForCommits(
   client: GithubClient,
   shas: string[],
 ): Promise<PR[]> {
   const { owner, repo } = getRepoContext();
   const prs: PR[] = [];
+  const shasByPullRequestNumber = new Map<number, string[]>();
 
-  for (let index = 0; index < shas.length; index += 1) {
-    const sha = shas[index];
+  for (const sha of shas) {
+    // eslint-disable-next-line no-await-in-loop -- Keep local Git lookups serial for stable release logs.
+    const subject = await getCommitSubject(sha);
+    const pullRequestNumber = getPullRequestNumberFromSubject(subject);
 
-    console.log('Fetching PRs associated with commit', sha);
+    if (pullRequestNumber == null) {
+      console.log('Ignoring commit with no PR number in subject', sha);
+    } else {
+      const shasForPullRequest = shasByPullRequestNumber.get(pullRequestNumber);
 
-    const prsForCommit = await runGithubRequestWithRetries(`Fetch PRs for commit ${sha}`, () =>
-      client.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
+      if (shasForPullRequest) {
+        shasForPullRequest.push(sha);
+      } else {
+        shasByPullRequestNumber.set(pullRequestNumber, [sha]);
+      }
+    }
+  }
+
+  const pullRequestsForCommits = Array.from(
+    shasByPullRequestNumber,
+    ([pullRequestNumber, shasForPullRequest]) => ({
+      pullRequestNumber,
+      shas: shasForPullRequest,
+    }),
+  );
+
+  for (const [
+    index,
+    { pullRequestNumber, shas: candidateShas },
+  ] of pullRequestsForCommits.entries()) {
+    console.log('Fetching PR #', pullRequestNumber);
+
+    // eslint-disable-next-line no-await-in-loop -- GitHub requests are intentionally paced.
+    const prForCommit = await runGithubRequestWithRetries(`Fetch PR #${pullRequestNumber}`, () =>
+      client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
         owner,
         repo,
-        commit_sha: sha,
-        // special header needed https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-        mediaType: {
-          previews: ['groot'],
-        },
+        pull_number: pullRequestNumber,
       }),
     );
 
-    if (prsForCommit.data.length === 0) {
-      console.log('Ignoring commit with no PRs', sha);
-    } else {
-      if (prsForCommit.data.length > 1) {
-        console.warn('Multiple PRs associated with commit, only considering the first', sha);
-      }
+    const pr = prForCommit.data as PR;
 
-      const prForCommit = prsForCommit.data[0] as PR;
-      prs.push(prForCommit);
+    if (pr.merge_commit_sha == null || !candidateShas.includes(pr.merge_commit_sha)) {
+      throw new Error(
+        `PR #${pullRequestNumber} merge commit ${
+          pr.merge_commit_sha ?? 'null'
+        } does not match candidate commits ${candidateShas.join(', ')}.`,
+      );
     }
 
-    if (index < shas.length - 1) {
+    prs.push(pr);
+
+    if (index < pullRequestsForCommits.length - 1) {
+      // eslint-disable-next-line no-await-in-loop -- GitHub requests are intentionally paced.
       await pauseBetweenGitHubRequests();
     }
   }


### PR DESCRIPTION
### Why harden the master push workflow?

The push workflow for `fix(release): use local commits for release window (#2022)` failed in the package-size step because `master` advanced while the workflow was running, then the stale checkout attempted an unconditional `git push`.

A following push workflow also showed the release script could still fail on GitHub's commit-associated-PR endpoint while resolving release metadata.

This PR makes the mutable parts of the `Push` workflow run only for the current remote `master` SHA and removes the fragile commit-associated-PR lookup from the release path.

#### :boom: Breaking Changes

- None.

#### :rocket: Enhancements

- None.

#### :memo: Documentation

- None.

#### :bug: Bug Fix

- Skip package-size commits, release publishing, and gallery deploys when a push workflow run is no longer the latest remote `master`.
- Avoid unconditional package-size `git push` calls when `yarn build:sizes` produces no changes.
- Avoid rebasing stale package-size commits onto newer `master` during the push workflow.
- Replace release PR discovery via GitHub's commit-associated-PR endpoint with local squash-merge subject parsing plus direct PR fetches for the repository's current merge style.
- Verify fetched PR `merge_commit_sha` values against local candidate commits before using PR labels for release decisions.

#### :house: Internal

- Serialize `Push` workflow runs for `master` with GitHub Actions concurrency.
- Use `git ls-remote origin refs/heads/master` freshness checks before mutable workflow steps.
- Keep release metadata lookup paced through the existing GitHub request retry helper.

#### Validation

- `yarn eslint scripts/performRelease/fetchPRsForCommits.ts --quiet`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/push.yml'); puts 'ok'"`\n- `git ls-remote` freshness check against current `master`\n- Mocked release PR lookup success smoke\n- Mocked merge-commit mismatch smoke\n- Real read-only GitHub smoke for PRs `#2004` and `#2022`