### PR TITLE
fix(stats): handle zero-IQR samples in computeStats

### DIFF
--- a/packages/visx-stats/src/util/computeStats.ts
+++ b/packages/visx-stats/src/util/computeStats.ts
@@ -15,12 +15,13 @@ export default function computeStats(numericalArray: number[]) {
   // calculate median of first half i.e. firstQuartile
   const lowerHalfLength = Math.floor(sampleSize / 2);
   const lowerHalf = points.slice(0, lowerHalfLength);
-  const firstQuartile = calcMedian(lowerHalf);
+  // For n < 2 the half-slices are empty; fall back to the sample median.
+  const firstQuartile = lowerHalf.length ? calcMedian(lowerHalf) : median;
 
-  // calculate median of first half i.e. secondQuartile
+  // calculate median of second half i.e. thirdQuartile
   const upperHalfLength = Math.ceil(sampleSize / 2);
   const upperHalf = points.slice(upperHalfLength);
-  const thirdQuartile = calcMedian(upperHalf);
+  const thirdQuartile = upperHalf.length ? calcMedian(upperHalf) : median;
   const IQR = thirdQuartile - firstQuartile;
 
   let min = firstQuartile - 1.5 * IQR;
@@ -31,29 +32,42 @@ export default function computeStats(numericalArray: number[]) {
     min = Math.min(...points);
     max = Math.max(...points);
   }
-  const binWidth = 2 * IQR * (sampleSize - outliers.length) ** (-1 / 3);
-  const binCount = Math.round((max - min) / binWidth);
-  const actualBinWidth = (max - min) / binCount;
 
-  const bins = new Array(binCount + 2).fill(0);
-  const values = new Array(binCount + 2).fill(min);
+  const inliers = points.filter((p) => p >= min && p <= max);
+  const binWidth = 2 * IQR * inliers.length ** (-1 / 3);
+  const range = max - min;
 
-  for (let i = 1; i <= binCount; i += 1) {
-    values[i] += actualBinWidth * (i - 0.5);
-  }
+  // Freedman–Diaconis yields binWidth 0 (and binCount NaN) when IQR is 0 or the
+  // inlier range collapses. Guard before allocating histogram arrays (#1772).
+  let binData: BinDatum[];
+  if (!Number.isFinite(binWidth) || binWidth <= 0 || !Number.isFinite(range) || range === 0) {
+    binData = [
+      { value: min, count: 0 },
+      { value: min, count: inliers.length },
+      { value: max, count: 0 },
+    ];
+  } else {
+    const binCount = Math.max(1, Math.round(range / binWidth));
+    const actualBinWidth = range / binCount;
 
-  values[values.length - 1] = max;
+    const bins = new Array(binCount + 2).fill(0);
+    const values = new Array(binCount + 2).fill(min);
 
-  points
-    .filter((p) => p >= min && p <= max)
-    .forEach((p) => {
+    for (let i = 1; i <= binCount; i += 1) {
+      values[i] += actualBinWidth * (i - 0.5);
+    }
+
+    values[values.length - 1] = max;
+
+    inliers.forEach((p) => {
       bins[Math.floor((p - min) / actualBinWidth) + 1] += 1;
     });
 
-  const binData: BinDatum[] = values.map((v, i) => ({
-    value: v,
-    count: bins[i],
-  }));
+    binData = values.map((v, i) => ({
+      value: v,
+      count: bins[i],
+    }));
+  }
 
   const boxPlot: BoxPlot = {
     min,

--- a/packages/visx-stats/test/computeStats.test.ts
+++ b/packages/visx-stats/test/computeStats.test.ts
@@ -1,4 +1,4 @@
-import { computeStats } from '../src';
+import computeStats from '../src/util/computeStats';
 
 const data = [1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 1];
 const edgeCaseData = [10000, 2400, 10000, 10000];
@@ -24,5 +24,30 @@ describe('computeStats', () => {
     const stats = computeStats(edgeCaseData);
     expect(stats.boxPlot.min).toBe(Math.min(...edgeCaseData));
     expect(stats.boxPlot.max).toBe(Math.max(...edgeCaseData));
+  });
+
+  test('it should not throw when IQR is zero', () => {
+    expect(() => computeStats([-1, 0, 0, 0, 0, 0, 1])).not.toThrow();
+    expect(() => computeStats([5, 5, 5, 5])).not.toThrow();
+  });
+
+  test('it should not throw for a single-value sample', () => {
+    const stats = computeStats([0]);
+    expect(stats.boxPlot).toEqual({
+      min: 0,
+      firstQuartile: 0,
+      median: 0,
+      thirdQuartile: 0,
+      max: 0,
+      outliers: [],
+    });
+    expect(stats.binData.length).toBeGreaterThan(0);
+  });
+
+  test('degenerate IQR samples still return usable binData', () => {
+    const stats = computeStats([5, 5, 5, 5]);
+    expect(stats.boxPlot.min).toBe(5);
+    expect(stats.boxPlot.max).toBe(5);
+    expect(stats.binData.some((bin) => bin.count > 0)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`computeStats` crashed with `RangeError: Invalid array length` on samples where IQR is 0 (or the inlier range collapses), e.g. `[-1, 0, 0, 0, 0, 0, 1]`, `[0]`, or `[5, 5, 5, 5]`.

Freedman–Diaconis gives `binWidth = 0` in those cases, so `binCount` becomes `NaN` and `new Array(binCount + 2)` throws. This guards that path and returns a single-bin histogram instead. For `n < 2`, quartile medians fall back to the sample median so single-value inputs stay well-defined.

Fixes #1772

## Test plan

- [x] Added regression tests for the issue reproductions
- [x] Existing computeStats cases still pass